### PR TITLE
Workflow to sync repository with storage bucket

### DIFF
--- a/.github/workflows/git-to-gcs.yml
+++ b/.github/workflows/git-to-gcs.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches: [master, develop]
+  repository_dispatch:
+jobs:
+  sync_prod:
+    if: github.event.action == 'prod' || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 'master'
+      - name: Sync to GCS
+        uses: aroelo/sync_to_gcs@20.6.0
+        with:
+          secrets: ${{ secrets.google_credentials }}
+          bucket_suffix: 'prod'
+
+  sync_dev:
+    if: github.event.action == 'dev' || github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 'develop'
+      - name: Sync to GCS
+        uses: aroelo/sync_to_gcs@20.6.0
+        with:
+          secrets: ${{ secrets.google_credentials }}
+          bucket_suffix: 'dev'

--- a/.github/workflows/sync-to-gcs.yml
+++ b/.github/workflows/sync-to-gcs.yml
@@ -14,6 +14,7 @@ jobs:
         uses: aroelo/sync_to_gcs@20.6.0
         with:
           secrets: ${{ secrets.google_credentials }}
+          bucket_pattern: 'github-'
           bucket_suffix: 'prod'
 
   sync_dev:
@@ -27,4 +28,5 @@ jobs:
         uses: aroelo/sync_to_gcs@20.6.0
         with:
           secrets: ${{ secrets.google_credentials }}
+          bucket_pattern: 'github-'
           bucket_suffix: 'dev'


### PR DESCRIPTION
I have added a workflow that can sync the content of this repository to a google storage bucket. 

See corresponding github action on marketplace: https://github.com/marketplace/actions/sync-to-gcs

This will be useful when automating set-up of cloud composer with terraform. 

It requires an existing google storage bucket with a specific pattern in the name and json credentials that have permission to upload data to this bucket.

Will have to add this as a secret to the repository.