### PR TITLE
Add extra badges to README.md

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch=True
+source=observatory_platform
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == "__main__":
+    if __name__ == '__main__':
+ignore_errors = True
+omit =
+    tests/*

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 tests/fixtures/** filter=lfs diff=lfs merge=lfs -text
+* linguist-vendored
+*.ipynb linguist-vendored=false

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           echo "${TESTS_GOOGLE_APPLICATION_CREDENTIALS_BASE64}" | base64 --decode > /tmp/google_application_credentials.json
           coverage run -m unittest discover
+          coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,19 +29,18 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -e .[tests]
       - name: Check licenses
         run: |
-          pip install liccheck==0.4.*
+          # stop the build if there are licensing issues
           liccheck --sfile strategy.ini --rfile requirements.txt --level CAUTIOUS --reporting liccheck-output.txt --no-deps
       - name: Lint with flake8
         run: |
-          pip install flake8
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with unittest
+      - name: Run unit tests with coverage
         env:
           TESTS_AZURE_CONTAINER_NAME: ${{ secrets.TESTS_AZURE_CONTAINER_NAME }}
           TESTS_AZURE_CONTAINER_SAS_TOKEN: ${{ secrets.TESTS_AZURE_CONTAINER_SAS_TOKEN }}
@@ -53,4 +52,10 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_application_credentials.json
         run: |
           echo "${TESTS_GOOGLE_APPLICATION_CREDENTIALS_BASE64}" | base64 --decode > /tmp/google_application_credentials.json
-          python -m unittest
+          coverage run -m unittest discover
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -58,5 +58,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ config.yaml
 *.tfstate.*
 .terraform.tfstate.lock.info
 .terraform/**
+.coverage
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ universities operate as Open Knowledge Institutions.
 The Observatory Platform is built with Apache Airflow and includes DAGs (workflows) for processing: Crossref Metadata, 
 Fundref, GRID, Microsoft Academic Graph (MAG) and Unpaywall.
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python Version](https://img.shields.io/badge/python-3.7-blue)](https://img.shields.io/badge/python-3.7-blue)
 ![Python package](https://github.com/The-Academic-Observatory/observatory-platform/workflows/Python%20package/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/observatory-platform/badge/?version=latest)](https://observatory-platform.readthedocs.io/en/latest/?badge=latest)
+[![codecov](https://codecov.io/gh/The-Academic-Observatory/observatory-platform/branch/develop/graph/badge.svg)](https://codecov.io/gh/The-Academic-Observatory/observatory-platform)
 
 ## Documentation
 For more detailed documentation about the Observatory Platform see the Read the Docs website [https://observatory-platform.readthedocs.io](https://observatory-platform.readthedocs.io)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ universities operate as Open Knowledge Institutions.
 The Observatory Platform is built with Apache Airflow and includes DAGs (workflows) for processing: Crossref Metadata, 
 Fundref, GRID, Microsoft Academic Graph (MAG) and Unpaywall.
 
-[![Documentation Status](https://readthedocs.org/projects/observatory-platform/badge/?version=latest)](https://observatory-platform.readthedocs.io/en/latest/?badge=latest) [![Documentation Status](https://img.shields.io/badge/python-3.7-blue)](https://img.shields.io/badge/python-3.7-blue)
+[![Python Version](https://img.shields.io/badge/python-3.7-blue)](https://img.shields.io/badge/python-3.7-blue)
+![Python package](https://github.com/The-Academic-Observatory/observatory-platform/workflows/Python%20package/badge.svg)
+[![Documentation Status](https://readthedocs.org/projects/observatory-platform/badge/?version=latest)](https://observatory-platform.readthedocs.io/en/latest/?badge=latest)
 
 ## Documentation
 For more detailed documentation about the Observatory Platform see the Read the Docs website [https://observatory-platform.readthedocs.io](https://observatory-platform.readthedocs.io)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
     keywords=['science', 'data', 'workflows', 'academic institutes', 'observatory-platform'],
     install_requires=install_requires,
     extras_require={
-        'docs': docs_requires
+        'docs': docs_requires,
+        'tests': ['liccheck==0.4.*', 'flake8==3.8.*', 'coverage==5.2']
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This pull request adds the following badges to README.md:
* Apache 2.0 license badge.
* Python Version 3.7 badge.
* Python package workflow badge.
* Codecov badge: also added codecov to the workflow file.

Have also made Github's  language detection feature ignore .ipynb files as it predicts the repository language incorrectly.