### PR TITLE
Restructured the way variables are loaded from config file.

### DIFF
--- a/observatory_platform/cli/observatory.py
+++ b/observatory_platform/cli/observatory.py
@@ -28,8 +28,8 @@ import docker
 import requests
 from cryptography.fernet import Fernet
 
-from observatory_platform.utils.config_utils import observatory_home, observatory_package_path, \
-    dags_path as default_dags_path, ObservatoryConfig
+from observatory_platform.utils.config_utils import AirflowVar, AirflowConn, observatory_home, \
+    observatory_package_path, dags_path as default_dags_path, ObservatoryConfig
 from observatory_platform.utils.proc_utils import wait_for_process
 
 
@@ -158,15 +158,15 @@ def get_env(dags_path: str, data_path: str, logs_path: str, postgres_path: str, 
     env['FERNET_KEY'] = config.fernet_key
 
     # Set connections
-    env['AIRFLOW_CONN_MAG_RELEASES_TABLE'] = config.mag_releases_table_connection
-    env['AIRFLOW_CONN_MAG_SNAPSHOTS_CONTAINER'] = config.mag_snapshots_container_connection
-    env['AIRFLOW_CONN_CROSSREF'] = config.crossref_connection
+    env['AIRFLOW_CONN_MAG_RELEASES_TABLE'] = config.airflow_connections[AirflowConn.mag_releases_table.value]
+    env['AIRFLOW_CONN_MAG_SNAPSHOTS_CONTAINER'] = config.airflow_connections[AirflowConn.mag_snapshots_container.value]
+    env['AIRFLOW_CONN_CROSSREF'] = config.airflow_connections[AirflowConn.crossref.value]
 
     # Set variables
-    env['AIRFLOW_VAR_PROJECT_ID'] = config.project_id
+    env['AIRFLOW_VAR_PROJECT_ID'] = config.airflow_variables[AirflowVar.project_id.value]
     env['AIRFLOW_VAR_DATA_LOCATION'] = config.data_location
-    env['AIRFLOW_VAR_DOWNLOAD_BUCKET_NAME'] = config.download_bucket_name
-    env['AIRFLOW_VAR_TRANSFORM_BUCKET_NAME'] = config.transform_bucket_name
+    env['AIRFLOW_VAR_DOWNLOAD_BUCKET_NAME'] = config.airflow_variables[AirflowVar.download_bucket_name.value]
+    env['AIRFLOW_VAR_TRANSFORM_BUCKET_NAME'] = config.airflow_variables[AirflowVar.transform_bucket_name.value]
     env['AIRFLOW_VAR_ENVIRONMENT'] = config.environment.value
 
     return env
@@ -332,7 +332,7 @@ def platform(command, config_path, dags_path, data_path, logs_path, postgres_pat
         else:
             print(indent("- file invalid", indent2))
             for key, value in config.validator.errors.items():
-                print(indent(f'- {key}: {", ".join(value)}', indent3))
+                print(indent(f'- {key}: {value}', indent3))
     else:
         print(indent("- file not found, generating a default file", indent2))
         gen_config_interface()

--- a/observatory_platform/cli/observatory.py
+++ b/observatory_platform/cli/observatory.py
@@ -73,6 +73,10 @@ def gen_config_interface():
         for key, val in params.items():
             if val is None:
                 print(f'  - {key}')
+            if type(val) is dict:
+                for val_key, val_val in val.items():
+                    if val_val is None:
+                        print(f'  - {val_key}')
     else:
         print("Not generating config.yaml")
 
@@ -158,16 +162,14 @@ def get_env(dags_path: str, data_path: str, logs_path: str, postgres_path: str, 
     env['FERNET_KEY'] = config.fernet_key
 
     # Set connections
-    env['AIRFLOW_CONN_MAG_RELEASES_TABLE'] = config.airflow_connections[AirflowConn.mag_releases_table.value]
-    env['AIRFLOW_CONN_MAG_SNAPSHOTS_CONTAINER'] = config.airflow_connections[AirflowConn.mag_snapshots_container.value]
-    env['AIRFLOW_CONN_CROSSREF'] = config.airflow_connections[AirflowConn.crossref.value]
+    for airflow_conn in AirflowConn:
+        if airflow_conn.value['schema']:
+            env[f'AIRFLOW_CONN_{airflow_conn.get().upper()}'] = config.airflow_connections[airflow_conn.get()]
 
     # Set variables
-    env['AIRFLOW_VAR_PROJECT_ID'] = config.airflow_variables[AirflowVar.project_id.value]
-    env['AIRFLOW_VAR_DATA_LOCATION'] = config.data_location
-    env['AIRFLOW_VAR_DOWNLOAD_BUCKET_NAME'] = config.airflow_variables[AirflowVar.download_bucket_name.value]
-    env['AIRFLOW_VAR_TRANSFORM_BUCKET_NAME'] = config.airflow_variables[AirflowVar.transform_bucket_name.value]
-    env['AIRFLOW_VAR_ENVIRONMENT'] = config.environment.value
+    for airflow_var in AirflowVar:
+        if airflow_var.value['schema']:
+            env[f'AIRFLOW_VAR_{airflow_var.get().upper()}'] = config.airflow_variables[airflow_var.get()]
 
     return env
 

--- a/observatory_platform/cli/observatory.py
+++ b/observatory_platform/cli/observatory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: James Diprose
+# Author: James Diprose, Aniek Roelofs
 
 import itertools
 import os
@@ -29,8 +29,12 @@ import docker
 import requests
 from cryptography.fernet import Fernet
 
-from observatory_platform.utils.config_utils import AirflowVar, AirflowConn, observatory_home, \
-    observatory_package_path, dags_path as default_dags_path, ObservatoryConfig
+from observatory_platform.utils.config_utils import AirflowVar, \
+    AirflowConn, \
+    observatory_home, \
+    observatory_package_path, \
+    dags_path as default_dags_path, \
+    ObservatoryConfig
 from observatory_platform.utils.proc_utils import wait_for_process
 
 
@@ -83,8 +87,7 @@ def gen_config_interface():
 
 
 @cli.command()
-@click.argument('command',
-                type=click.Choice(['fernet-key', 'config.yaml']))
+@click.argument('command', type=click.Choice(['fernet-key', 'config.yaml']))
 def generate(command):
     """ Generate information for the Observatory Platform platform.\n
 

--- a/observatory_platform/telescopes/crossref_metadata.py
+++ b/observatory_platform/telescopes/crossref_metadata.py
@@ -35,24 +35,20 @@ from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
 from natsort import natsorted
 
-from observatory_platform.utils.config_utils import (
-    AirflowVar,
-    AirflowConn,
-    find_schema,
-    SubFolder,
-    schema_path,
-    telescope_path,
-    check_variables,
-    check_connections
-)
-from observatory_platform.utils.gc_utils import (
-    bigquery_partitioned_table_id,
-    create_bigquery_dataset,
-    load_bigquery_table,
-    upload_file_to_cloud_storage,
-    bigquery_table_exists,
-    upload_files_to_cloud_storage
-)
+from observatory_platform.utils.config_utils import (AirflowConn,
+                                                     AirflowVar,
+                                                     SubFolder,
+                                                     check_connections,
+                                                     check_variables,
+                                                     find_schema,
+                                                     schema_path,
+                                                     telescope_path)
+from observatory_platform.utils.gc_utils import (bigquery_partitioned_table_id,
+                                                 bigquery_table_exists,
+                                                 create_bigquery_dataset,
+                                                 load_bigquery_table,
+                                                 upload_file_to_cloud_storage,
+                                                 upload_files_to_cloud_storage)
 from observatory_platform.utils.proc_utils import wait_for_process
 from observatory_platform.utils.url_utils import retry_session
 from tests.observatory_platform.config import test_fixtures_path
@@ -69,7 +65,9 @@ def download_release(release: 'CrossrefMetadataRelease', api_token: str):
     logging.info(f"Downloading from url: {release.url}")
 
     # Set API token header
-    header = {'Crossref-Plus-API-Token': f'Bearer {api_token}'}
+    header = {
+        'Crossref-Plus-API-Token': f'Bearer {api_token}'
+    }
 
     # Download release
     with requests.get(release.url, headers=header, stream=True) as response:
@@ -253,8 +251,7 @@ def pull_release(ti: TaskInstance) -> CrossrefMetadataRelease:
     """
 
     return ti.xcom_pull(key=CrossrefMetadataTelescope.RELEASES_TOPIC_NAME,
-                        task_ids=CrossrefMetadataTelescope.TASK_ID_CHECK_RELEASE,
-                        include_prior_dates=False)
+                        task_ids=CrossrefMetadataTelescope.TASK_ID_CHECK_RELEASE, include_prior_dates=False)
 
 
 class CrossrefMetadataTelescope:
@@ -262,7 +259,8 @@ class CrossrefMetadataTelescope:
 
     DAG_ID = 'crossref_metadata'
     DATASET_ID = 'crossref'
-    DESCRIPTION = 'The Crossref Metadata Plus dataset: https://www.crossref.org/services/metadata-retrieval/metadata-plus/'
+    DESCRIPTION = 'The Crossref Metadata Plus dataset: ' \
+                  'https://www.crossref.org/services/metadata-retrieval/metadata-plus/'
     RELEASES_TOPIC_NAME = "releases"
     QUEUE = 'remote_queue'
     MAX_PROCESSES = cpu_count()
@@ -286,7 +284,8 @@ class CrossrefMetadataTelescope:
     def check_dependencies(**kwargs):
         """ Check that all variables exist that are required to run the DAG.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -303,7 +302,8 @@ class CrossrefMetadataTelescope:
     def check_release_exists(**kwargs):
         """ Check that the release for this month exists.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -338,7 +338,8 @@ class CrossrefMetadataTelescope:
         """ Download release to file. If dev environment, copy debug file from this repository to the right location.
         Else download from url.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -362,7 +363,8 @@ class CrossrefMetadataTelescope:
     def upload_downloaded(**kwargs):
         """ Upload the downloaded files to a Google Cloud Storage bucket.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -382,7 +384,8 @@ class CrossrefMetadataTelescope:
     def extract(**kwargs):
         """ Extract release
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -405,7 +408,8 @@ class CrossrefMetadataTelescope:
     def transform(**kwargs):
         """ Transform release with sed command and save to new file.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -428,7 +432,8 @@ class CrossrefMetadataTelescope:
     def upload_transformed(**kwargs):
         """ Upload transformed release to a Google Cloud Storage bucket.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -464,7 +469,8 @@ class CrossrefMetadataTelescope:
     def bq_load(**kwargs):
         """ Upload transformed release to a bigquery table.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -503,7 +509,8 @@ class CrossrefMetadataTelescope:
     def cleanup(**kwargs):
         """ Delete files of downloaded, extracted and transformed release.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """

--- a/observatory_platform/telescopes/crossref_metadata.py
+++ b/observatory_platform/telescopes/crossref_metadata.py
@@ -36,6 +36,8 @@ from google.cloud.bigquery import SourceFormat
 from natsort import natsorted
 
 from observatory_platform.utils.config_utils import (
+    AirflowVar,
+    AirflowConn,
     find_schema,
     SubFolder,
     schema_path,
@@ -289,9 +291,9 @@ class CrossrefMetadataTelescope:
         :return: None.
         """
 
-        vars_valid = check_variables("data_path", "project_id", "data_location",
-                                     "download_bucket_name", "transform_bucket_name")
-        conns_valid = check_connections("crossref")
+        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
+                                     AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
+        conns_valid = check_connections(AirflowConn.crossref)
 
         if not vars_valid or not conns_valid:
             raise AirflowException('Required variables or connections are missing')

--- a/observatory_platform/telescopes/fundref.py
+++ b/observatory_platform/telescopes/fundref.py
@@ -35,21 +35,11 @@ from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
 from pendulum import Pendulum
 
-from observatory_platform.utils.config_utils import (
-    AirflowVar,
-    find_schema,
-    SubFolder,
-    schema_path,
-    telescope_path,
-    check_variables
-)
-from observatory_platform.utils.gc_utils import (
-    bigquery_partitioned_table_id,
-    create_bigquery_dataset,
-    load_bigquery_table,
-    upload_file_to_cloud_storage,
-    bigquery_table_exists
-)
+from observatory_platform.utils.config_utils import (AirflowVar, find_schema, SubFolder, schema_path, telescope_path,
+                                                     check_variables)
+from observatory_platform.utils.gc_utils import (bigquery_partitioned_table_id, create_bigquery_dataset,
+                                                 load_bigquery_table, upload_file_to_cloud_storage,
+                                                 bigquery_table_exists)
 from observatory_platform.utils.proc_utils import wait_for_process
 from observatory_platform.utils.url_utils import retry_session
 from tests.observatory_platform.config import test_fixtures_path
@@ -58,33 +48,23 @@ from tests.observatory_platform.config import test_fixtures_path
 def list_releases(start_date: Pendulum, end_date: Pendulum) -> List['FundrefRelease']:
     """ List all available fundref releases
 
-    :param telescope_url:
     :param start_date:
     :param end_date:
     :return: list of FundrefRelease instances.
     """
 
     # A selection of headers to prevent 403/forbidden error.
-    headers_list = [
-        {
-            'authority': 'gitlab.com',
-            'upgrade-insecure-requests': '1',
-            'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Safari/537.36',
-            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
-            'sec-fetch-site': 'none',
-            'sec-fetch-mode': 'navigate',
-            'sec-fetch-dest': 'document',
-            'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8'
-        },
-        {
-            'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0',
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-            'Accept-Language': 'en-US,en;q=0.5',
-            'DNT': '1',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1'
-        }
-    ]
+    headers_list = [{'authority': 'gitlab.com', 'upgrade-insecure-requests': '1',
+                     'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) '
+                                   'Chrome/84.0.4147.89 Safari/537.36',
+                     'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,'
+                               '*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+                     'sec-fetch-site': 'none', 'sec-fetch-mode': 'navigate', 'sec-fetch-dest': 'document',
+                     'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8'},
+                    {'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0',
+                     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+                     'Accept-Language': 'en-US,en;q=0.5', 'DNT': '1', 'Connection': 'keep-alive',
+                     'Upgrade-Insecure-Requests': '1'}]
 
     releases_list = []
     headers = random.choice(headers_list)
@@ -141,24 +121,15 @@ def download_release(release: 'FundrefRelease') -> str:
     logging.info(f"Downloading file: {file_path}, url: {release.url}")
 
     # A selection of headers to prevent 403/forbidden error.
-    headers_list = [
-        {
-            'authority': 'gitlab.com',
-            'upgrade-insecure-requests': '1',
-            'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36',
-            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
-            'sec-fetch-site': 'none',
-            'sec-fetch-mode': 'navigate',
-            'sec-fetch-dest': 'document',
-            'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8'
-        },
-        {
-            'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0',
-            'Accept': '*/*',
-            'Accept-Language': 'en-US,en;q=0.5',
-            'Referer': 'https://gitlab.com/'
-        }
-    ]
+    headers_list = [{'authority': 'gitlab.com', 'upgrade-insecure-requests': '1',
+                     'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) '
+                                   'Chrome/83.0.4103.116 Safari/537.36',
+                     'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,'
+                               '*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+                     'sec-fetch-site': 'none', 'sec-fetch-mode': 'navigate', 'sec-fetch-dest': 'document',
+                     'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8'},
+                    {'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0',
+                     'Accept': '*/*', 'Accept-Language': 'en-US,en;q=0.5', 'Referer': 'https://gitlab.com/'}]
 
     # Download release
     with requests.get(release.url, headers=random.choice(headers_list), stream=True) as response:
@@ -292,36 +263,12 @@ def new_funder_template():
 
     :return: a blank funder object.
     """
-    return {
-        'funder': None,
-        'pre_label': None,
-        'alt_label': [],
-        'narrower': [],
-        'broader': [],
-        'modified': None,
-        'created': None,
-        'funding_body_type': None,
-        'funding_body_sub_type': None,
-        'region': None,
-        'country': None,
-        'country_code': None,
-        'state': None,
-        'tax_id': None,
-        'continuation_of': [],
-        'renamed_as': [],
-        'replaces': [],
-        'affil_with': [],
-        'merged_with': [],
-        'incorporated_into': [],
-        'is_replaced_by': [],
-        'incorporates': [],
-        'split_into': [],
-        'status': None,
-        'merger_of': [],
-        'split_from': None,
-        'formly_known_as': None,
-        'notation': None
-    }
+    return {'funder': None, 'pre_label': None, 'alt_label': [], 'narrower': [], 'broader': [], 'modified': None,
+            'created': None, 'funding_body_type': None, 'funding_body_sub_type': None, 'region': None, 'country': None,
+            'country_code': None, 'state': None, 'tax_id': None, 'continuation_of': [], 'renamed_as': [],
+            'replaces': [], 'affil_with': [], 'merged_with': [], 'incorporated_into': [], 'is_replaced_by': [],
+            'incorporates': [], 'split_into': [], 'status': None, 'merger_of': [], 'split_from': None,
+            'formly_known_as': None, 'notation': None}
 
 
 def parse_fundref_registry_rdf(registry_file_path: str) -> Tuple[List, Dict]:
@@ -438,8 +385,9 @@ def add_funders_relationships(funders: List, funders_by_key: Dict) -> List:
 
 
 def recursive_funders(funders_by_key: Dict, funder: Dict, depth: int, direction: str, parents: List) -> Tuple[
-    List, int]:
-    """ Recursively goes through a funder/sub_funder dict. The funder properties can be looked up with the funders_by_key
+                        List, int]:
+    """ Recursively goes through a funder/sub_funder dict. The funder properties can be looked up with the
+    funders_by_key
     dictionary that stores the properties per funder id. Any children/parents for the funder are already given in the
     xml element with the 'narrower' and 'broader' tags. For each funder in the list, it will recursively add any
     children/parents for those funders in 'narrower'/'broader' and their funder properties.
@@ -523,30 +471,33 @@ class FundrefTelescope:
     def check_dependencies(**kwargs):
         """ Check that all variables exist that are required to run the DAG.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
-        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
-        AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
+        vars_valid = check_variables(AirflowVar.data_path.get(), AirflowVar.project_id.get(),
+                                     AirflowVar.data_location.get(), AirflowVar.download_bucket_name.get(),
+                                     AirflowVar.transform_bucket_name.get())
         if not vars_valid:
             raise AirflowException('Required variables are missing')
 
     @staticmethod
     def list_releases(**kwargs):
-        """ Based on a list of all releases, checks which ones were released between this and the next execution date of the
-        DAG. If the release falls within the time period mentioned above, checks if a bigquery table doesn't exist yet for
-        the release. A list of releases that passed both checks is passed to the next tasks. If the list is empty the workflow will
-        stop.
+        """ Based on a list of all releases, checks which ones were released between this and the next execution date
+        of the DAG. If the release falls within the time period mentioned above, checks if a bigquery table doesn't
+        exist yet for the release. A list of releases that passed both checks is passed to the next tasks. If the
+        list is empty the workflow will stop.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
         # Get variables
-        project_id = Variable.get("project_id")
+        project_id = Variable.get(AirflowVar.project_id.get())
 
         # List releases between a start date and an end date
         execution_date = kwargs['execution_date']
@@ -581,7 +532,8 @@ class FundrefTelescope:
         """ Download release to file. If dev environment, copy debug file from this repository to the right location.
         Else download from url.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -591,7 +543,7 @@ class FundrefTelescope:
         releases_list = pull_releases(ti)
 
         # Get variables
-        environment = Variable.get("environment")
+        environment = Variable.get(AirflowVar.environment.get())
 
         # Download each release
         for release in releases_list:
@@ -604,7 +556,8 @@ class FundrefTelescope:
     def upload_downloaded(**kwargs):
         """ Upload the downloaded files to a Google Cloud Storage bucket.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -614,7 +567,7 @@ class FundrefTelescope:
         releases_list = pull_releases(ti)
 
         # Get variables
-        bucket_name = Variable.get("download_bucket_name")
+        bucket_name = Variable.get(AirflowVar.download_bucket_name.get())
 
         # Upload each release
         for release in releases_list:
@@ -625,7 +578,8 @@ class FundrefTelescope:
     def extract(**kwargs):
         """ Extract release to new file.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -640,10 +594,12 @@ class FundrefTelescope:
 
     @staticmethod
     def transform(**kwargs):
-        """ Transform release by parsing the raw rdf file, transforming it into a json file and replacing geoname associated
+        """ Transform release by parsing the raw rdf file, transforming it into a json file and replacing geoname
+        associated
         ids with their geoname name.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -660,7 +616,8 @@ class FundrefTelescope:
     def upload_transformed(**kwargs):
         """ Upload the transformed release to a Google Cloud Storage bucket.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -670,7 +627,7 @@ class FundrefTelescope:
         releases_list = pull_releases(ti)
 
         # Get variables
-        bucket_name = Variable.get("transform_bucket_name")
+        bucket_name = Variable.get(AirflowVar.transform_bucket_name.get())
 
         # Upload each release
         for release in releases_list:
@@ -681,7 +638,8 @@ class FundrefTelescope:
     def bq_load(**kwargs):
         """ Upload transformed release to a bigquery table.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -691,9 +649,9 @@ class FundrefTelescope:
         releases_list = pull_releases(ti)
 
         # Get variables
-        project_id = Variable.get("project_id")
-        data_location = Variable.get("data_location")
-        bucket_name = Variable.get("transform_bucket_name")
+        project_id = Variable.get(AirflowVar.project_id.get())
+        data_location = Variable.get(AirflowVar.data_location.get())
+        bucket_name = Variable.get(AirflowVar.transform_bucket_name.get())
 
         # Create dataset
         dataset_id = FundrefTelescope.DAG_ID
@@ -721,7 +679,8 @@ class FundrefTelescope:
     def cleanup(**kwargs):
         """ Delete files of downloaded, extracted and transformed releases.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """

--- a/observatory_platform/telescopes/fundref.py
+++ b/observatory_platform/telescopes/fundref.py
@@ -36,6 +36,7 @@ from google.cloud.bigquery import SourceFormat
 from pendulum import Pendulum
 
 from observatory_platform.utils.config_utils import (
+    AirflowVar,
     find_schema,
     SubFolder,
     schema_path,
@@ -527,8 +528,8 @@ class FundrefTelescope:
         :return: None.
         """
 
-        vars_valid = check_variables("data_path", "project_id", "data_location",
-                                     "download_bucket_name", "transform_bucket_name")
+        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
+        AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
         if not vars_valid:
             raise AirflowException('Required variables are missing')
 

--- a/observatory_platform/telescopes/geonames.py
+++ b/observatory_platform/telescopes/geonames.py
@@ -29,11 +29,13 @@ from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
 from pendulum import Pendulum
 
-from observatory_platform.utils.config_utils import (AirflowVar, find_schema, SubFolder, schema_path, telescope_path, )
+from observatory_platform.utils.config_utils import AirflowVar, SubFolder, find_schema, schema_path, telescope_path
 from observatory_platform.utils.config_utils import check_variables
 from observatory_platform.utils.data_utils import get_file
-from observatory_platform.utils.gc_utils import (bigquery_partitioned_table_id, create_bigquery_dataset,
-                                                 load_bigquery_table, upload_file_to_cloud_storage)
+from observatory_platform.utils.gc_utils import (bigquery_partitioned_table_id,
+                                                 create_bigquery_dataset,
+                                                 load_bigquery_table,
+                                                 upload_file_to_cloud_storage)
 from tests.observatory_platform.config import test_fixtures_path
 
 

--- a/observatory_platform/telescopes/geonames.py
+++ b/observatory_platform/telescopes/geonames.py
@@ -31,6 +31,7 @@ from pendulum import Pendulum
 
 from observatory_platform.utils.config_utils import check_variables
 from observatory_platform.utils.config_utils import (
+    AirflowVar,
     find_schema,
     SubFolder,
     schema_path,
@@ -181,8 +182,8 @@ class GeonamesTelescope:
         for a list of the keyword arguments that are passed to this argument.
         """
 
-        vars_valid = check_variables("data_path", "project_id", "data_location",
-                                     "download_bucket_name", "transform_bucket_name")
+        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
+        AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
         if not vars_valid:
             raise AirflowException('Required variables are missing')
 

--- a/observatory_platform/telescopes/grid.py
+++ b/observatory_platform/telescopes/grid.py
@@ -35,8 +35,8 @@ from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
 from pendulum import Pendulum
 
+from observatory_platform.utils.config_utils import AirflowVar, telescope_path, SubFolder, schema_path, find_schema
 from observatory_platform.utils.config_utils import check_variables
-from observatory_platform.utils.config_utils import telescope_path, SubFolder, schema_path, find_schema
 from observatory_platform.utils.data_utils import get_file
 from observatory_platform.utils.gc_utils import (upload_file_to_cloud_storage, load_bigquery_table,
                                                  create_bigquery_dataset, bigquery_partitioned_table_id)
@@ -189,8 +189,8 @@ class GridTelescope:
         :return: None.
         """
 
-        vars_valid = check_variables("data_path", "project_id", "data_location",
-                                     "download_bucket_name", "transform_bucket_name")
+        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
+                                     AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
         if not vars_valid:
             raise AirflowException('Required variables are missing')
 

--- a/observatory_platform/telescopes/grid.py
+++ b/observatory_platform/telescopes/grid.py
@@ -184,13 +184,15 @@ class GridTelescope:
     def check_dependencies(**kwargs):
         """ Check that all variables exist that are required to run the DAG.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
-        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
-                                     AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
+        vars_valid = check_variables(AirflowVar.data_path.get(), AirflowVar.project_id.get(),
+                                     AirflowVar.data_location.get(), AirflowVar.download_bucket_name.get(),
+                                     AirflowVar.transform_bucket_name.get())
         if not vars_valid:
             raise AirflowException('Required variables are missing')
 
@@ -203,7 +205,8 @@ class GridTelescope:
             title (str): the Figshare article title.
             published_date (Pendulum): the published date of the Figshare article.
 
-        :param kwargs: the context passed from the BranchPythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the BranchPythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: the identifier of the task to execute next.
         """
@@ -238,7 +241,8 @@ class GridTelescope:
         Pushes the following xcom:
             download_path (str): the path to the downloaded GRID release.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -272,13 +276,14 @@ class GridTelescope:
     def upload_downloaded(**kwargs):
         """ Task to upload the downloaded GRID releases for a given month.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
         # Get bucket name
-        bucket_name = Variable.get("download_bucket_name")
+        bucket_name = Variable.get(AirflowVar.download_bucket_name.get())
 
         # Pull messages
         ti: TaskInstance = kwargs['ti']
@@ -299,7 +304,8 @@ class GridTelescope:
         Pushes the following xcom:
             extracted_path (str): the path to the extracted GRID release.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -335,7 +341,8 @@ class GridTelescope:
             json_gz_file_name (str): the file name for the transformed GRID release.
             json_gz_file_path (str): the path to the transformed GRID release (including file name).
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -382,7 +389,8 @@ class GridTelescope:
             release_date (str): the release date of the GRID release.
             blob_name (str): the name of the blob on the Google Cloud storage bucket.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -393,7 +401,7 @@ class GridTelescope:
                                include_prior_dates=False)
 
         # Upload each release
-        bucket_name = Variable.get("transform_bucket_name")
+        bucket_name = Variable.get(AirflowVar.transform_bucket_name.get())
         msgs_out = []
         for msg_in in msgs_in:
             file_name = msg_in['json_gz_file_name']
@@ -418,7 +426,8 @@ class GridTelescope:
     def bq_load(**kwargs):
         """ Task to load the transformed GRID releases for a given month to BigQuery.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -428,9 +437,9 @@ class GridTelescope:
                                include_prior_dates=False)
 
         # Upload each release
-        project_id = Variable.get("project_id")
-        data_location = Variable.get("data_location")
-        bucket_name = Variable.get("transform_bucket_name")
+        project_id = Variable.get(AirflowVar.project_id.get())
+        data_location = Variable.get(AirflowVar.data_location.get())
+        bucket_name = Variable.get(AirflowVar.transform_bucket_name.get())
 
         # Create dataset
         dataset_id = GridTelescope.DAG_ID
@@ -465,7 +474,8 @@ class GridTelescope:
     def cleanup(**kwargs):
         """ Delete files of downloaded, extracted and transformed releases.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """

--- a/observatory_platform/telescopes/grid.py
+++ b/observatory_platform/telescopes/grid.py
@@ -24,8 +24,8 @@ import os
 import pathlib
 import shutil
 from shutil import copyfile
-from typing import List, Dict, Tuple
-from zipfile import ZipFile, BadZipFile
+from typing import Dict, List, Tuple
+from zipfile import BadZipFile, ZipFile
 
 import jsonlines
 import pendulum
@@ -35,11 +35,13 @@ from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
 from pendulum import Pendulum
 
-from observatory_platform.utils.config_utils import AirflowVar, telescope_path, SubFolder, schema_path, find_schema
+from observatory_platform.utils.config_utils import AirflowVar, SubFolder, find_schema, schema_path, telescope_path
 from observatory_platform.utils.config_utils import check_variables
 from observatory_platform.utils.data_utils import get_file
-from observatory_platform.utils.gc_utils import (upload_file_to_cloud_storage, load_bigquery_table,
-                                                 create_bigquery_dataset, bigquery_partitioned_table_id)
+from observatory_platform.utils.gc_utils import (bigquery_partitioned_table_id,
+                                                 create_bigquery_dataset,
+                                                 load_bigquery_table,
+                                                 upload_file_to_cloud_storage)
 from observatory_platform.utils.url_utils import retry_session
 
 GRID_DATASET_URL = "https://api.figshare.com/v2/collections/3812929/articles?page_size=1000"
@@ -53,7 +55,9 @@ def list_grid_releases(timeout: float = 30.) -> List[Dict]:
     :return: the list of GRID releases.
     """
 
-    response = retry_session().get(GRID_DATASET_URL, timeout=timeout, headers={'Accept-encoding': 'gzip'})
+    response = retry_session().get(GRID_DATASET_URL, timeout=timeout, headers={
+        'Accept-encoding': 'gzip'
+    })
     return json.loads(response.text)
 
 
@@ -67,8 +71,9 @@ def download_grid_release(download_path: str, article_id: int, title: str, timeo
     :return: the paths on the system of the downloaded files.
     """
 
-    response = retry_session().get(GRID_FILE_URL.format(article_id=article_id), timeout=timeout,
-                                   headers={'Accept-encoding': 'gzip'})
+    response = retry_session().get(GRID_FILE_URL.format(article_id=article_id), timeout=timeout, headers={
+        'Accept-encoding': 'gzip'
+    })
     article_files = json.loads(response.text)
 
     downloads = []

--- a/observatory_platform/telescopes/mag.py
+++ b/observatory_platform/telescopes/mag.py
@@ -38,12 +38,21 @@ from mag_archiver.mag import MagArchiverClient, MagDateType, MagRelease, MagStat
 from natsort import natsorted
 from pendulum import Pendulum
 
-from observatory_platform.utils.config_utils import (AirflowConn, AirflowVar, telescope_path, SubFolder, schema_path,
-                                                     find_schema, check_variables, check_connections)
+from observatory_platform.utils.config_utils import (AirflowConn,
+                                                     AirflowVar,
+                                                     SubFolder,
+                                                     check_connections,
+                                                     check_variables,
+                                                     find_schema,
+                                                     schema_path,
+                                                     telescope_path)
 from observatory_platform.utils.gc_utils import (azure_to_google_cloud_storage_transfer,
-                                                 download_blobs_from_cloud_storage, upload_files_to_cloud_storage,
-                                                 load_bigquery_table, create_bigquery_dataset,
-                                                 bigquery_partitioned_table_id, table_name_from_blob)
+                                                 bigquery_partitioned_table_id,
+                                                 create_bigquery_dataset,
+                                                 download_blobs_from_cloud_storage,
+                                                 load_bigquery_table,
+                                                 table_name_from_blob,
+                                                 upload_files_to_cloud_storage)
 from observatory_platform.utils.proc_utils import wait_for_process
 from tests.observatory_platform.config import test_fixtures_path
 
@@ -481,11 +490,28 @@ def db_load_mag_release(project_id: str, bucket_name: str, data_location: str, r
     :return: whether the MAG release was loaded into BigQuery successfully.
     """
 
-    settings = {'Authors': {'quote': '', 'allow_quoted_newlines': True},
-        'FieldsOfStudy': {'quote': '', 'allow_quoted_newlines': False},
-        'PaperAuthorAffiliations': {'quote': '', 'allow_quoted_newlines': False},
-        'PaperCitationContexts': {'quote': '', 'allow_quoted_newlines': True},
-        'Papers': {'quote': '', 'allow_quoted_newlines': True}}
+    settings = {
+        'Authors': {
+            'quote': '',
+            'allow_quoted_newlines': True
+        },
+        'FieldsOfStudy': {
+            'quote': '',
+            'allow_quoted_newlines': False
+        },
+        'PaperAuthorAffiliations': {
+            'quote': '',
+            'allow_quoted_newlines': False
+        },
+        'PaperCitationContexts': {
+            'quote': '',
+            'allow_quoted_newlines': True
+        },
+        'Papers': {
+            'quote': '',
+            'allow_quoted_newlines': True
+        }
+    }
 
     # Create dataset
     create_bigquery_dataset(project_id, dataset_id, data_location, MagTelescope.DESCRIPTION)

--- a/observatory_platform/telescopes/mag.py
+++ b/observatory_platform/telescopes/mag.py
@@ -34,6 +34,7 @@ from airflow.models.taskinstance import TaskInstance
 from google.cloud import storage
 from google.cloud.bigquery import SourceFormat
 from google.cloud.storage import Blob
+from mag_archiver.mag import MagArchiverClient, MagDateType, MagRelease, MagState
 from natsort import natsorted
 from pendulum import Pendulum
 
@@ -44,7 +45,6 @@ from observatory_platform.utils.gc_utils import (azure_to_google_cloud_storage_t
                                                  load_bigquery_table, create_bigquery_dataset,
                                                  bigquery_partitioned_table_id, table_name_from_blob)
 from observatory_platform.utils.proc_utils import wait_for_process
-from mag_archiver.mag import MagArchiverClient, MagDateType, MagRelease, MagState
 from tests.observatory_platform.config import test_fixtures_path
 
 
@@ -175,14 +175,16 @@ class MagTelescope:
     def check_dependencies(**kwargs):
         """ Check that all variables and connections exist that are required to run the DAG.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
-        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
-        AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
-        conns_valid = check_connections(AirflowConn.mag_releases_table, AirflowConn.mag_snapshots_container)
+        vars_valid = check_variables(AirflowVar.data_path.get(), AirflowVar.project_id.get(),
+                                     AirflowVar.data_location.get(), AirflowVar.download_bucket_name.get(),
+                                     AirflowVar.transform_bucket_name.get())
+        conns_valid = check_connections(AirflowConn.mag_releases_table.get(), AirflowConn.mag_snapshots_container.get())
 
         if not vars_valid or not conns_valid:
             raise AirflowException('Required variables or connections are missing')
@@ -198,7 +200,8 @@ class MagTelescope:
         Pushes the following xcom:
             a list of MagRelease instances.
 
-        :param kwargs: the context passed from the BranchPythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the BranchPythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: the identifier of the task to execute next.
         """
@@ -231,7 +234,8 @@ class MagTelescope:
             mag_snapshots_container: the Azure Storage Account name (login) and the sas token (password) for the
             Azure storage blob container that contains the MAG releases.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -241,9 +245,9 @@ class MagTelescope:
         releases = pull_releases(ti)
 
         # Get variables
-        environment = Variable.get("environment")
-        gcp_project_id = Variable.get("project_id")
-        gcp_bucket_name = Variable.get("download_bucket_name")
+        environment = Variable.get(AirflowVar.environment.get())
+        gcp_project_id = Variable.get(AirflowVar.project_id.get())
+        gcp_bucket_name = Variable.get(AirflowVar.download_bucket_name.get())
 
         if environment == 'dev':
             # TODO: this is a bit messy. In the future, for the test environment we should just have smaller files at
@@ -307,13 +311,14 @@ class MagTelescope:
     def download(**kwargs):
         """ Downloads the MAG release from Google Cloud Storage.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
         # Get variables
-        bucket_name = Variable.get("download_bucket_name")
+        bucket_name = Variable.get(AirflowVar.download_bucket_name.get())
 
         # Get MAG releases
         ti: TaskInstance = kwargs['ti']
@@ -339,7 +344,8 @@ class MagTelescope:
     def transform(**kwargs):
         """ Transforms the MAG release into a form that can be uploaded to BigQuery.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -368,13 +374,14 @@ class MagTelescope:
     def upload_transformed(**kwargs):
         """ Uploads the transformed MAG release files to Google Cloud Storage for loading into BigQuery.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
         # Get variables
-        bucket_name = Variable.get("transform_bucket_name")
+        bucket_name = Variable.get(AirflowVar.transform_bucket_name.get())
 
         # Get MAG releases
         ti: TaskInstance = kwargs['ti']
@@ -387,8 +394,8 @@ class MagTelescope:
                                                     release.source_container)
             posix_paths = list_mag_release_files(release_transformed_path)
             paths = [str(path) for path in posix_paths]
-            blob_names = [f'telescopes/{MagTelescope.DAG_ID}/{release.source_container}/{path.name}' for
-                          path in posix_paths]
+            blob_names = [f'telescopes/{MagTelescope.DAG_ID}/{release.source_container}/{path.name}' for path in
+                          posix_paths]
             success = upload_files_to_cloud_storage(bucket_name, blob_names, paths,
                                                     max_processes=MagTelescope.MAX_PROCESSES,
                                                     max_connections=MagTelescope.MAX_CONNECTIONS,
@@ -403,7 +410,8 @@ class MagTelescope:
     def bq_load(**kwargs):
         """ Loads a MAG release into BigQuery.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -413,9 +421,9 @@ class MagTelescope:
         releases = pull_releases(ti)
 
         # Get config variables
-        project_id = Variable.get("project_id")
-        data_location = Variable.get("data_location")
-        bucket_name = Variable.get("transform_bucket_name")
+        project_id = Variable.get(AirflowVar.project_id.get())
+        data_location = Variable.get(AirflowVar.data_location.get())
+        bucket_name = Variable.get(AirflowVar.transform_bucket_name.get())
 
         # For each release, load into BigQuery
         for release in releases:
@@ -432,7 +440,8 @@ class MagTelescope:
     def cleanup(**kwargs):
         """ Delete files of downloaded, extracted and transformed releases.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -472,13 +481,11 @@ def db_load_mag_release(project_id: str, bucket_name: str, data_location: str, r
     :return: whether the MAG release was loaded into BigQuery successfully.
     """
 
-    settings = {
-        'Authors': {'quote': '', 'allow_quoted_newlines': True},
+    settings = {'Authors': {'quote': '', 'allow_quoted_newlines': True},
         'FieldsOfStudy': {'quote': '', 'allow_quoted_newlines': False},
         'PaperAuthorAffiliations': {'quote': '', 'allow_quoted_newlines': False},
         'PaperCitationContexts': {'quote': '', 'allow_quoted_newlines': True},
-        'Papers': {'quote': '', 'allow_quoted_newlines': True}
-    }
+        'Papers': {'quote': '', 'allow_quoted_newlines': True}}
 
     # Create dataset
     create_bigquery_dataset(project_id, dataset_id, data_location, MagTelescope.DESCRIPTION)

--- a/observatory_platform/telescopes/mag.py
+++ b/observatory_platform/telescopes/mag.py
@@ -37,8 +37,8 @@ from google.cloud.storage import Blob
 from natsort import natsorted
 from pendulum import Pendulum
 
-from observatory_platform.utils.config_utils import (telescope_path, SubFolder, schema_path, find_schema,
-                                                     check_variables, check_connections)
+from observatory_platform.utils.config_utils import (AirflowConn, AirflowVar, telescope_path, SubFolder, schema_path,
+                                                     find_schema, check_variables, check_connections)
 from observatory_platform.utils.gc_utils import (azure_to_google_cloud_storage_transfer,
                                                  download_blobs_from_cloud_storage, upload_files_to_cloud_storage,
                                                  load_bigquery_table, create_bigquery_dataset,
@@ -180,9 +180,9 @@ class MagTelescope:
         :return: None.
         """
 
-        vars_valid = check_variables("data_path", "project_id", "data_location",
-                                     "download_bucket_name", "transform_bucket_name")
-        conns_valid = check_connections("mag_releases_table", "mag_snapshots_container")
+        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
+        AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
+        conns_valid = check_connections(AirflowConn.mag_releases_table, AirflowConn.mag_snapshots_container)
 
         if not vars_valid or not conns_valid:
             raise AirflowException('Required variables or connections are missing')

--- a/observatory_platform/telescopes/unpaywall.py
+++ b/observatory_platform/telescopes/unpaywall.py
@@ -32,6 +32,7 @@ from pendulum import Pendulum
 
 from observatory_platform.utils.config_utils import check_variables
 from observatory_platform.utils.config_utils import (
+    AirflowVar,
     find_schema,
     SubFolder,
     schema_path,
@@ -259,8 +260,8 @@ class UnpaywallTelescope:
         :return: None.
         """
 
-        vars_valid = check_variables("data_path", "project_id", "data_location", "environment",
-                                     "download_bucket_name", "transform_bucket_name")
+        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
+        AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
         if not vars_valid:
             raise AirflowException('Required variables are missing')
 

--- a/observatory_platform/telescopes/unpaywall.py
+++ b/observatory_platform/telescopes/unpaywall.py
@@ -30,22 +30,14 @@ from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
 from pendulum import Pendulum
 
+from observatory_platform.utils.config_utils import (AirflowVar, find_schema, SubFolder, schema_path, telescope_path, )
 from observatory_platform.utils.config_utils import check_variables
-from observatory_platform.utils.config_utils import (
-    AirflowVar,
-    find_schema,
-    SubFolder,
-    schema_path,
-    telescope_path,
-)
 from observatory_platform.utils.data_utils import get_file
-from observatory_platform.utils.gc_utils import (
-    bigquery_partitioned_table_id,
-    create_bigquery_dataset,
-    load_bigquery_table,
-    upload_file_to_cloud_storage,
-    bigquery_table_exists
-)
+from observatory_platform.utils.gc_utils import (bigquery_partitioned_table_id,
+                                                 create_bigquery_dataset,
+                                                 load_bigquery_table,
+                                                 upload_file_to_cloud_storage,
+                                                 bigquery_table_exists)
 from observatory_platform.utils.proc_utils import wait_for_process
 from observatory_platform.utils.url_utils import retry_session
 from tests.observatory_platform.config import test_fixtures_path
@@ -66,7 +58,6 @@ def list_releases(start_date: Pendulum, end_date: Pendulum) -> List['UnpaywallRe
     """ Parses xml string retrieved from GET request to create list of urls for
     different releases.
 
-    :param telescope_url: url on which to execute GET request
     :param start_date:
     :param end_date:
     :return: a list of UnpaywallRelease instances.
@@ -126,8 +117,7 @@ def extract_release(release: 'UnpaywallRelease') -> str:
     logging.info(f"Extracting file: {release.filepath_download}")
 
     cmd = f"gunzip -c {release.filepath_download} > {release.filepath_extract}"
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                         executable='/bin/bash')
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable='/bin/bash')
     stdout, stderr = wait_for_process(p)
 
     if stdout:
@@ -255,13 +245,15 @@ class UnpaywallTelescope:
     def check_dependencies(**kwargs):
         """ Check that all variables exist that are required to run the DAG.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
-        vars_valid = check_variables(AirflowVar.data_path, AirflowVar.project_id, AirflowVar.data_location,
-        AirflowVar.download_bucket_name, AirflowVar.transform_bucket_name)
+        vars_valid = check_variables(AirflowVar.data_path.get(), AirflowVar.project_id.get(),
+                                     AirflowVar.data_location.get(), AirflowVar.download_bucket_name.get(),
+                                     AirflowVar.transform_bucket_name.get())
         if not vars_valid:
             raise AirflowException('Required variables are missing')
 
@@ -272,13 +264,14 @@ class UnpaywallTelescope:
         exist yet for the release. A list of releases that passed both checks is passed to the next tasks. If the list
         is empty the workflow will stop.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
 
         # Get variables
-        project_id = Variable.get("project_id")
+        project_id = Variable.get(AirflowVar.project_id.get())
 
         # List releases between a start and end date
         execution_date = kwargs['execution_date']
@@ -311,7 +304,8 @@ class UnpaywallTelescope:
         """ Download release to file.
         If dev environment, copy debug file from this repository to the right location. Else download from url.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -321,7 +315,7 @@ class UnpaywallTelescope:
         releases_list = pull_releases(ti)
 
         # Get variables
-        environment = Variable.get("environment")
+        environment = Variable.get(AirflowVar.environment.get())
 
         # Download each release
         for release in releases_list:
@@ -334,7 +328,8 @@ class UnpaywallTelescope:
     def upload_downloaded(**kwargs):
         """ Upload downloaded release to a google cloud storage bucket.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -344,7 +339,7 @@ class UnpaywallTelescope:
         releases_list = pull_releases(ti)
 
         # Get variables
-        bucket_name = Variable.get("download_bucket_name")
+        bucket_name = Variable.get(AirflowVar.download_bucket_name.get())
 
         # Upload each release
         for release in releases_list:
@@ -355,7 +350,8 @@ class UnpaywallTelescope:
     def extract(**kwargs):
         """ Unzip release to new file.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -372,7 +368,8 @@ class UnpaywallTelescope:
     def transform(**kwargs):
         """ Transform release with sed command and save to new file.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -389,7 +386,8 @@ class UnpaywallTelescope:
     def upload_transformed(**kwargs):
         """ Upload transformed release to a google cloud storage bucket.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -399,7 +397,7 @@ class UnpaywallTelescope:
         releases_list = pull_releases(ti)
 
         # Get variables
-        bucket_name = Variable.get("transform_bucket_name")
+        bucket_name = Variable.get(AirflowVar.transform_bucket_name.get())
 
         # Upload each release
         for release in releases_list:
@@ -410,7 +408,8 @@ class UnpaywallTelescope:
     def load_to_bq(**kwargs):
         """ Upload transformed release to a bigquery table.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
@@ -420,9 +419,9 @@ class UnpaywallTelescope:
         releases_list: List[UnpaywallRelease] = pull_releases(ti)
 
         # Get variables
-        project_id = Variable.get("project_id")
-        bucket_name = Variable.get("transform_bucket_name")
-        data_location = Variable.get("data_location")
+        project_id = Variable.get(AirflowVar.project_id.get())
+        bucket_name = Variable.get(AirflowVar.transform_bucket_name.get())
+        data_location = Variable.get(AirflowVar.data_location.get())
 
         # Create dataset
         dataset_id = UnpaywallTelescope.DATASET_ID
@@ -453,7 +452,8 @@ class UnpaywallTelescope:
     def cleanup(**kwargs):
         """ Delete files of downloaded, extracted and transformed release.
 
-        :param kwargs: the context passed from the PythonOperator. See https://airflow.apache.org/docs/stable/macros-ref.html
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """

--- a/observatory_platform/telescopes/unpaywall.py
+++ b/observatory_platform/telescopes/unpaywall.py
@@ -30,14 +30,14 @@ from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
 from pendulum import Pendulum
 
-from observatory_platform.utils.config_utils import (AirflowVar, find_schema, SubFolder, schema_path, telescope_path, )
+from observatory_platform.utils.config_utils import AirflowVar, SubFolder, find_schema, schema_path, telescope_path
 from observatory_platform.utils.config_utils import check_variables
 from observatory_platform.utils.data_utils import get_file
 from observatory_platform.utils.gc_utils import (bigquery_partitioned_table_id,
+                                                 bigquery_table_exists,
                                                  create_bigquery_dataset,
                                                  load_bigquery_table,
-                                                 upload_file_to_cloud_storage,
-                                                 bigquery_table_exists)
+                                                 upload_file_to_cloud_storage)
 from observatory_platform.utils.proc_utils import wait_for_process
 from observatory_platform.utils.url_utils import retry_session
 from tests.observatory_platform.config import test_fixtures_path

--- a/observatory_platform/utils/config_utils.py
+++ b/observatory_platform/utils/config_utils.py
@@ -16,6 +16,7 @@
 
 
 import glob
+import itertools
 import logging
 import os
 import pathlib
@@ -287,12 +288,13 @@ class ObservatoryConfig:
             }
         }
     }
-    for airflow_conn in AirflowConn:
-        if airflow_conn.value['schema']:
-            schema['airflow_connections']['schema'][airflow_conn.get()] = airflow_conn.value['schema']
-    for airflow_var in AirflowVar:
-        if airflow_var.value['schema']:
-            schema['airflow_variables']['schema'][airflow_var.get()] = airflow_var.value['schema']
+    for obj in itertools.chain(AirflowConn, AirflowVar):
+        if obj.value['schema']:
+            if type(obj) == AirflowConn:
+                schema['airflow_connections']['schema'][obj.get()] = obj.value['schema']
+            else:
+                schema['airflow_variables']['schema'][obj.get()] = obj.value['schema']
+    del obj
 
     def __init__(self,
                  fernet_key: Union[None, str] = None,

--- a/observatory_platform/utils/config_utils.py
+++ b/observatory_platform/utils/config_utils.py
@@ -190,7 +190,7 @@ def telescope_path(sub_folder: SubFolder, name: str) -> str:
     global data_path
     if data_path is None:
         logging.info('telescope_path: requesting data_path variable')
-        data_path = airflow.models.Variable.get("data_path")
+        data_path = airflow.models.Variable.get(AirflowVar.data_path.get())
 
     # Create telescope path
     path = os.path.join(data_path, 'telescopes', sub_folder.value, name)
@@ -302,8 +302,8 @@ class ObservatoryConfig:
                  validator: ObservatoryConfigValidator = None):
         """ Holds the settings for the Observatory Platform, used by DAGs.
 
-        :param environment: whether the system is running in dev, test or prod mode.
-        :param google_application_credentials: the path to the Google Application Credentials: https://cloud.google.com/docs/authentication/getting-started
+        :param google_application_credentials: the path to the Google Application Credentials:
+        https://cloud.google.com/docs/authentication/getting-started
         :param fernet_key:
         """
 


### PR DESCRIPTION
Noticed when I wanted to add a 'terraform' connection inside Airflow I have to add this to 5 different methods of the ObservatoryConfig class. I wanted to make this process a little bit easier and this is just a proposal of one way to do it. You now only have to add it to one AirflowConn or AirflowVar class (besides changing code in other places which remains the same for both ways). 
What do you think @jdddog, do you have any suggestions?

Instead of hardcoding each individual airflow variable/connection as part of a config instance, each config instance now has two variables 'airflow_variables' and 'airflow_connections'. This makes it easier to add more variables/connections in the future.

To ensure that the right name for a variable/connection is used two classes were added: AirflowConn and AirflowVar. The variable/connection name from here is used when reading the config file, defining environment variables and inside telescopes.
This prevents errors regarding e.g. misspelling the variable/connection name.

Example config file:
```
environment: dev
data_location: us-east1
fernet_key: Jdl5louNP1
google_application_credentials: /Users/284060a/keys/gcp/workflows-dev-ead352480b42.json
airflow_connections:
  crossref: mysql://crossref-token@
  terraform: mysql://terraform-token@
  mag_releases_table: mysql://azure-storage-account-name:url-encoded-sas-token@
  mag_snapshots_container: mysql://azure-storage-account-name:url-encoded-sas-token@
airflow_variables:
  download_bucket_name: workflows-dev-910922156021-download
  transform_bucket_name: workflows-dev-910922156021-transform
  project_id: workflows-dev
```