### PR TITLE
Hotfix/installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,5 @@ ratelimit==2.2.*
 wos==0.2.*
 backoff==1.10.*
 oauth2client==1.5.2
+importlib-metadata==1.7.*
+


### PR DESCRIPTION
- On some systems (mine, ubuntu 20.04), the installed version of importlib-metadata will be 2.0.0, whereas one of the package dependencies requires <2.  Since 1.7.4 works on Jamie's machine, targetting 1.4.* in requirements.txt
- Had weird artifact problem with airflow db where despite clearing out as many docker-compose images/orphans, and all docker images/containers and the config directory, the webserver container kept bootlooping due to missing table fields. Adding 'airflow initdb' to the entrypoint-airflow.sh script fixes this.  It's meant to be a non destructive command so it should be no harm no foul in adding it to handle that situation.