### PR TITLE
Reports: Fixes to graphs and tests with related updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 tests/fixtures/** filter=lfs diff=lfs merge=lfs -text
 docs/* linguist-documentation
 notebooks/* linguist-documentation
+*.csv filter=lfs diff=lfs merge=lfs -text

--- a/observatory_platform/reports/abstract_table.py
+++ b/observatory_platform/reports/abstract_table.py
@@ -15,6 +15,7 @@
 # Author: Cameron Neylon & Richard Hosking
 
 import pandas as pd
+from typing import Optional
 
 from observatory_platform.reports import chart_utils, report_utils
 from observatory_platform.reports import defaults
@@ -33,6 +34,7 @@ class AbstractObservatoryTable:
                  scope: str = defaults.scope,
                  focus_year: int = None,
                  year_range: tuple = None,
+                 bq_table: Optional[str] = None,
                  collect_and_run: bool = True,
                  **kwargs):
         """Initialisation function
@@ -45,6 +47,8 @@ class AbstractObservatoryTable:
         self.scope = scope
         self.focus_year = focus_year
         self.year_range = year_range
+        if bq_table:
+            self.bq_table = bq_table
 
         if collect_and_run:
             self.collect_data()

--- a/observatory_platform/reports/chart_utils.py
+++ b/observatory_platform/reports/chart_utils.py
@@ -93,8 +93,8 @@ def nice_column_names(df):
         ('Books', 'authored_books'),
         ('Book Sections', 'book_sections'),
         ('Edited Volumes', 'edited_volumes'),
-        ('Reports‡', 'reports'),
-        ('Datasets‡', 'datasets')
+        ('Reports', 'reports'),
+        ('Datasets', 'datasets')
     ]
     for col in cols:
         if col[1] in df.columns.values:

--- a/observatory_platform/reports/charts/collaborations_layout.py
+++ b/observatory_platform/reports/charts/collaborations_layout.py
@@ -70,6 +70,6 @@ class CollaborationsLayout(AbstractObservatoryChart):
                            wspace=0.3)
         axes = [self.fig.add_subplot(grid[:, :-1]), self.fig.add_subplot(grid[1:2, 1])]
 
-        self.map.plot(ax=axes[0])
+        self.map.plot(ax=axes[0], **kwargs)
         self.bar.plot(ax=axes[1])
         return self.fig

--- a/observatory_platform/reports/charts/coordinates_map.py
+++ b/observatory_platform/reports/charts/coordinates_map.py
@@ -63,8 +63,14 @@ class CoordinatesMap(AbstractObservatoryChart):
         else:
             self.fig = ax.get_figure()
         self.world.plot(ax=ax, zorder=1)
-        self.collab_gdf.plot(ax=ax, markersize='count',
-                             zorder=2, color='black', alpha=0.4)
+
+        if 'marker_scale' in kwargs:
+            scale = kwargs.pop('marker_scale')
+            markersize = self.collab_gdf['count'] / scale
+        else:
+            markersize = self.collab_gdf.count
+        self.collab_gdf.plot(ax=ax, markersize=markersize,
+                             zorder=2, color='black', alpha=0.4, **kwargs)
         ax.set_axis_off()
         if self.xlim:
             ax.set(xlim=self.xlim)

--- a/observatory_platform/reports/charts/funder_graph.py
+++ b/observatory_platform/reports/charts/funder_graph.py
@@ -63,10 +63,10 @@ class FunderGraph(AbstractObservatoryChart):
             data = data[data.id == self.identifier]
         data = data.sort_values('count', ascending=False)[0:self.num_funders]
 
-        data = data.melt(id_vars=['published_year', 'name'],
+        data = data.melt(id_vars=['published_year', 'funder'],
                          var_name='variables')
 
-        data.loc[:, 'name'] = data['name'].apply(
+        data.loc[:, 'funder'] = data['funder'].apply(
             lambda s: s[0:self.shorten_names])
         self.figdata = data
         return self.figdata
@@ -77,17 +77,17 @@ class FunderGraph(AbstractObservatoryChart):
 
         self.fig, axes = plt.subplots(
             nrows=1, ncols=2, sharey=True, figsize=(8, 4))
-        sns.barplot(y="name",
-                    x="value",
-                    hue="variables",
+        sns.barplot(y='funder',
+                    x='value',
+                    hue='variables',
                     data=self.figdata[self.figdata.variables.isin(['count',
                                                                    'oa'])],
                     ax=axes[0])
         axes[0].set(ylabel=None, xlabel='Number of Outputs')
         handles, labels = axes[0].get_legend_handles_labels()
         axes[0].legend(handles, ['Total', 'Open Access'])
-        sns.barplot(y="name",
-                    x="value",
+        sns.barplot(y='funder',
+                    x='value',
                     data=self.figdata[self.figdata.variables == 'percent_oa'],
                     color='blue', ax=axes[1])
         axes[1].set(ylabel=None, xlabel='% Open Access')

--- a/observatory_platform/reports/charts/global_comparison_layout.py
+++ b/observatory_platform/reports/charts/global_comparison_layout.py
@@ -66,7 +66,7 @@ class GlobalComparisonLayout(AbstractObservatoryChart):
                                       figsize=(8, 3))
         self.globalscatter.plot(ax=axes[0], xlim=(0, 100), ylim=(0, 100))
 
-        numcountries = len(self.region_data.country.unique())
+        numcountries = len(self.region_data[self.region_data.published_year==self.focus_year].country.unique())
         colorpalette = sns.color_palette(
             palette='bright', n_colors=numcountries)
         self.regionscatter.plot(ax=axes[1],

--- a/observatory_platform/reports/charts/oa_advantage_bar_chart.py
+++ b/observatory_platform/reports/charts/oa_advantage_bar_chart.py
@@ -40,9 +40,9 @@ class OAAdvantageBarChart(AbstractObservatoryChart):
         """
 
         self.df['Citations per non-OA Output'] = (self.df.total_citations -
-                                                  self.df.oa_citations) / (self.df.total - self.df.total_oa)
+                                                  self.df.oa_citations) / (self.df.total - self.df.oa)
         self.df['Citations per Output (all)'] = self.df.total_citations / self.df.total
-        self.df['Citations per OA Output'] = self.df.oa_citations / self.df.total_oa
+        self.df['Citations per OA Output'] = self.df.oa_citations / self.df.oa
         self.df['Citations per Gold OA Output'] = self.df.gold_citations / self.df.gold
         self.df['Citations per Green OA Output'] = self.df.green_citations / self.df.green
         self.df['Citations per Hybrid OA Output'] = self.df.hybrid_citations / self.df.hybrid

--- a/observatory_platform/reports/charts/output_types_pie_chart.py
+++ b/observatory_platform/reports/charts/output_types_pie_chart.py
@@ -44,7 +44,7 @@ class OutputTypesPieChart(AbstractObservatoryChart):
         figdata = self.df[(self.df.id == self.identifier) &
                           (self.df.published_year == self.focus_year) &
                           (self.df.type.isin(type_categories))
-                          ][['type', 'total']]
+                          ][['type', 'count']]
         figdata['type_category'] = pd.Categorical(
             figdata.type,
             categories=defaults.output_types,
@@ -62,7 +62,7 @@ class OutputTypesPieChart(AbstractObservatoryChart):
         else:
             self.fig = ax.get_figure()
         palette = [defaults.outputs_palette[k] for k in defaults.output_types]
-        outputs_pie = self.figdata.plot.pie(y='total',
+        outputs_pie = self.figdata.plot.pie(y='count',
                                             startangle=90,
                                             labels=None,
                                             legend=True,

--- a/observatory_platform/reports/charts/output_types_time_chart.py
+++ b/observatory_platform/reports/charts/output_types_time_chart.py
@@ -30,12 +30,16 @@ class OutputTypesTimeChart(GenericTimeChart):
     def __init__(self,
                  df: pd.DataFrame,
                  identifier: str,
-                 year_range: tuple = (2000, 2020)
+                 year_range: tuple = (2000, 2020),
+                 typecolumn: str = 'type',
+                 countcolumn: str = 'count'
                  ):
         """Initialisation function
         """
 
         columns = ['Output Types', 'value']
+        self.typecolumn = typecolumn
+        self.countcolumn = countcolumn
         super().__init__(df, columns, identifier, year_range)
         self.melt_var_name = 'Output Types'
 
@@ -43,8 +47,8 @@ class OutputTypesTimeChart(GenericTimeChart):
         """Data selection and processing function
         """
 
-        self.df['Output Types'] = self.df.type
-        self.df['value'] = self.df.total
+        self.df['Output Types'] = self.df[self.typecolumn]
+        self.df['value'] = self.df[self.countcolumn]
         columns = ['id', 'Year of Publication'] + self.columns
         self.columns = defaults.output_types
         figdata = self.df[self.df.id == self.identifier][columns]
@@ -53,13 +57,15 @@ class OutputTypesTimeChart(GenericTimeChart):
         return self.figdata
 
     def plot(self,
-             palette=defaults.outputs_palette,
+             palette=None,
              ax=None,
              **kwargs):
         """Plotting function
         """
 
-        super().plot(palette=defaults.outputs_palette,
+        if not palette:
+            palette = defaults.outputs_palette
+        super().plot(palette=palette,
                      ax=ax, **kwargs)
         plt.ylabel('Number of Outputs')
         return self.fig

--- a/observatory_platform/reports/charts/scatter_plot.py
+++ b/observatory_platform/reports/charts/scatter_plot.py
@@ -49,6 +49,8 @@ class ScatterPlot(AbstractObservatoryChart):
                  hue_column: str = 'region',
                  size_column: str = 'total',
                  focus_id: str = None,
+                 focus_marker: str='x',
+                 focus_marker_color: str='black',
                  **kwargs):
         """Initialisation Method
 
@@ -93,6 +95,8 @@ class ScatterPlot(AbstractObservatoryChart):
         self.hue_column = hue_column
         self.size_column = size_column
         self.focus_id = focus_id
+        self.focus_marker = focus_marker
+        self.focus_marker_color = focus_marker_color
         self.kwargs = kwargs
 
     def process_data(self) -> pd.DataFrame:
@@ -163,7 +167,7 @@ class ScatterPlot(AbstractObservatoryChart):
         if self.focus_id:
             sns.scatterplot(x=self.x, y=self.y,
                             data=figdata[figdata.id == self.focus_id],
-                            color="black", s=500, marker='X', legend=False,
+                            color=self.focus_marker_color, s=200, marker=self.focus_marker, legend=False,
                             ax=self.ax)
         self.ax.spines['top'].set_visible(False)
         self.ax.spines['right'].set_visible(False)

--- a/observatory_platform/reports/defaults.py
+++ b/observatory_platform/reports/defaults.py
@@ -51,12 +51,13 @@ country_clean = {"country": {
 outputs_clean = {'type': {
     'total': 'Total Outputs',
     'journal_articles': 'Journal Articles',
-    'proceedings_articles': 'Proceedings',
+    'proceedings_article': 'Proceedings',
     'authored_books': 'Books',
     'book_sections': 'Book Sections',
     'edited_volumes': 'Edited Volumes',
-    'reports': 'Reports‡',
-    'datasets': 'Datasets‡'
+    'reports': 'Reports',
+    'datasets': 'Datasets',
+    'other_outputs': 'Other'
 }}
 
 # List of output types for research publications
@@ -66,8 +67,32 @@ output_types = [
     'Books',
     'Book Sections',
     'Edited Volumes',
-    'Reports‡',
-    'Datasets‡'
+    'Reports',
+    'Datasets'
+]
+# Discipline lists
+# MAG Level0 disciplines
+
+disciplines_mag_level0 = [
+    'Medicine',
+    'Biology',
+    'Environmental science',
+    'Chemistry',
+    'Materials science',
+    'Geology',
+    'Physics',
+    'Computer science',
+    'Engineering',
+    'Mathematics',
+    'Geography',
+    'Psychology',
+    'Economics',
+    'Business',
+    'Political science',
+    'Sociology',
+    'History',
+    'Philosophy',
+    'Art'
 ]
 
 # List of types of Open Access
@@ -78,6 +103,54 @@ oa_types = [
     'Hybrid OA (%)',
     # 'Green in IR (%)',
 ]
+
+# Types of Funder (Fundref Data)
+
+funder_types = [
+    'National government',
+    'Research institutes and centers',
+    'Federal/National Government',
+    'null',
+    'Trusts, charities, foundations (both publically funded and privately funded)',
+    'Local government',
+    'Universities (academic only)',
+    'Associations and societies (private and public)',
+    'international',
+    'For-profit companies (industry)',
+    'other non-profit',
+    'government non-federal',
+    'Other non-profit',
+    'foundation',
+    'professional associations and societies',
+    'federal',
+    'corporate',
+    'academic'
+]
+
+# Standardisation of funder types
+
+funder_type_clean = {'funder_type': {
+    'National government': 'National Government',
+    'Research institutes and centers': 'Research Institute',
+    'Federal/National Government': 'National Government',
+    'null': 'None',
+    'Trusts, charities, foundations (both publically funded and privately funded)': 'Foundation',
+    'Local government': 'Non-national Government',
+    'Universities (academic only)': 'Academic Institution',
+    'Associations and societies (private and public)': 'Association',
+    'international': 'International',
+    'For-profit companies (industry)': 'Corporate',
+    'other non-profit': 'Other non-profit',
+    'government non-federal': 'Non-national Government',
+    'Other non-profit': 'Other non-profit',
+    'foundation': 'Foundation',
+    'professional associations and societies': 'Association',
+    'federal': 'National Government',
+    'corporate': 'Corporate',
+    'academic': 'Academic Institution'}
+}
+
+clean_funder_types = list(set(funder_type_clean['funder_type'].values()))
 
 # --- Palettes ---
 
@@ -107,3 +180,7 @@ husl = sns.color_palette(n_colors=len(output_types))
 outputs_palette = dict([(output_type, husl[i])
                         for i, output_type in enumerate(output_types)])
 outputs_palette.update({'Total Outputs': 'black'})
+
+# Disciplines Palettes
+colors = sns.color_palette('Set3') * 2
+mag_level0_palette = {field: colors[i] for i, field in enumerate(disciplines_mag_level0)}

--- a/observatory_platform/reports/report_utils.py
+++ b/observatory_platform/reports/report_utils.py
@@ -18,14 +18,16 @@ import numpy as np
 import pandas as pd
 import pydata_google_auth
 from num2words import num2words
+from typing import Union
+from precipy.analytics_function import AnalyticsFunction
 
 from observatory_platform.reports.charts.oapc_time_chart import *
 
 
-def generate_table_data(batch,
+def generate_table_data(af: AnalyticsFunction,
                         title,
                         df: pd.DataFrame,
-                        identifier: str,
+                        identifier: Union[str, None],
                         columns: list,
                         identifier_column: str = 'id',
                         sort_column: str = 'Year of Publication',
@@ -37,10 +39,12 @@ def generate_table_data(batch,
     """
 
     table_data = pd.DataFrame()
-    df = df[df[identifier_column] == identifier]
-    df.sort_values('Year of Publication', inplace=True)
+    if identifier is not None:
+        filtered = df[df[identifier_column] == identifier]
+    else:
+        filtered = df
     for i, column in enumerate(columns):
-        col_data = df[column]
+        col_data = filtered[column]
         if short_column_names:
             column = short_column_names[i]
         if col_data.dtype == 'float64':

--- a/observatory_platform/reports/report_utils.py
+++ b/observatory_platform/reports/report_utils.py
@@ -19,13 +19,11 @@ import pandas as pd
 import pydata_google_auth
 from num2words import num2words
 from typing import Union
-from precipy.analytics_function import AnalyticsFunction
 
 from observatory_platform.reports.charts.oapc_time_chart import *
 
 
-def generate_table_data(af: AnalyticsFunction,
-                        title,
+def generate_table_data(title: str,
                         df: pd.DataFrame,
                         identifier: Union[str, None],
                         columns: list,

--- a/observatory_platform/reports/report_utils.py
+++ b/observatory_platform/reports/report_utils.py
@@ -30,7 +30,7 @@ def generate_table_data(af: AnalyticsFunction,
                         identifier: Union[str, None],
                         columns: list,
                         identifier_column: str = 'id',
-                        sort_column: str = 'Year of Publication',
+                        sort_column: Union[str, None] = 'Year of Publication',
                         sort_ascending: bool = True,
                         decimals: int = 0,
                         short_column_names: list = None,
@@ -48,9 +48,13 @@ def generate_table_data(af: AnalyticsFunction,
         if short_column_names:
             column = short_column_names[i]
         if col_data.dtype == 'float64':
-            col_data = np.int_(col_data.round(decimals=decimals))
+            if decimals == 0:
+                col_data = (col_data.round(decimals=decimals)).astype(int, errors='ignore')
+            else:
+                col_data = (col_data.round(decimals=decimals)).astype(float, errors='ignore')
         table_data[column] = col_data
-    table_data.sort_values(sort_column, ascending=sort_ascending, inplace=True)
+    if sort_column:
+        table_data.sort_values(sort_column, ascending=sort_ascending, inplace=True)
     table_data_list = table_data.to_dict(orient='records')
 
     if short_column_names:

--- a/observatory_platform/reports/tables.py
+++ b/observatory_platform/reports/tables.py
@@ -49,7 +49,8 @@ FROM `{bq_table}` as table,
     UNNEST(years) as years
 WHERE
     years.published_year > {year_range[0]} and
-    years.published_year < {year_range[1]} {scope}
+    years.published_year < {year_range[1]} 
+    {scope}
 """
 
 
@@ -79,7 +80,8 @@ FROM `{bq_table}` as table,
 WHERE
     years.published_year > {year_range[0]} and
     years.published_year < {year_range[1]} and
-    type.total > 5 {scope}
+    type.total > 3 
+    {scope}
 """
 
     def clean_data(self):
@@ -114,7 +116,8 @@ FROM `{bq_table}` as table,
 WHERE
     years.published_year > {year_range[0]} and
     years.published_year < {year_range[1]} and
-    collabs.count > 5 {scope}
+    collabs.count > 5 
+    {scope}
 """
 
 
@@ -143,7 +146,8 @@ FROM `{bq_table}` as table,
 WHERE
     years.published_year > {year_range[0]} and
     years.published_year < {year_range[1]} and
-    publishers.count > 50 {scope}
+    publishers.count > 4 
+    {scope}
 """
 
     def clean_data(self):
@@ -181,7 +185,8 @@ FROM `{bq_table}` as table,
 WHERE
     years.published_year > {year_range[0]} and
     years.published_year < {year_range[1]} and
-    journals.count > 5 {scope}
+    journals.count > 1 
+    {scope}
 """
 
     def clean_data(self):
@@ -209,6 +214,7 @@ SELECT
   years.published_year as published_year,
   years.metrics.total as total,
   funders.name as funder,
+  funders.funding_body_type as funder_type,
   funders.count as count,
   funders.oa as oa,
   funders.gold as gold,
@@ -219,7 +225,8 @@ FROM `{bq_table}` as table,
 WHERE
     years.published_year > {year_range[0]} and
     years.published_year < {year_range[1]} and
-    funders.count > 20 {scope}
+    funders.count > 2 
+    {scope}
 """
 
     def clean_data(self):
@@ -228,7 +235,8 @@ WHERE
 
         chart_utils.calculate_percentages(self.df,
                                           ['oa', 'green', 'gold'],
-                                          'count')
+                                            'count')
+        self.df['Funder Type'] = self.df.funder_type.map(chart_utils.funder_type_clean['funder_type'])
         super().clean_data()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,8 @@ tldextract==2.2.*
 urllib3==1.25.*
 matplotlib==3.1.*
 pandas==0.25.*
-seaborn>=0.10.*
+seaborn==0.11.*
 geopandas==0.8.*
-precipy>=0.2.3
 numpy==1.19.*
 ipython==7.16.*
 pydata-google-auth==1.1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,9 @@ tldextract==2.2.*
 urllib3==1.25.*
 matplotlib==3.1.*
 pandas==0.25.*
-seaborn==0.10.*
+seaborn>=0.10.*
 geopandas==0.8.*
+precipy>=0.2.3
 numpy==1.19.*
 ipython==7.16.*
 pydata-google-auth==1.1.*

--- a/tests/fixtures/reports/test_citations_data.csv
+++ b/tests/fixtures/reports/test_citations_data.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8a8f360daed5ed194cbf9d0c6c75d379dfd31a08cfa4a1b494b5e34ab69e761
+size 285368

--- a/tests/fixtures/reports/test_data.csv
+++ b/tests/fixtures/reports/test_data.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94becd169e6c800ef0dfa7f013fc28d64cfb7c71230e0f06fc112f06b3cad6e7
-size 154358

--- a/tests/fixtures/reports/test_funding_data.csv
+++ b/tests/fixtures/reports/test_funding_data.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b472f27752857653c86d9329c3acba215d8fd474e4b1c59987f35ed182a11b5f
-size 287593
+oid sha256:9349da2bb851a53518aeff4c2fafc487e54ad126c8a7cc41260d25a2c2dc88b6
+size 4417891

--- a/tests/fixtures/reports/test_funding_data.csv
+++ b/tests/fixtures/reports/test_funding_data.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68851bdd16a356f8fba828a4d4492f625186f612b2fa1513cf7b9e3c24f29be4
-size 1420088
+oid sha256:b472f27752857653c86d9329c3acba215d8fd474e4b1c59987f35ed182a11b5f
+size 287593

--- a/tests/fixtures/reports/test_oa_data.csv
+++ b/tests/fixtures/reports/test_oa_data.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a77dbfe9bf7526d26955e602301ca2e920a7f09a6e22599dc14b7c406c2f9ac
-size 43850
+oid sha256:bd97adfef238498a0c389ec52af941ed8cb6b2b4f566fc4d7b1d93f74332baec
+size 406729

--- a/tests/fixtures/reports/test_oa_data.csv
+++ b/tests/fixtures/reports/test_oa_data.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd97adfef238498a0c389ec52af941ed8cb6b2b4f566fc4d7b1d93f74332baec
-size 406729
+oid sha256:d8dfe1f036f96f9f025d9345c04641120d2dac71e1793646fb55adcaa9b881ec
+size 478758

--- a/tests/fixtures/reports/test_outputs_data.csv
+++ b/tests/fixtures/reports/test_outputs_data.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a4bde4c5e95cebc4201809bbd6ab687a046df2a02d5c2f82fc72c72254e1c734
-size 284272
+oid sha256:dfe5b6132ee8875df5f830abede636d0208c230a22ed3fce5ffca63cd35ba260
+size 1044073

--- a/tests/fixtures/reports/test_outputs_data.csv
+++ b/tests/fixtures/reports/test_outputs_data.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4b939244ccb01da6ebe6c0f9fac7fa564b0b8b23461a268f9cc4736eff36e95
-size 66855
+oid sha256:a4bde4c5e95cebc4201809bbd6ab687a046df2a02d5c2f82fc72c72254e1c734
+size 284272

--- a/tests/observatory_platform/reports/test_charts.py
+++ b/tests/observatory_platform/reports/test_charts.py
@@ -48,7 +48,7 @@ class TestAbstractChart(unittest.TestCase):
         test_data_file = os.path.join(fixtures_data_dir(__file__),
                                       'reports', self.test_data)
         self.df = pd.read_csv(test_data_file)
-        self.available_ids = self.df.id.unique()
+        self.available_ids = list(self.df.id.unique())
 
     def test_init(self):
         if self.test_class:
@@ -96,7 +96,7 @@ class TestTimePlot(TestAbstractChart):
         super().setUp()
         self.test_class = TimePlot
         self.init_args = {
-            'year_range': (2010, 2018),
+            'year_range': (2016, 2020),
             'unis': self.available_ids[0:4],
             'plot_column': 'percent_oa'
         }
@@ -110,13 +110,13 @@ class TestTimePlotLayout(TestAbstractChart):
         self.test_class = TimePlotLayout
         self.init_args = {
             'plots': [
-                {'year_range': (2010, 2018),
+                {'year_range': (2016, 2020),
                  'unis': self.available_ids[0:4],
                  'y_column': 'percent_oa'},
-                {'year_range': (2010, 2018),
+                {'year_range': (2016, 2020),
                  'unis': self.available_ids[0:3],
                  'y_column': 'percent_gold'},
-                {'year_range': (2010, 2018),
+                {'year_range': (2016, 2020),
                  'unis': self.available_ids[0:4],
                  'y_column': 'percent_green'}
             ]
@@ -130,7 +130,7 @@ class TestTimePath(TestAbstractChartWithAnimation):
         super().setUp()
         self.test_class = TimePath
         self.init_args = {
-            'year_range': (2010, 2018),
+            'year_range': (2016, 2020),
             'unis': self.available_ids[0:4],
             'x': 'percent_gold',
             'y': 'percent_green'
@@ -181,13 +181,13 @@ class TestBoxScatter(TestAbstractChart):
 
 class TestOutputTypesPieChart(TestAbstractChart):
     def setUp(self):
+        self.test_data = 'test_outputs_data.csv'
         super().setUp()
         self.test_class = OutputTypesPieChart
         self.init_args = {
             'identifier': self.available_ids[0],
             'focus_year': 2018
         }
-        self.test_data = 'test_outputs_data.csv'
         self.plot_args = {}
 
 
@@ -226,6 +226,7 @@ class TestOApcTimeChart(TestAbstractChart):
 
 class TestCitationCountTimeChart(TestAbstractChart):
     def setUp(self):
+        self.test_data = 'test_citations_data.csv'
         super().setUp()
         self.test_class = CitationCountTimeChart
         self.init_args = {
@@ -237,6 +238,7 @@ class TestCitationCountTimeChart(TestAbstractChart):
 
 class TestOAAdvantageBarChart(TestAbstractChart):
     def setUp(self):
+        self.test_data = 'test_citations_data.csv'
         super().setUp()
         self.test_class = OAAdvantageBarChart
         self.init_args = {
@@ -260,13 +262,14 @@ class TestBarComparisonChart(TestAbstractChart):
 
 class TestFunderGraph(TestAbstractChart):
     def setUp(self):
+        self.test_data = 'test_funding_data.csv'
         super().setUp()
         self.test_class = FunderGraph
         self.init_args = {
             'focus_year': 2018,
             'identifier': self.available_ids[0]
         }
-        self.test_data = 'test_funding_data.csv'
+
         self.plot_args = {}
 
 
@@ -277,7 +280,7 @@ class TestDistributionComparisonChart(TestAbstractChart):
         self.init_args = {
             'focus_year': 2018,
             'identifier': self.available_ids[0],
-            'plot_column': 'percent_total_oa',
+            'plot_column': 'percent_oa',
             'comparison': self.available_ids[0:4]
         }
         self.plot_args = {}

--- a/tests/observatory_platform/reports/test_charts.py
+++ b/tests/observatory_platform/reports/test_charts.py
@@ -48,6 +48,7 @@ class TestAbstractChart(unittest.TestCase):
         test_data_file = os.path.join(fixtures_data_dir(__file__),
                                       'reports', self.test_data)
         self.df = pd.read_csv(test_data_file)
+        self.available_ids = self.df.id.unique()
 
     def test_init(self):
         if self.test_class:
@@ -78,6 +79,7 @@ class TestAbstractChartWithAnimation(TestAbstractChart):
 class TestScatterPlot(TestAbstractChartWithAnimation):
 
     def setUp(self):
+        super().setUp()
         self.test_class = ScatterPlot
         self.init_args = {
             'x': 'percent_green',
@@ -86,69 +88,54 @@ class TestScatterPlot(TestAbstractChartWithAnimation):
             'filter_value': 2017
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestTimePlot(TestAbstractChart):
 
     def setUp(self):
+        super().setUp()
         self.test_class = TimePlot
         self.init_args = {
             'year_range': (2010, 2018),
-            'unis': ['grid.1032.0',
-                     'grid.20861.3d',
-                     'grid.4991.5',
-                     'grid.6571.5'],
-            'plot_column': 'percent_total_oa'
+            'unis': self.available_ids[0:4],
+            'plot_column': 'percent_oa'
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestTimePlotLayout(TestAbstractChart):
 
     def setUp(self):
+        super().setUp()
         self.test_class = TimePlotLayout
         self.init_args = {
             'plots': [
                 {'year_range': (2010, 2018),
-                 'unis': ['grid.1032.0',
-                          'grid.20861.3d',
-                          'grid.4991.5',
-                          'grid.6571.5'],
-                 'y_column': 'percent_total_oa'},
+                 'unis': self.available_ids[0:4],
+                 'y_column': 'percent_oa'},
                 {'year_range': (2010, 2018),
-                 'unis': ['grid.1032.0',
-                          'grid.20861.3d',
-                          'grid.6571.5'],
+                 'unis': self.available_ids[0:3],
                  'y_column': 'percent_gold'},
                 {'year_range': (2010, 2018),
-                 'unis': ['grid.1032.0',
-                          'grid.20861.3d',
-                          'grid.4991.5',
-                          'grid.6571.5'],
+                 'unis': self.available_ids[0:4],
                  'y_column': 'percent_green'}
             ]
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestTimePath(TestAbstractChartWithAnimation):
 
     def setUp(self):
+        super().setUp()
         self.test_class = TimePath
         self.init_args = {
             'year_range': (2010, 2018),
-            'unis': ['grid.1032.0',
-                     'grid.20861.3d',
-                     'grid.4991.5',
-                     'grid.6571.5'],
+            'unis': self.available_ids[0:4],
             'x': 'percent_gold',
             'y': 'percent_green'
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestLayout(TestAbstractChart):
@@ -157,6 +144,7 @@ class TestLayout(TestAbstractChart):
 
 class TestRankChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = RankChart
         self.init_args = {
             'rankcol': 'percent_gold',
@@ -164,136 +152,133 @@ class TestRankChart(TestAbstractChart):
             'filter_value': 2017
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestConfidenceInternalRankChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = ConfidenceIntervalRank
         self.init_args = {
-            'rankcol': 'percent_total_oa',
-            'errorcol': 'percent_total_oa_err',
+            'rankcol': 'percent_oa',
+            'errorcol': 'percent_oa_err',
             'filter_name': 'published_year',
             'filter_value': 2017
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestBoxScatter(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = BoxScatter
         self.init_args = {
             'year': 2017,
             'group_column': 'country',
-            'plot_column': 'percent_total_oa'
+            'plot_column': 'percent_oa'
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestOutputTypesPieChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = OutputTypesPieChart
         self.init_args = {
-            'identifier': 'grid.1032.0',
+            'identifier': self.available_ids[0],
             'focus_year': 2018
         }
         self.test_data = 'test_outputs_data.csv'
         self.plot_args = {}
-        super().setUp()
 
 
 class TestGenericTimeChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = GenericTimeChart
         self.init_args = {
-            'columns': ['percent_total_oa', 'percent_green', 'percent_gold'],
-            'identifier': 'grid.1032.0'
+            'columns': ['percent_oa', 'percent_green', 'percent_gold'],
+            'identifier': self.available_ids[0]
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestOutputTypesTimeChart(TestAbstractChart):
     def setUp(self):
+        self.test_data = 'test_outputs_data.csv'
+        super().setUp()
         self.test_class = OutputTypesTimeChart
         self.init_args = {
-            'identifier': 'grid.1032.0'
+            'identifier': self.available_ids[0]
         }
-        self.test_data = 'test_outputs_data.csv'
         self.plot_args = {}
-        super().setUp()
 
 
 class TestOApcTimeChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = OApcTimeChart
         self.init_args = {
-            'identifier': 'grid.1032.0'
+            'identifier': self.available_ids[0]
         }
         self.plot_args = {}
-        super().setUp()
+
 
 
 class TestCitationCountTimeChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = CitationCountTimeChart
         self.init_args = {
-            'identifier': 'grid.1032.0'
+            'identifier': self.available_ids[0]
         }
         self.plot_args = {}
-        super().setUp()
+
 
 
 class TestOAAdvantageBarChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = OAAdvantageBarChart
         self.init_args = {
             'focus_year': 2017,
-            'identifier': 'grid.1032.0'
+            'identifier': self.available_ids[0]
         }
         self.plot_args = {}
-        super().setUp()
 
 
 class TestBarComparisonChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = BarComparisonChart
         self.init_args = {
-            'comparison': ['grid.1032.0',
-                           'grid.20861.3d',
-                           'grid.4991.5',
-                           'grid.6571.5'],
+            'comparison': self.available_ids[0:5],
             'focus_year': 2017,
         }
         self.plot_args = {}
-        super().setUp()
+
 
 
 class TestFunderGraph(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = FunderGraph
         self.init_args = {
             'focus_year': 2018,
-            'identifier': 'grid.1032.0'
+            'identifier': self.available_ids[0]
         }
         self.test_data = 'test_funding_data.csv'
         self.plot_args = {}
-        super().setUp()
 
 
 class TestDistributionComparisonChart(TestAbstractChart):
     def setUp(self):
+        super().setUp()
         self.test_class = DistributionComparisonChart
         self.init_args = {
             'focus_year': 2018,
-            'identifier': 'grid.1032.0',
+            'identifier': self.available_ids[0],
             'plot_column': 'percent_total_oa',
-            'comparison': ['grid.1032.0',
-                           'grid.20861.3d',
-                           'grid.4991.5',
-                           'grid.6571.5']
+            'comparison': self.available_ids[0:4]
         }
         self.plot_args = {}
-        super().setUp()
+

--- a/tests/observatory_platform/utils/test_charts_utils.py
+++ b/tests/observatory_platform/utils/test_charts_utils.py
@@ -1,0 +1,55 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Cameron Neylon
+
+from pathlib import Path
+import pydata_google_auth
+
+from observatory_platform.reports.tables import (
+    InstitutionOpenAccessTable,
+    InstitutionFundersTable,
+    InstitutionOutputsTable
+)
+from observatory_platform.utils.test_utils import fixtures_data_dir
+
+def update_chart_test_data():
+    """ Use the current tables definition to get up to date test data if necessary"""
+
+    scopes = [
+        'https://www.googleapis.com/auth/cloud-platform',
+        'https://www.googleapis.com/auth/drive',
+    ]
+
+    credentials = pydata_google_auth.get_user_credentials(
+        scopes,
+    )
+
+    scope = """
+LIMIT 1000
+"""
+    # Set the arguments up for table production
+    args = [credentials, 'coki-scratch-space', scope, 2018, (2016, 2020)]
+    openaccess = InstitutionOpenAccessTable(*args)
+    funders = InstitutionFundersTable(*args)
+    output_types = InstitutionOutputsTable(*args)
+
+    fixtures_path = Path(fixtures_data_dir(__file__))
+    openaccess.df.to_csv(fixtures_path / 'reports' / 'test_oa_data.csv')
+    funders.df.to_csv(fixtures_path / 'reports'/ 'test_funding_data.csv')
+    output_types.df.to_csv(fixtures_path / 'reports' / 'test_outputs_data.csv')
+
+
+if __name__ == '__main__':
+    update_chart_test_data()

--- a/tests/observatory_platform/utils/test_charts_utils.py
+++ b/tests/observatory_platform/utils/test_charts_utils.py
@@ -20,8 +20,10 @@ import pydata_google_auth
 from observatory_platform.reports.tables import (
     InstitutionOpenAccessTable,
     InstitutionFundersTable,
-    InstitutionOutputsTable
+    InstitutionOutputsTable,
+    InstitutionCitationsTable
 )
+from observatory_platform.reports.chart_utils import calculate_confidence_interval
 from observatory_platform.utils.test_utils import fixtures_data_dir
 
 def update_chart_test_data():
@@ -36,19 +38,22 @@ def update_chart_test_data():
         scopes,
     )
 
-    scope = """
-LIMIT 1000
+    scope = """AND
+  id in (SELECT id from `open-knowledge-publications.institutional_oa_evaluation_2020.named_grids_in_scope`)
 """
     # Set the arguments up for table production
     args = [credentials, 'coki-scratch-space', scope, 2018, (2016, 2020)]
     openaccess = InstitutionOpenAccessTable(*args)
+    calculate_confidence_interval(openaccess.df, ['percent_oa'])
     funders = InstitutionFundersTable(*args)
     output_types = InstitutionOutputsTable(*args)
+    citations = InstitutionCitationsTable(*args)
 
     fixtures_path = Path(fixtures_data_dir(__file__))
     openaccess.df.to_csv(fixtures_path / 'reports' / 'test_oa_data.csv')
     funders.df.to_csv(fixtures_path / 'reports'/ 'test_funding_data.csv')
     output_types.df.to_csv(fixtures_path / 'reports' / 'test_outputs_data.csv')
+    citations.df.to_csv(fixtures_path / 'reports' / 'test_citations_data.csv')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A range of issues arose in the default naming of columns with
shifts to the new schema. These changes should not generally
be breaking and should actually fix problems that might not
have been previously obvious with the Output Types graph and
the funder graph.

I've also added a new test utility that will pull fresh test data so that this can be easily updated for
future schema changes. It also hard codes some of the publicness aspects that we adopted for the
eLife paper, i.e. only publicly naming universities that appear in the top 100.

This in turn led to a series of small changes to the tests. The tests remain less fully fleshed out than
they should be but they do all pass now.

Finally, I had to add precipy to requirements.txt to get tests to pass and took the opportunity to change
the seaborn version requirement to >=0.10.* New code in the groups report (not connected to this pull
request) will require >=0.11.0 but those are breaking changes which don't immediate effect anything here.