### PR TITLE
Github Actions workflow that publishes releases to PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -54,9 +54,9 @@ jobs:
           packages_dir: observatory-dags/dist/
 
       - name: Publish observatory-reports
-          if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-          uses: pypa/gh-action-pypi-publish@master
-          with:
-            user: __token__
-            password: ${{ secrets.pypi_password }}
-            packages_dir: observatory-reports/dist/
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          packages_dir: observatory-reports/dist/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,12 +27,15 @@ jobs:
       - name: Build packages
         run: |
           cd observatory-platform
+          cp ../README.md .
           python3 setup.py sdist
 
           cd ../observatory-dags
+          cp ../README.md .
           python3 setup.py sdist
 
           cd ../observatory-reports
+          cp ../README.md .
           python3 setup.py sdist
 
           cd ../

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -21,18 +21,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e observatory-platform
-          pip install -e observatory-dags
-          pip install -e observatory-reports
 
       - name: Build packages
         run: |
           cd observatory-platform
-          python3 setup.py sdist
-
-          cd ../observatory-dags
-          python3 setup.py sdist
-
-          cd ../observatory-reports
           python3 setup.py sdist
 
           cd ../
@@ -44,19 +36,3 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           packages_dir: observatory-platform/dist/
-
-      - name: Publish observatory-dags
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          packages_dir: observatory-dags/dist/
-
-      - name: Publish observatory-reports
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          packages_dir: observatory-reports/dist/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,4 +1,4 @@
-name: Python Package
+name: Publish to PyPI
 
 on:
   push:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -21,10 +21,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e observatory-platform
+          pip install -e observatory-dags
+          pip install -e observatory-reports
 
       - name: Build packages
         run: |
           cd observatory-platform
+          python3 setup.py sdist
+
+          cd ../observatory-dags
+          python3 setup.py sdist
+
+          cd ../observatory-reports
           python3 setup.py sdist
 
           cd ../
@@ -36,3 +44,19 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           packages_dir: observatory-platform/dist/
+
+      - name: Publish observatory-dags
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          packages_dir: observatory-dags/dist/
+
+      - name: Publish observatory-reports
+          if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+          uses: pypa/gh-action-pypi-publish@master
+          with:
+            user: __token__
+            password: ${{ secrets.pypi_password }}
+            packages_dir: observatory-reports/dist/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,11 +54,9 @@ jobs:
           packages_dir: observatory-dags/dist/
 
       - name: Publish observatory-reports
-          if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-          uses: pypa/gh-action-pypi-publish@master
-          with:
-            user: __token__
-            password: ${{ secrets.pypi_password }}
-            packages_dir: observatory-reports/dist/
-
-
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          packages_dir: observatory-reports/dist/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,12 +46,12 @@ jobs:
           packages_dir: observatory-platform/dist/
 
       - name: Publish observatory-dags
-          if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-          uses: pypa/gh-action-pypi-publish@master
-          with:
-            user: __token__
-            password: ${{ secrets.pypi_password }}
-            packages_dir: observatory-dags/dist/
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          packages_dir: observatory-dags/dist/
 
       - name: Publish observatory-reports
           if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-name: Python Package & PyPI Deploy
+name: Python Package
 
 on:
   push:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,64 @@
+name: Python Package & PyPI Deploy
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e observatory-platform
+          pip install -e observatory-dags
+          pip install -e observatory-reports
+
+      - name: Build packages
+        run: |
+          cd observatory-platform
+          python3 setup.py sdist
+
+          cd ../observatory-dags
+          python3 setup.py sdist
+
+          cd ../observatory-reports
+          python3 setup.py sdist
+
+          cd ../
+
+      - name: Publish observatory-platform
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          packages_dir: observatory-platform/dist/
+
+      - name: Publish observatory-dags
+          if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+          uses: pypa/gh-action-pypi-publish@master
+          with:
+            user: __token__
+            password: ${{ secrets.pypi_password }}
+            packages_dir: observatory-dags/dist/
+
+      - name: Publish observatory-reports
+          if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+          uses: pypa/gh-action-pypi-publish@master
+          with:
+            user: __token__
+            password: ${{ secrets.pypi_password }}
+            packages_dir: observatory-reports/dist/
+
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Unit Tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Observatory Platform](./logo.jpg?raw=true)
+![Observatory Platform](https://raw.githubusercontent.com/The-Academic-Observatory/observatory-platform/develop/logo.jpg)
 
 The Observatory Platform is an environment for fetching, processing and analysing data to understand how well 
 universities operate as Open Knowledge Institutions. 

--- a/observatory-dags/README.md
+++ b/observatory-dags/README.md
@@ -1,0 +1,1 @@
+## Observatory DAGs

--- a/observatory-dags/requirements.txt
+++ b/observatory-dags/requirements.txt
@@ -1,5 +1,5 @@
 observatory-platform
-mag-archiver==2020.12.*
+mag-archiver==2020.12.1.dev1
 xmltodict==0.12.*
 backoff==1.10.*
 ratelimit==2.2.*

--- a/observatory-dags/requirements.txt
+++ b/observatory-dags/requirements.txt
@@ -1,5 +1,5 @@
 observatory-platform
-mag-archiver @ git+git://github.com/The-Academic-Observatory/mag-archiver@develop#egg=mag-archiver
+mag-archiver==2020.12.*
 xmltodict==0.12.*
 backoff==1.10.*
 ratelimit==2.2.*

--- a/observatory-dags/setup.cfg
+++ b/observatory-dags/setup.cfg
@@ -3,7 +3,7 @@ name = observatory-dags
 author = Curtin University
 author-email = agent@observatory.academy
 summary = Observatory DAGs provides Apache Airflow DAGs for fetching, processing and analysing data for the Observatory Platform.
-description-file = ../README.md
+description-file = README.md
 description-content-type = text/markdown; charset=UTF-8
 home-page = https://github.com/The-Academic-Observatory/observatory-platform
 project_urls =

--- a/observatory-dags/setup.cfg
+++ b/observatory-dags/setup.cfg
@@ -1,22 +1,21 @@
 [metadata]
-name = observatory-dags
+name = observatory-reports
 author = Curtin University
 author-email = agent@observatory.academy
-summary = DAGs for the Observatory Platform
-description = DAGs for the Observatory Platform
+summary = Observatory DAGs provides Apache Airflow DAGs for fetching, processing and analysing data for the Observatory Platform.
 description-file = ../README.md
 description-content-type = text/markdown; charset=UTF-8
 home-page = https://github.com/The-Academic-Observatory/observatory-platform
 project_urls =
     Bug Tracker = https://github.com/The-Academic-Observatory/observatory-platform/issues
-    Documentation = https://coki-academic-observatory.readthedocs-hosted.com/en/latest
+    Documentation = https://observatory-platform.readthedocs.io/en/latest/
     Source Code = https://github.com/The-Academic-Observatory/observatory-platform
-    Download = https://github.com/The-Academic-Observatory/observatory-platform/v20.7.0.tar.gz
-license = Apache-2
+python-requires = >=3.7
+license = Apache License Version 2.0
 classifier =
     Development Status :: 2 - Pre-Alpha
     Environment :: Console
-    Environment :: Web Browser
+    Environment :: Web Environment
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     License :: OSI Approved :: Apache Software License
@@ -28,17 +27,16 @@ classifier =
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities
-
 keywords =
     science
     data
     workflows
     academic institutes
-    observatory-dags
+    observatory-platform
 
 [files]
-namespace_packages = observatory
 packages = observatory
+namespace_packages = observatory
 
 [extras]
 tests =

--- a/observatory-dags/setup.cfg
+++ b/observatory-dags/setup.cfg
@@ -38,6 +38,8 @@ keywords =
 packages =
     observatory
     observatory.dags
+data_files =
+    observatory/dags/database = observatory/dags/database/*
 
 [extras]
 tests =

--- a/observatory-dags/setup.cfg
+++ b/observatory-dags/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = observatory-reports
+name = observatory-dags
 author = Curtin University
 author-email = agent@observatory.academy
 summary = Observatory DAGs provides Apache Airflow DAGs for fetching, processing and analysing data for the Observatory Platform.

--- a/observatory-dags/setup.cfg
+++ b/observatory-dags/setup.cfg
@@ -35,8 +35,9 @@ keywords =
     observatory-platform
 
 [files]
-packages = observatory
-namespace_packages = observatory
+packages =
+    observatory
+    observatory.dags
 
 [extras]
 tests =

--- a/observatory-platform/README.md
+++ b/observatory-platform/README.md
@@ -1,0 +1,1 @@
+## Observatory Platform

--- a/observatory-platform/setup.cfg
+++ b/observatory-platform/setup.cfg
@@ -15,7 +15,7 @@ license = Apache License Version 2.0
 classifier =
     Development Status :: 2 - Pre-Alpha
     Environment :: Console
-    Environment :: Web Browser
+    Environment :: Web Environment
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     License :: OSI Approved :: Apache Software License

--- a/observatory-platform/setup.cfg
+++ b/observatory-platform/setup.cfg
@@ -41,7 +41,9 @@ packages =
 data_files =
     observatory/platform/docker = observatory/platform/docker/*
     observatory/platform/terraform = observatory/platform/terraform/*
-    observatory/platform = observatory/platform/*.jinja2
+    observatory/platform =
+        observatory/platform/config.yaml.jinja2
+        observatory/platform/config-terraform.yaml.jinja2
 
 [entry_points]
 console_scripts =

--- a/observatory-platform/setup.cfg
+++ b/observatory-platform/setup.cfg
@@ -35,8 +35,9 @@ keywords =
     observatory-platform
 
 [files]
-packages = observatory
-namespace_packages = observatory
+packages =
+    observatory
+    observatory.platform
 
 [entry_points]
 console_scripts =

--- a/observatory-platform/setup.cfg
+++ b/observatory-platform/setup.cfg
@@ -3,20 +3,15 @@ name = observatory-platform
 author = Curtin University
 author-email = agent@observatory.academy
 summary = The Observatory Platform is an environment for fetching, processing and analysing data to understand how well universities operate as Open Knowledge Institutions.
-    The Observatory Platform is built with Apache Airflow and includes DAGs (workflows) for processing various data sources. Consult the project documentation for more information.
-    See the Github Project here: https://github.com/The-Academic-Observatory/observatory-platform
-    See the documentation here: https://coki-academic-observatory.readthedocs-hosted.com/en/latest.
-    The Observatory Platform is compatible with Python 3.7.
-description = Telescopes, Workflows and Data Services for the Observatory Platform
 description-file = ../README.md
 description-content-type = text/markdown; charset=UTF-8
 home-page = https://github.com/The-Academic-Observatory/observatory-platform
 project_urls =
     Bug Tracker = https://github.com/The-Academic-Observatory/observatory-platform/issues
-    Documentation = https://coki-academic-observatory.readthedocs-hosted.com/en/latest
+    Documentation = https://observatory-platform.readthedocs.io/en/latest/
     Source Code = https://github.com/The-Academic-Observatory/observatory-platform
-    Download = https://github.com/The-Academic-Observatory/observatory-platform/v20.7.0.tar.gz
-license = Apache-2
+python-requires = >=3.7
+license = Apache License Version 2.0
 classifier =
     Development Status :: 2 - Pre-Alpha
     Environment :: Console
@@ -32,7 +27,6 @@ classifier =
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities
-
 keywords =
     science
     data
@@ -41,8 +35,8 @@ keywords =
     observatory-platform
 
 [files]
-namespace_packages = observatory
 packages = observatory
+namespace_packages = observatory
 
 [entry_points]
 console_scripts =

--- a/observatory-platform/setup.cfg
+++ b/observatory-platform/setup.cfg
@@ -3,7 +3,7 @@ name = observatory-platform
 author = Curtin University
 author-email = agent@observatory.academy
 summary = The Observatory Platform is an environment for fetching, processing and analysing data to understand how well universities operate as Open Knowledge Institutions.
-description-file = ../README.md
+description-file = README.md
 description-content-type = text/markdown; charset=UTF-8
 home-page = https://github.com/The-Academic-Observatory/observatory-platform
 project_urls =

--- a/observatory-platform/setup.cfg
+++ b/observatory-platform/setup.cfg
@@ -38,6 +38,10 @@ keywords =
 packages =
     observatory
     observatory.platform
+data_files =
+    observatory/platform/docker = observatory/platform/docker/*
+    observatory/platform/terraform = observatory/platform/terraform/*
+    observatory/platform = observatory/platform/*.jinja2
 
 [entry_points]
 console_scripts =

--- a/observatory-reports/README.md
+++ b/observatory-reports/README.md
@@ -1,0 +1,1 @@
+## Observatory Reports

--- a/observatory-reports/setup.cfg
+++ b/observatory-reports/setup.cfg
@@ -3,7 +3,7 @@ name = observatory-reports
 author = Curtin University
 author-email = agent@observatory.academy
 summary = Observatory Reports provides report building functionality for the Observatory Platform.
-description-file = ../README.md
+description-file = README.md
 description-content-type = text/markdown; charset=UTF-8
 home-page = https://github.com/The-Academic-Observatory/observatory-platform
 project_urls =

--- a/observatory-reports/setup.cfg
+++ b/observatory-reports/setup.cfg
@@ -35,8 +35,9 @@ keywords =
     observatory-platform
 
 [files]
-packages = observatory
-namespace_packages = observatory
+packages =
+    observatory
+    observatory.reports
 
 [extras]
 tests =

--- a/observatory-reports/setup.cfg
+++ b/observatory-reports/setup.cfg
@@ -2,21 +2,20 @@
 name = observatory-reports
 author = Curtin University
 author-email = agent@observatory.academy
-summary = Reports for the Observatory Platform
-description = Reports for the Observatory Platform
+summary = Observatory Reports provides report building functionality for the Observatory Platform.
 description-file = ../README.md
 description-content-type = text/markdown; charset=UTF-8
 home-page = https://github.com/The-Academic-Observatory/observatory-platform
 project_urls =
     Bug Tracker = https://github.com/The-Academic-Observatory/observatory-platform/issues
-    Documentation = https://coki-academic-observatory.readthedocs-hosted.com/en/latest
+    Documentation = https://observatory-platform.readthedocs.io/en/latest/
     Source Code = https://github.com/The-Academic-Observatory/observatory-platform
-    Download = https://github.com/The-Academic-Observatory/observatory-platform/v20.7.0.tar.gz
-license = Apache-2
+python-requires = >=3.7
+license = Apache License Version 2.0
 classifier =
     Development Status :: 2 - Pre-Alpha
     Environment :: Console
-    Environment :: Web Browser
+    Environment :: Web Environment
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     License :: OSI Approved :: Apache Software License
@@ -28,7 +27,6 @@ classifier =
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities
-
 keywords =
     science
     data
@@ -37,15 +35,14 @@ keywords =
     observatory-platform
 
 [files]
-namespace_packages = observatory
 packages = observatory
+namespace_packages = observatory
 
 [extras]
 tests =
     liccheck==0.4.*
     flake8==3.8.*
     coverage==5.2
-    redis==3.5.*
 
 [pbr]
 skip_authors = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+This file is required so that when python3 setup.py sdist is run, pbr will copy the requirements.txt files in
+observatory-dags, observatory-platform and observatory-reports into the respective builds.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-name = observatory

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[metadata]
+name = observatory
+; This file is required because Sphinx needs it to determine the project name.
+; The following error will be thrown otherwise: 'Could not find a setup.cfg to extract project name from'


### PR DESCRIPTION
This pull request adds a Github Actions workflow, `publish-pypi.yaml`, that builds a tagged release of the Observatory and publishes it to PyPI. The action only runs when a tag is created.

The packages built and published include:
* observatory-platform: https://pypi.org/project/observatory-platform/
* observatory-dags: https://pypi.org/project/observatory-dags/
* observatory-reports: https://pypi.org/project/observatory-reports/

I've done a little bit of refactoring of the Github Actions workflows, namely, renamed pythonpackage.yml to unit-tests.yml (and called the workflow Unit Tests) as this workflow runs the unit tests.

This pull request is focusing on getting the workflow setup, so if there are suggestions for updating the documentation on PyPI or how we standardise the version numbering (this is independent of the workflow - it is just based on the Github tag) then that can be done in another ticket.