### PR TITLE
Fix for double quotes being part of a field in MAG PaperExtendedAttributes table

### DIFF
--- a/observatory-dags/observatory/dags/telescopes/mag.py
+++ b/observatory-dags/observatory/dags/telescopes/mag.py
@@ -523,6 +523,10 @@ def db_load_mag_release(project_id: str, bucket_name: str, data_location: str, r
             'quote': '',
             'allow_quoted_newlines': True
         },
+        'PaperExtendedAttributes': {
+            'quote': '',
+            'allow_quoted_newlines': False
+        },
         'Papers': {
             'quote': '',
             'allow_quoted_newlines': True


### PR DESCRIPTION
Fix for double quotes being part of a field in MAG PaperExtendedAttributes table