### PR TITLE
Update crossref metadata schema

### DIFF
--- a/docs/datasets/provider_crossref/dataset_crossref_metadata.md
+++ b/docs/datasets/provider_crossref/dataset_crossref_metadata.md
@@ -5,354 +5,2094 @@ standardised into the Crossref metadata dataset. This dataset is made available 
 services and tools for manuscript tracking, searching, bibliographic management, 
 library systems, author profiling, specialist subject databases, scholarly sharing networks
 . _- source: [Crossref Metadata](https://www.crossref.org/services/metadata-retrieval/)_ 
-and [data details](https://github.com/CrossRef/rest-api-doc)
+and [schema details](https://github.com/Crossref/rest-api-doc/blob/master/api_format.md)
 
 ---
 
 **Schema**
 
-+ **issn_type** [*Record*]
-    + **type** [*String*]
-    + **value** [*String*]
-+ **ISSN** [*String*]
-+ **ISBN** [*String*]
-+ **URL** [*String*]
-+ **publisher_location** [*String*]
-+ **references_count** [*Integer*]
-+ **alternative_id** [*String*]
-+ **issued** [*Record*]
-    + **date_parts** [*Integer*]
-+ **posted** [*Record*]
-    + **date_parts** [*Integer*]
-+ **group_title** [*String*]
-+ **score** [*String*]
-+ **subject** [*String*]
-+ **abstract** [*String*]
-+ **deposited** [*Record*]
-    + **timestamp** [*Integer*]
-    + **date_time** [*Timestamp*]
-    + **date_parts** [*Integer*]
-+ **link** [*Record*]
-    + **intended_application** [*String*]
-    + **content_version** [*String*]
-    + **content_type** [*String*]
-    + **URL** [*String*]
-+ **published_print** [*Record*]
-    + **date_parts** [*Integer*]
-+ **accepted** [*Record*]
-    + **date_parts** [*Integer*]
-+ **indexed** [*Record*]
-    + **timestamp** [*Integer*]
-    + **date_time** [*Timestamp*]
-    + **date_parts** [*Integer*]
-+ **update_to** [*Record*]
-    + **updated** [*Record*]
-        + **timestamp** [*Integer*]
-        + **date_time** [*String*]
-        + **date_parts** [*Integer*]
-    + **DOI** [*String*]
-    + **type** [*String*]
-    + **label** [*String*]
-+ **approved** [*Record*]
-    + **date_parts** [*Integer*]
-+ **source** [*String*]
-+ **content_created** [*Record*]
-    + **date_parts** [*Integer*]
-+ **content_updated** [*Record*]
-    + **date_parts** [*Integer*]
-+ **DOI** [*String*]
-+ **content_domain** [*Record*]
-    + **crossmark_restriction** [*Boolean*]
-    + **domain** [*String*]
-+ **relation** [*Record*]
-    + **cites** [*String*]
-    + **has_preprint** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_part** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_review** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_supplemented_by** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_part_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_identical_to** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **references** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_manifestation** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_reply_to** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_based_on** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_review_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_reply** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_replaced_by** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_comment** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **documents** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_version_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_version** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_related_material** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_compiled_by** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_translation** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_translation_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_preprint_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_referenced_by** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_supplement_to** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_variant_form_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **replaces** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_manifestation_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_related_material** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_basis_for** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_comment_on** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **continues** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_continued_by** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_derivation** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_data_basis_for** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_documented_by** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_derived_from** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **has_manuscript** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_manuscript_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **based_on_data** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_original_form_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-    + **is_varient_form_of** [*Record*]
-        + **id_type** [*String*]
-        + **id** [*String*]
-        + **asserted_by** [*String*]
-+ **license** [*Record*]
-    + **content_version** [*String*]
-    + **delay_in_days** [*Integer*]
-    + **start** [*Record*]
-        + **timestamp** [*Integer*]
-        + **date_time** [*String*]
-        + **date_parts** [*Integer*]
-    + **URL** [*String*]
-+ **volume** [*String*]
-+ **funder** [*Record*]
-    + **DOI** [*String*]
-    + **name** [*String*]
-    + **doi_asserted_by** [*String*]
-    + **award** [*String*]
-+ **is_referenced_by_count** [*Integer*]
-+ **degree** [*String*]
-+ **subtitle** [*String*]
-+ **issue** [*String*]
-+ **reference_count** [*Integer*]
-+ **type** [*String*]
-+ **page** [*String*]
-+ **update_policy** [*String*]
-+ **title** [*String*]
-+ **publisher** [*String*]
-+ **created** [*Record*]
-    + **timestamp** [*Integer*]
-    + **date_time** [*Timestamp*]
-    + **date_parts** [*Integer*]
-+ **prefix** [*Float*]
-+ **author** [*Record*]
-    + **affiliation** [*Record*]
-        + **name** [*String*]
-    + **family** [*String*]
-    + **given** [*String*]
-    + **name** [*String*]
-    + **suffix** [*String*]
-    + **ORCID** [*String*]
-    + **authenticated_orcid** [*Boolean*]
-+ **editor** [*Record*]
-    + **affiliation** [*Record*]
-        + **name** [*String*]
-    + **family** [*String*]
-    + **given** [*String*]
-    + **name** [*String*]
-    + **suffix** [*String*]
-    + **ORCID** [*String*]
-    + **authenticated_orcid** [*Boolean*]
-+ **translator** [*Record*]
-    + **affiliation** [*Record*]
-        + **name** [*String*]
-    + **family** [*String*]
-    + **given** [*String*]
-    + **name** [*String*]
-    + **suffix** [*String*]
-    + **ORCID** [*String*]
-    + **authenticated_orcid** [*Boolean*]
-+ **chair** [*Record*]
-    + **affiliation** [*Record*]
-        + **name** [*String*]
-    + **family** [*String*]
-    + **given** [*String*]
-    + **name** [*String*]
-    + **suffix** [*String*]
-    + **ORCID** [*String*]
-    + **authenticated_orcid** [*Boolean*]
-+ **member** [*Integer*]
-+ **short_container_title** [*String*]
-+ **reference** [*Record*]
-    + **unstructured** [*String*]
-    + **key** [*String*]
-    + **journal_title** [*String*]
-    + **first_page** [*String*]
-    + **ISBN** [*String*]
-    + **doi_asserted_by** [*String*]
-    + **series_title** [*String*]
-    + **article_title** [*String*]
-    + **volume** [*String*]
-    + **author** [*String*]
-    + **year** [*String*]
-    + **DOI** [*String*]
-    + **ISSN** [*String*]
-    + **issn_type** [*String*]
-    + **isbn_type** [*String*]
-    + **volume_title** [*String*]
-    + **issue** [*String*]
-    + **edition** [*String*]
-    + **component** [*String*]
-    + **standards_body** [*String*]
-    + **standard_designator** [*String*]
-+ **event** [*Record*]
-    + **name** [*String*]
-    + **location** [*String*]
-    + **acronym** [*String*]
-    + **sponsor** [*String*]
-    + **number** [*String*]
-    + **theme** [*String*]
-    + **start** [*Record*]
-        + **date_parts** [*Integer*]
-    + **end** [*Record*]
-        + **date_parts** [*Integer*]
-+ **standards_body** [*Record*]
-    + **name** [*String*]
-    + **acronym** [*String*]
-+ **container_title** [*String*]
-+ **short_title** [*String*]
-+ **original_title** [*String*]
-+ **published_online** [*Record*]
-    + **date_parts** [*Integer*]
-+ **assertion** [*Record*]
-    + **value** [*String*]
-    + **name** [*String*]
-    + **url** [*String*]
-    + **group** [*Record*]
-        + **name** [*String*]
-        + **label** [*String*]
-    + **label** [*String*]
-    + **explanation** [*Record*]
-        + **URL** [*String*]
-    + **order** [*Integer*]
-+ **article_number** [*String*]
-+ **archive** [*String*]
-+ **clinical_trial_number** [*Record*]
-    + **clinical_trial_number** [*String*]
-    + **registry** [*String*]
-    + **type** [*String*]
+```json
+[
+  {
+    "description": "Name of work's publisher.",
+    "mode": "NULLABLE",
+    "name": "publisher",
+    "type": "STRING"
+  },
+  {
+    "description": "Work titles, including translated titles.",
+    "mode": "REPEATED",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "description": "Work titles in the work's original publication language.",
+    "mode": "REPEATED",
+    "name": "original_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Short or abbreviated work titles",
+    "mode": "REPEATED",
+    "name": "short_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Abstract as a JSON string or a JATS XML snippet encoded into a JSON string.",
+    "mode": "NULLABLE",
+    "name": "abstract",
+    "type": "STRING"
+  },
+  {
+    "description": "Deprecated. Same as references-count.",
+    "mode": "NULLABLE",
+    "name": "reference_count",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Count of outbound references deposited with Crossref",
+    "mode": "NULLABLE",
+    "name": "references_count",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Count of inbound references deposited with Crossref.",
+    "mode": "NULLABLE",
+    "name": "is_referenced_by_count",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Currently always Crossref.",
+    "mode": "NULLABLE",
+    "name": "source",
+    "type": "STRING"
+  },
+  {
+    "description": "DOI prefix identifier of the form http://id.crossref.org/prefix/DOI_PREFIX.",
+    "mode": "NULLABLE",
+    "name": "prefix",
+    "type": "FLOAT"
+  },
+  {
+    "description": "DOI of the work.",
+    "mode": "NULLABLE",
+    "name": "DOI",
+    "type": "STRING"
+  },
+  {
+    "description": "URL form of the work's DOI.",
+    "mode": "NULLABLE",
+    "name": "URL",
+    "type": "STRING"
+  },
+  {
+    "description": "Member identifier of the form http://id.crossref.org/member/MEMBER_ID",
+    "mode": "NULLABLE",
+    "name": "member",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Enumeration, one of the type ids from https://api.crossref.org/v1/types.",
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "description": "Date on which the DOI was first registered.",
+    "fields": [
+      {
+        "description": "Seconds since UNIX epoch.",
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER"
+      },
+      {
+        "description": "ISO 8601 date time.",
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "created",
+    "type": "RECORD"
+  },
+  {
+    "description": "Date on which the work metadata was most recently updated.",
+    "fields": [
+      {
+        "description": "Seconds since UNIX epoch.",
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER"
+      },
+      {
+        "description": "ISO 8601 date time.",
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "deposited",
+    "type": "RECORD"
+  },
+  {
+    "description": "Date on which the work metadata was most recently indexed. Re-indexing does not imply a metadata change, see deposited for the most recent metadata change date.",
+    "fields": [
+      {
+        "description": "Seconds since UNIX epoch.",
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER"
+      },
+      {
+        "description": "ISO 8601 date time.",
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "indexed",
+    "type": "RECORD"
+  },
+  {
+    "description": "Earliest of published-print and published-online",
+    "fields": [
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "issued",
+    "type": "RECORD"
+  },
+  {
+    "description": "Date on which posted content was made available online.",
+    "fields": [
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "posted",
+    "type": "RECORD"
+  },
+  {
+    "description": "Date on which a work was accepted, after being submitted, during a submission process.",
+    "fields": [
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "accepted",
+    "type": "RECORD"
+  },
+  {
+    "description": "Work subtitles, including original language and translated.",
+    "mode": "REPEATED",
+    "name": "subtitle",
+    "type": "STRING"
+  },
+  {
+    "description": "Full titles of the containing work (usually a book or journal)",
+    "mode": "REPEATED",
+    "name": "container_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Abbreviated titles of the containing work.",
+    "mode": "REPEATED",
+    "name": "short_container_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Group title for posted content.",
+    "mode": "NULLABLE",
+    "name": "group_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Issue number of an article's journal.",
+    "mode": "NULLABLE",
+    "name": "issue",
+    "type": "STRING"
+  },
+  {
+    "description": "Volume number of an article's journal.",
+    "mode": "NULLABLE",
+    "name": "volume",
+    "type": "STRING"
+  },
+  {
+    "description": "Pages numbers of an article within its journal.",
+    "mode": "NULLABLE",
+    "name": "page",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "article_number",
+    "type": "STRING"
+  },
+  {
+    "description": "Date on which the work was published in print.",
+    "fields": [
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_print",
+    "type": "RECORD"
+  },
+  {
+    "description": "Date on which the work was published online.",
+    "fields": [
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_online",
+    "type": "RECORD"
+  },
+  {
+    "description": "Subject category names, a controlled vocabulary from Sci-Val. Available for most journal articles",
+    "mode": "REPEATED",
+    "name": "subject",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "mode": "REPEATED",
+    "name": "ISSN",
+    "type": "STRING"
+  },
+  {
+    "description": "List of ISSNs with ISSN type information",
+    "fields": [
+      {
+        "description": "ISSN type, can either be print ISSN or electronic ISSN.",
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING"
+      },
+      {
+        "description": "ISSN value",
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "issn_type",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "mode": "REPEATED",
+    "name": "ISBN",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "mode": "REPEATED",
+    "name": "archive",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "Either vor (version of record,) am (accepted manuscript,) tdm (text and data mining) or unspecified.",
+        "mode": "NULLABLE",
+        "name": "content_version",
+        "type": "STRING"
+      },
+      {
+        "description": "Number of days between the publication date of the work and the start date of this license.",
+        "mode": "NULLABLE",
+        "name": "delay_in_days",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Date on which this license begins to take effect",
+        "fields": [
+          {
+            "description": "Seconds since UNIX epoch.",
+            "mode": "NULLABLE",
+            "name": "timestamp",
+            "type": "INTEGER"
+          },
+          {
+            "description": "ISO 8601 date time.",
+            "mode": "NULLABLE",
+            "name": "date_time",
+            "type": "STRING"
+          },
+          {
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "start",
+        "type": "RECORD"
+      },
+      {
+        "description": "Link to a web page describing this license",
+        "mode": "NULLABLE",
+        "name": "URL",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "license",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "Funding body primary name",
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "description": "Optional Open Funder Registry DOI uniquely identifing the funding body (http://www.crossref.org/fundingdata/registry.html)",
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING"
+      },
+      {
+        "description": "Award number(s) for awards given by the funding body.",
+        "mode": "REPEATED",
+        "name": "award",
+        "type": "STRING"
+      },
+      {
+        "description": "Either crossref or publisher",
+        "mode": "NULLABLE",
+        "name": "doi_asserted_by",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "funder",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "url",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "fields": [
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "URL",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "explanation",
+        "type": "RECORD"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "label",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "order",
+        "type": "INTEGER"
+      },
+      {
+        "description": "",
+        "fields": [
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          },
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "label",
+            "type": "STRING"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "group",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "assertion",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING"
+      },
+      {
+        "description": "URL-form of an ORCID identifier",
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING"
+      },
+      {
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication.",
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "",
+        "fields": [
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "author",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING"
+      },
+      {
+        "description": "URL-form of an ORCID identifier",
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING"
+      },
+      {
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication.",
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "",
+        "fields": [
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "editor",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING"
+      },
+      {
+        "description": "URL-form of an ORCID identifier",
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING"
+      },
+      {
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication.",
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "",
+        "fields": [
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "chair",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING"
+      },
+      {
+        "description": "URL-form of an ORCID identifier",
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING"
+      },
+      {
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication.",
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "",
+        "fields": [
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "translator",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "Date on which the update was published.",
+        "fields": [
+          {
+            "description": "Seconds since UNIX epoch.",
+            "mode": "NULLABLE",
+            "name": "timestamp",
+            "type": "INTEGER"
+          },
+          {
+            "description": "ISO 8601 date time.",
+            "mode": "NULLABLE",
+            "name": "date_time",
+            "type": "STRING"
+          },
+          {
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "updated",
+        "type": "RECORD"
+      },
+      {
+        "description": "DOI of the updated work.",
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING"
+      },
+      {
+        "description": "The type of update, for example retraction or correction.",
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING"
+      },
+      {
+        "description": "A display-friendly label for the update type.",
+        "mode": "NULLABLE",
+        "name": "label",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "update_to",
+    "type": "RECORD"
+  },
+  {
+    "description": "Link to an update policy covering Crossmark updates for this work.",
+    "mode": "NULLABLE",
+    "name": "update_policy",
+    "type": "STRING"
+  },
+  {
+    "description": "URLs to full-text locations.",
+    "fields": [
+      {
+        "description": "Either text-mining, similarity-checking or unspecified.",
+        "mode": "NULLABLE",
+        "name": "intended_application",
+        "type": "STRING"
+      },
+      {
+        "description": "Either vor (version of record,) am (accepted manuscript) or unspecified.",
+        "mode": "NULLABLE",
+        "name": "content_version",
+        "type": "STRING"
+      },
+      {
+        "description": "Content type (or MIME type) of the full-text object.",
+        "mode": "NULLABLE",
+        "name": "content_type",
+        "type": "STRING"
+      },
+      {
+        "description": "Direct link to a full-text download location.",
+        "mode": "NULLABLE",
+        "name": "URL",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "link",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "description": "Identifier of the clinical trial.",
+        "mode": "NULLABLE",
+        "name": "clinical_trial_number",
+        "type": "STRING"
+      },
+      {
+        "description": "DOI of the clinical trial regsitry that assigned the trial number.",
+        "mode": "NULLABLE",
+        "name": "registry",
+        "type": "STRING"
+      },
+      {
+        "description": "One of preResults, results or postResults",
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "clinical_trial_number",
+    "type": "RECORD"
+  },
+  {
+    "description": "Other identifiers for the work provided by the depositing member",
+    "mode": "REPEATED",
+    "name": "alternative_id",
+    "type": "STRING"
+  },
+  {
+    "description": "List of references made by the work",
+    "fields": [
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING"
+      },
+      {
+        "description": "One of crossref or publisher.",
+        "mode": "NULLABLE",
+        "name": "doi_asserted_by",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "issue",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "first_page",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "volume",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "edition",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "component",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "standard_designator",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "standards_body",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "author",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "year",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "unstructured",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "journal_title",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "article_title",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "series_title",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "volume_title",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "ISSN",
+        "type": "STRING"
+      },
+      {
+        "description": "One of pissn or eissn",
+        "mode": "NULLABLE",
+        "name": "issn_type",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "ISBN",
+        "type": "STRING"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "isbn_type",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "reference",
+    "type": "RECORD"
+  },
+  {
+    "description": "Information on domains that support Crossmark for this work.",
+    "fields": [
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "crossmark_restriction",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "",
+        "mode": "REPEATED",
+        "name": "domain",
+        "type": "STRING"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "content_domain",
+    "type": "RECORD"
+  },
+  {
+    "description": "Relations to other works.",
+    "fields": [
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_format",
+        "type": "RECORD"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "cites",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_preprint",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_part",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_review",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_supplemented_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_part_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_identical_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "references",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_manifestation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_reply_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_based_on",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_review_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_reply",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_replaced_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_comment",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "documents",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_version_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_version",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_related_material",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_compiled_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_translation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_translation_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_preprint_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_referenced_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_supplement_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_variant_form_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "replaces",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_manifestation_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_related_material",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_basis_for",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_comment_on",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "continues",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_continued_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_derivation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_data_basis_for",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_documented_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_derived_from",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_manuscript",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_manuscript_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "based_on_data",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_original_form_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_varient_form_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "requires",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "relation",
+    "type": "RECORD"
+  },
+  {
+    "description": "Location of work's publisher",
+    "mode": "NULLABLE",
+    "name": "publisher_location",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "score",
+    "type": "STRING"
+  },
+  {
+    "description": "description NA",
+    "fields": [
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "approved",
+    "type": "RECORD"
+  },
+  {
+    "description": "description NA",
+    "fields": [
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "content_created",
+    "type": "RECORD"
+  },
+  {
+    "description": "description NA",
+    "fields": [
+      {
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "content_updated",
+    "type": "RECORD"
+  },
+  {
+    "description": "description NA",
+    "mode": "REPEATED",
+    "name": "degree",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "location",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "acronym",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "sponsor",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "number",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "theme",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "start",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates",
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "end",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "event",
+    "type": "RECORD"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "acronym",
+        "type": "STRING"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "standards_body",
+    "type": "RECORD"
+  }
+]
 
+```

--- a/observatory-dags/observatory/dags/database/schema/crossref_metadata_2018-04-01.json
+++ b/observatory-dags/observatory/dags/database/schema/crossref_metadata_2018-04-01.json
@@ -1,297 +1,984 @@
 [
   {
+    "mode": "NULLABLE",
+    "name": "publisher",
+    "type": "STRING",
+    "description": "Name of work's publisher."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "title",
+    "type": "STRING",
+    "description": "Work titles, including translated titles."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "original_title",
+    "type": "STRING",
+    "description": "Work titles in the work's original publication language."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "short_title",
+    "type": "STRING",
+    "description": "Short or abbreviated work titles"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "abstract",
+    "type": "STRING",
+    "description": "Abstract as a JSON string or a JATS XML snippet encoded into a JSON string."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reference_count",
+    "type": "INTEGER",
+    "description": "Deprecated. Same as references-count."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "references_count",
+    "type": "INTEGER",
+    "description": "Count of outbound references deposited with Crossref"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_referenced_by_count",
+    "type": "INTEGER",
+    "description": "Count of inbound references deposited with Crossref."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source",
+    "type": "STRING",
+    "description": "Currently always Crossref."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "prefix",
+    "type": "FLOAT",
+    "description": "DOI prefix identifier of the form http://id.crossref.org/prefix/DOI_PREFIX."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "DOI",
+    "type": "STRING",
+    "description": "DOI of the work."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "URL",
+    "type": "STRING",
+    "description": "URL form of the work's DOI."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "member",
+    "type": "INTEGER",
+    "description": "Member identifier of the form http://id.crossref.org/member/MEMBER_ID"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING",
+    "description": "Enumeration, one of the type ids from https://api.crossref.org/v1/types."
+  },
+  {
     "fields": [
       {
-        "mode": "NULLABLE", 
-        "name": "type", 
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP",
+        "description": "ISO 8601 date time."
+      },
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "created",
+    "type": "RECORD",
+    "description": "Date on which the DOI was first registered."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP",
+        "description": "ISO 8601 date time."
+      },
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "deposited",
+    "type": "RECORD",
+    "description": "Date on which the work metadata was most recently updated."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP",
+        "description": "ISO 8601 date time."
+      },
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "indexed",
+    "type": "RECORD",
+    "description": "Date on which the work metadata was most recently indexed. Re-indexing does not imply a metadata change, see deposited for the most recent metadata change date."
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "issued",
+    "type": "RECORD",
+    "description": "Earliest of published-print and published-online"
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "posted",
+    "type": "RECORD",
+    "description": "Date on which posted content was made available online."
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "accepted",
+    "type": "RECORD",
+    "description": "Date on which a work was accepted, after being submitted, during a submission process."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "subtitle",
+    "type": "STRING",
+    "description": "Work subtitles, including original language and translated."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "container_title",
+    "type": "STRING",
+    "description": "Full titles of the containing work (usually a book or journal)"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "short_container_title",
+    "type": "STRING",
+    "description": "Abbreviated titles of the containing work."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "group_title",
+    "type": "STRING",
+    "description": "Group title for posted content."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "issue",
+    "type": "STRING",
+    "description": "Issue number of an article's journal."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "volume",
+    "type": "STRING",
+    "description": "Volume number of an article's journal."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "page",
+    "type": "STRING",
+    "description": "Pages numbers of an article within its journal."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "article_number",
+    "type": "STRING",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_print",
+    "type": "RECORD",
+    "description": "Date on which the work was published in print."
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_online",
+    "type": "RECORD",
+    "description": "Date on which the work was published online."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "subject",
+    "type": "STRING",
+    "description": "Subject category names, a controlled vocabulary from Sci-Val. Available for most journal articles"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "ISSN",
+    "type": "STRING",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING",
+        "description": "ISSN type, can either be print ISSN or electronic ISSN."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "ISSN value"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "issn_type",
+    "type": "RECORD",
+    "description": "List of ISSNs with ISSN type information"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "ISBN",
+    "type": "STRING",
+    "description": ""
+  },
+  {
+    "mode": "REPEATED",
+    "name": "archive",
+    "type": "STRING",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "content_version",
+        "type": "STRING",
+        "description": "Either vor (version of record,) am (accepted manuscript,) tdm (text and data mining) or unspecified."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "delay_in_days",
+        "type": "INTEGER",
+        "description": "Number of days between the publication date of the work and the start date of this license."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "timestamp",
+            "type": "INTEGER",
+            "description": "Seconds since UNIX epoch."
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "date_time",
+            "type": "STRING",
+            "description": "ISO 8601 date time."
+          },
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "start",
+        "type": "RECORD",
+        "description": "Date on which this license begins to take effect"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "URL",
+        "type": "STRING",
+        "description": "Link to a web page describing this license"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "license",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING",
+        "description": "Funding body primary name"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING",
+        "description": "Optional Open Funder Registry DOI uniquely identifing the funding body (http://www.crossref.org/fundingdata/registry.html)"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "award",
+        "type": "STRING",
+        "description": "Award number(s) for awards given by the funding body."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "doi_asserted_by",
+        "type": "STRING",
+        "description": "Either crossref or publisher"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "funder",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "URL",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "explanation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "label",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "order",
+        "type": "INTEGER",
+        "description": ""
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "label",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "group",
+        "type": "RECORD",
+        "description": ""
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "assertion",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
         "type": "STRING"
-      }, 
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "value", 
+        "mode": "NULLABLE",
+        "name": "suffix",
         "type": "STRING"
       }
-    ], 
-    "mode": "REPEATED", 
-    "name": "issn_type", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "ISSN", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "ISBN", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "URL", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "publisher_location", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "references_count", 
-    "type": "INTEGER"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "alternative_id", 
-    "type": "STRING"
-  }, 
+    ],
+    "mode": "REPEATED",
+    "name": "author",
+    "type": "RECORD",
+    "description": ""
+  },
   {
     "fields": [
       {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
-      }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "issued", 
-    "type": "RECORD"
-  }, 
-  {
-    "fields": [
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
       {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
-      }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "posted", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "group_title", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "score", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "subject", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "abstract", 
-    "type": "STRING"
-  }, 
-  {
-    "fields": [
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "timestamp", 
-        "type": "INTEGER"
-      }, 
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "date_time", 
-        "type": "TIMESTAMP"
-      }, 
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
       {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
-      }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "deposited", 
-    "type": "RECORD"
-  }, 
-  {
-    "fields": [
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "intended_application", 
+        "mode": "NULLABLE",
+        "name": "name",
         "type": "STRING"
-      }, 
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "content_version", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "content_type", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "URL", 
+        "mode": "NULLABLE",
+        "name": "suffix",
         "type": "STRING"
       }
-    ], 
-    "mode": "REPEATED", 
-    "name": "link", 
-    "type": "RECORD"
-  }, 
+    ],
+    "mode": "REPEATED",
+    "name": "editor",
+    "type": "RECORD",
+    "description": ""
+  },
   {
     "fields": [
       {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
       }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "published_print", 
-    "type": "RECORD"
-  }, 
+    ],
+    "mode": "REPEATED",
+    "name": "chair",
+    "type": "RECORD",
+    "description": ""
+  },
   {
     "fields": [
       {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
       }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "accepted", 
-    "type": "RECORD"
-  }, 
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE", 
-        "name": "timestamp", 
-        "type": "INTEGER"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "date_time", 
-        "type": "TIMESTAMP"
-      }, 
-      {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
-      }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "indexed", 
-    "type": "RECORD"
-  }, 
+    ],
+    "mode": "REPEATED",
+    "name": "translator",
+    "type": "RECORD",
+    "description": ""
+  },
   {
     "fields": [
       {
         "fields": [
           {
-            "mode": "NULLABLE", 
-            "name": "timestamp", 
-            "type": "INTEGER"
-          }, 
+            "mode": "NULLABLE",
+            "name": "timestamp",
+            "type": "INTEGER",
+            "description": "Seconds since UNIX epoch."
+          },
           {
-            "mode": "NULLABLE", 
-            "name": "date_time", 
-            "type": "STRING"
-          }, 
+            "mode": "NULLABLE",
+            "name": "date_time",
+            "type": "STRING",
+            "description": "ISO 8601 date time."
+          },
           {
-            "mode": "REPEATED", 
-            "name": "date_parts", 
-            "type": "INTEGER"
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
           }
-        ], 
-        "mode": "NULLABLE", 
-        "name": "updated", 
-        "type": "RECORD"
-      }, 
+        ],
+        "mode": "NULLABLE",
+        "name": "updated",
+        "type": "RECORD",
+        "description": "Date on which the update was published."
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "DOI", 
-        "type": "STRING"
-      }, 
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING",
+        "description": "DOI of the updated work."
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "type", 
-        "type": "STRING"
-      }, 
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING",
+        "description": "The type of update, for example retraction or correction."
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "label", 
-        "type": "STRING"
+        "mode": "NULLABLE",
+        "name": "label",
+        "type": "STRING",
+        "description": "A display-friendly label for the update type."
       }
-    ], 
-    "mode": "REPEATED", 
-    "name": "update_to", 
-    "type": "RECORD"
-  }, 
+    ],
+    "mode": "REPEATED",
+    "name": "update_to",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_policy",
+    "type": "STRING",
+    "description": "Link to an update policy covering Crossmark updates for this work."
+  },
   {
     "fields": [
       {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "intended_application",
+        "type": "STRING",
+        "description": "Either text-mining, similarity-checking or unspecified."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "content_version",
+        "type": "STRING",
+        "description": "Either vor (version of record,) am (accepted manuscript) or unspecified."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "content_type",
+        "type": "STRING",
+        "description": "Content type (or MIME type) of the full-text object."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "URL",
+        "type": "STRING",
+        "description": "Direct link to a full-text download location."
       }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "approved", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "source", 
-    "type": "STRING"
-  }, 
+    ],
+    "mode": "REPEATED",
+    "name": "link",
+    "type": "RECORD",
+    "description": "URLs to full-text locations."
+  },
   {
     "fields": [
       {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "clinical_trial_number",
+        "type": "STRING",
+        "description": "Identifier of the clinical trial."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "registry",
+        "type": "STRING",
+        "description": "DOI of the clinical trial regsitry that assigned the trial number."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING",
+        "description": "One of preResults, results or postResults"
       }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "content_created", 
-    "type": "RECORD"
-  }, 
+    ],
+    "mode": "REPEATED",
+    "name": "clinical_trial_number",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "mode": "REPEATED",
+    "name": "alternative_id",
+    "type": "STRING",
+    "description": "Other identifiers for the work provided by the depositing member"
+  },
   {
     "fields": [
       {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "doi_asserted_by",
+        "type": "STRING",
+        "description": "One of crossref or publisher."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "issue",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "first_page",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "volume",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "edition",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "component",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "standard_designator",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "standards_body",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "author",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "year",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "unstructured",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "journal_title",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "article_title",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "series_title",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "volume_title",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ISSN",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "issn_type",
+        "type": "STRING",
+        "description": "One of pissn or eissn"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ISBN",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "isbn_type",
+        "type": "STRING",
+        "description": ""
       }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "content_updated", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "DOI", 
-    "type": "STRING"
-  }, 
+    ],
+    "mode": "REPEATED",
+    "name": "reference",
+    "type": "RECORD",
+    "description": "List of references made by the work"
+  },
   {
     "fields": [
       {
-        "mode": "NULLABLE", 
-        "name": "crossmark_restriction", 
-        "type": "BOOLEAN"
-      }, 
+        "mode": "NULLABLE",
+        "name": "crossmark_restriction",
+        "type": "BOOLEAN",
+        "description": ""
+      },
       {
-        "mode": "REPEATED", 
-        "name": "domain", 
-        "type": "STRING"
+        "mode": "REPEATED",
+        "name": "domain",
+        "type": "STRING",
+        "description": ""
       }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "content_domain", 
-    "type": "RECORD"
-  }, 
+    ],
+    "mode": "NULLABLE",
+    "name": "content_domain",
+    "type": "RECORD",
+    "description": "Information on domains that support Crossmark for this work."
+  },
   {
     "fields": [
       {
@@ -317,866 +1004,866 @@
         "type": "RECORD"
       },
       {
-        "mode": "REPEATED", 
-        "name": "cites", 
+        "mode": "REPEATED",
+        "name": "cites",
         "type": "STRING"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_preprint", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_part", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_review", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_supplemented_by", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_part_of", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_identical_to", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "references", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_manifestation", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_reply_to", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_based_on", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_review_of", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_reply", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_replaced_by", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_comment", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "documents", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_version_of", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_version", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_related_material", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_compiled_by", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_translation", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_translation_of", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_preprint_of", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_referenced_by", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_supplement_to", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_variant_form_of", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "replaces", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_manifestation_of", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_related_material", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_basis_for", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_comment_on", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "continues", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_continued_by", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_derivation", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_data_basis_for", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_documented_by", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_derived_from", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "id", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "has_manuscript", 
-        "type": "RECORD"
       },
-      { 
+      {
         "fields": [
-          { 
+          {
             "mode": "NULLABLE",
             "name": "id_type",
             "type": "STRING"
           },
-          { 
+          {
             "mode": "NULLABLE",
-            "name": "id", 
+            "name": "id",
             "type": "STRING"
           },
-          { 
-            "mode": "NULLABLE", 
+          {
+            "mode": "NULLABLE",
             "name": "asserted_by",
             "type": "STRING"
           }
-        ], 
-        "mode": "REPEATED", 
-        "name": "is_manuscript_of",
+        ],
+        "mode": "REPEATED",
+        "name": "has_preprint",
         "type": "RECORD"
-      }, 
+      },
       {
         "fields": [
           {
-            "mode": "NULLABLE", 
-            "name": "id_type", 
+            "mode": "NULLABLE",
+            "name": "id_type",
             "type": "STRING"
-          }, 
+          },
           {
-            "mode": "NULLABLE", 
-            "name": "id", 
+            "mode": "NULLABLE",
+            "name": "id",
             "type": "STRING"
-          }, 
+          },
           {
-            "mode": "NULLABLE", 
-            "name": "asserted_by", 
+            "mode": "NULLABLE",
+            "name": "asserted_by",
             "type": "STRING"
           }
-        ], 
-        "mode": "REPEATED", 
-        "name": "based_on_data", 
+        ],
+        "mode": "REPEATED",
+        "name": "has_part",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_review",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_supplemented_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_part_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_identical_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "references",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_manifestation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_reply_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_based_on",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_review_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_reply",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_replaced_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_comment",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "documents",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_version_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_version",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_related_material",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_compiled_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_translation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_translation_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_preprint_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_referenced_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_supplement_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_variant_form_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "replaces",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_manifestation_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_related_material",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_basis_for",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_comment_on",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "continues",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_continued_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_derivation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_data_basis_for",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_documented_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_derived_from",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_manuscript",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_manuscript_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "based_on_data",
         "type": "RECORD"
       },
       {
@@ -1223,678 +1910,151 @@
         "name": "is_varient_form_of",
         "type": "RECORD"
       }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "relation", 
-    "type": "RECORD"
-  }, 
+    ],
+    "mode": "NULLABLE",
+    "name": "relation",
+    "type": "RECORD",
+    "description": "Relations to other works."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publisher_location",
+    "type": "STRING",
+    "description": "Location of work's publisher"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "score",
+    "type": "STRING",
+    "description": ""
+  },
   {
     "fields": [
       {
-        "mode": "NULLABLE", 
-        "name": "content_version", 
-        "type": "STRING"
-      }, 
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "approved",
+    "type": "RECORD",
+    "description": "description NA"
+  },
+  {
+    "fields": [
       {
-        "mode": "NULLABLE", 
-        "name": "delay_in_days", 
-        "type": "INTEGER"
-      }, 
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "content_created",
+    "type": "RECORD",
+    "description": "description NA"
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "content_updated",
+    "type": "RECORD",
+    "description": "description NA"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "degree",
+    "type": "STRING",
+    "description": "description NA"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "location",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "acronym",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "sponsor",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "number",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "theme",
+        "type": "STRING"
+      },
       {
         "fields": [
           {
-            "mode": "NULLABLE", 
-            "name": "timestamp", 
-            "type": "INTEGER"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "date_time", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "REPEATED", 
-            "name": "date_parts", 
-            "type": "INTEGER"
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
           }
-        ], 
-        "mode": "NULLABLE", 
-        "name": "start", 
+        ],
+        "mode": "NULLABLE",
+        "name": "start",
         "type": "RECORD"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "URL", 
-        "type": "STRING"
-      }
-    ], 
-    "mode": "REPEATED", 
-    "name": "license", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "volume", 
-    "type": "STRING"
-  }, 
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE", 
-        "name": "DOI", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "name", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "doi_asserted_by", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "REPEATED", 
-        "name": "award", 
-        "type": "STRING"
-      }
-    ], 
-    "mode": "REPEATED", 
-    "name": "funder", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "is_referenced_by_count", 
-    "type": "INTEGER"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "degree", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "subtitle", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "issue", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "reference_count", 
-    "type": "INTEGER"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "type", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "page", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "update_policy", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "title", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "publisher", 
-    "type": "STRING"
-  }, 
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE", 
-        "name": "timestamp", 
-        "type": "INTEGER"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "date_time", 
-        "type": "TIMESTAMP"
-      }, 
-      {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
-      }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "created", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "prefix", 
-    "type": "FLOAT"
-  }, 
-  {
-    "fields": [
+      },
       {
         "fields": [
           {
-            "mode": "NULLABLE", 
-            "name": "name", 
-            "type": "STRING"
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
           }
-        ], 
-        "mode": "REPEATED", 
-        "name": "affiliation", 
-        "type": "RECORD"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "family", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "given", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "name", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "suffix", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "ORCID", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "authenticated_orcid", 
-        "type": "BOOLEAN"
-      }
-    ], 
-    "mode": "REPEATED", 
-    "name": "author", 
-    "type": "RECORD"
-  }, 
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "name", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "affiliation", 
-        "type": "RECORD"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "family", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "given", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "name", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "suffix", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "ORCID", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "authenticated_orcid", 
-        "type": "BOOLEAN"
-      }
-    ], 
-    "mode": "REPEATED", 
-    "name": "editor", 
-    "type": "RECORD"
-  }, 
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "name", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "affiliation", 
-        "type": "RECORD"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "family", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "given", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "name", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "suffix", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "ORCID", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "authenticated_orcid", 
-        "type": "BOOLEAN"
-      }
-    ], 
-    "mode": "REPEATED", 
-    "name": "translator", 
-    "type": "RECORD"
-  }, 
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "name", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "REPEATED", 
-        "name": "affiliation", 
-        "type": "RECORD"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "family", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "given", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "name", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "suffix", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "ORCID", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "authenticated_orcid", 
-        "type": "BOOLEAN"
-      }
-    ], 
-    "mode": "REPEATED", 
-    "name": "chair", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "member", 
-    "type": "INTEGER"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "short_container_title", 
-    "type": "STRING"
-  }, 
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE", 
-        "name": "unstructured", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "key", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "journal_title", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "first_page", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "ISBN", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "doi_asserted_by", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "series_title", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "article_title", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "volume", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "author", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "year", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "DOI", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "ISSN", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "issn_type", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "isbn_type", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "volume_title", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "issue", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "edition", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "component", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "standards_body", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "standard_designator", 
-        "type": "STRING"
-      }
-    ], 
-    "mode": "REPEATED", 
-    "name": "reference", 
-    "type": "RECORD"
-  }, 
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE", 
-        "name": "name", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "location", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "acronym", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "REPEATED", 
-        "name": "sponsor", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "number", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "theme", 
-        "type": "STRING"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "REPEATED", 
-            "name": "date_parts", 
-            "type": "INTEGER"
-          }
-        ], 
-        "mode": "NULLABLE", 
-        "name": "start", 
-        "type": "RECORD"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "REPEATED", 
-            "name": "date_parts", 
-            "type": "INTEGER"
-          }
-        ], 
-        "mode": "NULLABLE", 
-        "name": "end", 
+        ],
+        "mode": "NULLABLE",
+        "name": "end",
         "type": "RECORD"
       }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "event", 
+    ],
+    "mode": "NULLABLE",
+    "name": "event",
     "type": "RECORD"
-  }, 
+  },
   {
     "fields": [
       {
-        "mode": "NULLABLE", 
-        "name": "name", 
+        "mode": "NULLABLE",
+        "name": "name",
         "type": "STRING"
-      }, 
+      },
       {
-        "mode": "NULLABLE", 
-        "name": "acronym", 
-        "type": "STRING"
-      }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "standards_body", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "container_title", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "short_title", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "original_title", 
-    "type": "STRING"
-  }, 
-  {
-    "fields": [
-      {
-        "mode": "REPEATED", 
-        "name": "date_parts", 
-        "type": "INTEGER"
-      }
-    ], 
-    "mode": "NULLABLE", 
-    "name": "published_online", 
-    "type": "RECORD"
-  }, 
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE", 
-        "name": "value", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "name", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "url", 
-        "type": "STRING"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "name", 
-            "type": "STRING"
-          }, 
-          {
-            "mode": "NULLABLE", 
-            "name": "label", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "NULLABLE", 
-        "name": "group", 
-        "type": "RECORD"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "label", 
-        "type": "STRING"
-      }, 
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE", 
-            "name": "URL", 
-            "type": "STRING"
-          }
-        ], 
-        "mode": "NULLABLE", 
-        "name": "explanation", 
-        "type": "RECORD"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "order", 
-        "type": "INTEGER"
-      }
-    ], 
-    "mode": "REPEATED", 
-    "name": "assertion", 
-    "type": "RECORD"
-  }, 
-  {
-    "mode": "NULLABLE", 
-    "name": "article_number", 
-    "type": "STRING"
-  }, 
-  {
-    "mode": "REPEATED", 
-    "name": "archive", 
-    "type": "STRING"
-  }, 
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE", 
-        "name": "clinical_trial_number", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "registry", 
-        "type": "STRING"
-      }, 
-      {
-        "mode": "NULLABLE", 
-        "name": "type", 
+        "mode": "NULLABLE",
+        "name": "acronym",
         "type": "STRING"
       }
-    ], 
-    "mode": "REPEATED", 
-    "name": "clinical_trial_number", 
-    "type": "RECORD"
+    ],
+    "mode": "NULLABLE",
+    "name": "standards_body",
+    "type": "RECORD",
+    "description": ""
   }
 ]

--- a/observatory-dags/observatory/dags/database/schema/crossref_metadata_2020-09-01.json
+++ b/observatory-dags/observatory/dags/database/schema/crossref_metadata_2020-09-01.json
@@ -1,189 +1,707 @@
 [
   {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "type",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "issn_type",
-    "type": "RECORD"
+    "mode": "NULLABLE",
+    "name": "publisher",
+    "type": "STRING",
+    "description": "Name of work's publisher."
   },
   {
     "mode": "REPEATED",
-    "name": "ISSN",
-    "type": "STRING"
+    "name": "title",
+    "type": "STRING",
+    "description": "Work titles, including translated titles."
   },
   {
     "mode": "REPEATED",
-    "name": "ISBN",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "URL",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publisher_location",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "references_count",
-    "type": "INTEGER"
+    "name": "original_title",
+    "type": "STRING",
+    "description": "Work titles in the work's original publication language."
   },
   {
     "mode": "REPEATED",
-    "name": "alternative_id",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "issued",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "posted",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "group_title",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "score",
-    "type": "STRING"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "subject",
-    "type": "STRING"
+    "name": "short_title",
+    "type": "STRING",
+    "description": "Short or abbreviated work titles"
   },
   {
     "mode": "NULLABLE",
     "name": "abstract",
-    "type": "STRING"
+    "type": "STRING",
+    "description": "Abstract as a JSON string or a JATS XML snippet encoded into a JSON string."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "reference_count",
+    "type": "INTEGER",
+    "description": "Deprecated. Same as references-count."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "references_count",
+    "type": "INTEGER",
+    "description": "Count of outbound references deposited with Crossref"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_referenced_by_count",
+    "type": "INTEGER",
+    "description": "Count of inbound references deposited with Crossref."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "source",
+    "type": "STRING",
+    "description": "Currently always Crossref."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "prefix",
+    "type": "FLOAT",
+    "description": "DOI prefix identifier of the form http://id.crossref.org/prefix/DOI_PREFIX."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "DOI",
+    "type": "STRING",
+    "description": "DOI of the work."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "URL",
+    "type": "STRING",
+    "description": "URL form of the work's DOI."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "member",
+    "type": "INTEGER",
+    "description": "Member identifier of the form http://id.crossref.org/member/MEMBER_ID"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING",
+    "description": "Enumeration, one of the type ids from https://api.crossref.org/v1/types."
   },
   {
     "fields": [
       {
         "mode": "NULLABLE",
         "name": "timestamp",
-        "type": "INTEGER"
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
       },
       {
         "mode": "NULLABLE",
         "name": "date_time",
-        "type": "TIMESTAMP"
+        "type": "TIMESTAMP",
+        "description": "ISO 8601 date time."
       },
       {
         "mode": "REPEATED",
         "name": "date_parts",
-        "type": "INTEGER"
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "created",
+    "type": "RECORD",
+    "description": "Date on which the DOI was first registered."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP",
+        "description": "ISO 8601 date time."
+      },
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
       }
     ],
     "mode": "NULLABLE",
     "name": "deposited",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "intended_application",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "content_version",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "content_type",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "URL",
-        "type": "STRING"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "link",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "published_print",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "accepted",
-    "type": "RECORD"
+    "type": "RECORD",
+    "description": "Date on which the work metadata was most recently updated."
   },
   {
     "fields": [
       {
         "mode": "NULLABLE",
         "name": "timestamp",
-        "type": "INTEGER"
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
       },
       {
         "mode": "NULLABLE",
         "name": "date_time",
-        "type": "TIMESTAMP"
+        "type": "TIMESTAMP",
+        "description": "ISO 8601 date time."
       },
       {
         "mode": "REPEATED",
         "name": "date_parts",
-        "type": "INTEGER"
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
       }
     ],
     "mode": "NULLABLE",
     "name": "indexed",
-    "type": "RECORD"
+    "type": "RECORD",
+    "description": "Date on which the work metadata was most recently indexed. Re-indexing does not imply a metadata change, see deposited for the most recent metadata change date."
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "issued",
+    "type": "RECORD",
+    "description": "Earliest of published-print and published-online"
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "posted",
+    "type": "RECORD",
+    "description": "Date on which posted content was made available online."
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "accepted",
+    "type": "RECORD",
+    "description": "Date on which a work was accepted, after being submitted, during a submission process."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "subtitle",
+    "type": "STRING",
+    "description": "Work subtitles, including original language and translated."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "container_title",
+    "type": "STRING",
+    "description": "Full titles of the containing work (usually a book or journal)"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "short_container_title",
+    "type": "STRING",
+    "description": "Abbreviated titles of the containing work."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "group_title",
+    "type": "STRING",
+    "description": "Group title for posted content."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "issue",
+    "type": "STRING",
+    "description": "Issue number of an article's journal."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "volume",
+    "type": "STRING",
+    "description": "Volume number of an article's journal."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "page",
+    "type": "STRING",
+    "description": "Pages numbers of an article within its journal."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "article_number",
+    "type": "STRING",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_print",
+    "type": "RECORD",
+    "description": "Date on which the work was published in print."
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_online",
+    "type": "RECORD",
+    "description": "Date on which the work was published online."
+  },
+  {
+    "mode": "REPEATED",
+    "name": "subject",
+    "type": "STRING",
+    "description": "Subject category names, a controlled vocabulary from Sci-Val. Available for most journal articles"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "ISSN",
+    "type": "STRING",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING",
+        "description": "ISSN type, can either be print ISSN or electronic ISSN."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "ISSN value"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "issn_type",
+    "type": "RECORD",
+    "description": "List of ISSNs with ISSN type information"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "ISBN",
+    "type": "STRING",
+    "description": ""
+  },
+  {
+    "mode": "REPEATED",
+    "name": "archive",
+    "type": "STRING",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "content_version",
+        "type": "STRING",
+        "description": "Either vor (version of record,) am (accepted manuscript,) tdm (text and data mining) or unspecified."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "delay_in_days",
+        "type": "INTEGER",
+        "description": "Number of days between the publication date of the work and the start date of this license."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "timestamp",
+            "type": "INTEGER",
+            "description": "Seconds since UNIX epoch."
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "date_time",
+            "type": "STRING",
+            "description": "ISO 8601 date time."
+          },
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "start",
+        "type": "RECORD",
+        "description": "Date on which this license begins to take effect"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "URL",
+        "type": "STRING",
+        "description": "Link to a web page describing this license"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "license",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING",
+        "description": "Funding body primary name"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING",
+        "description": "Optional Open Funder Registry DOI uniquely identifing the funding body (http://www.crossref.org/fundingdata/registry.html)"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "award",
+        "type": "STRING",
+        "description": "Award number(s) for awards given by the funding body."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "doi_asserted_by",
+        "type": "STRING",
+        "description": "Either crossref or publisher"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "funder",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "URL",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "explanation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "label",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "order",
+        "type": "INTEGER",
+        "description": ""
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "label",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "group",
+        "type": "RECORD",
+        "description": ""
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "assertion",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "author",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "editor",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "chair",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "translator",
+    "type": "RECORD",
+    "description": ""
   },
   {
     "fields": [
@@ -192,105 +710,274 @@
           {
             "mode": "NULLABLE",
             "name": "timestamp",
-            "type": "INTEGER"
+            "type": "INTEGER",
+            "description": "Seconds since UNIX epoch."
           },
           {
             "mode": "NULLABLE",
             "name": "date_time",
-            "type": "STRING"
+            "type": "STRING",
+            "description": "ISO 8601 date time."
           },
           {
             "mode": "REPEATED",
             "name": "date_parts",
-            "type": "INTEGER"
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
           }
         ],
         "mode": "NULLABLE",
         "name": "updated",
-        "type": "RECORD"
+        "type": "RECORD",
+        "description": "Date on which the update was published."
       },
       {
         "mode": "NULLABLE",
         "name": "DOI",
-        "type": "STRING"
+        "type": "STRING",
+        "description": "DOI of the updated work."
       },
       {
         "mode": "NULLABLE",
         "name": "type",
-        "type": "STRING"
+        "type": "STRING",
+        "description": "The type of update, for example retraction or correction."
       },
       {
         "mode": "NULLABLE",
         "name": "label",
-        "type": "STRING"
+        "type": "STRING",
+        "description": "A display-friendly label for the update type."
       }
     ],
     "mode": "REPEATED",
     "name": "update_to",
-    "type": "RECORD"
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "update_policy",
+    "type": "STRING",
+    "description": "Link to an update policy covering Crossmark updates for this work."
   },
   {
     "fields": [
       {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "intended_application",
+        "type": "STRING",
+        "description": "Either text-mining, similarity-checking or unspecified."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "content_version",
+        "type": "STRING",
+        "description": "Either vor (version of record,) am (accepted manuscript) or unspecified."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "content_type",
+        "type": "STRING",
+        "description": "Content type (or MIME type) of the full-text object."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "URL",
+        "type": "STRING",
+        "description": "Direct link to a full-text download location."
       }
     ],
-    "mode": "NULLABLE",
-    "name": "approved",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "source",
-    "type": "STRING"
+    "mode": "REPEATED",
+    "name": "link",
+    "type": "RECORD",
+    "description": "URLs to full-text locations."
   },
   {
     "fields": [
       {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "clinical_trial_number",
+        "type": "STRING",
+        "description": "Identifier of the clinical trial."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "registry",
+        "type": "STRING",
+        "description": "DOI of the clinical trial regsitry that assigned the trial number."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING",
+        "description": "One of preResults, results or postResults"
       }
     ],
-    "mode": "NULLABLE",
-    "name": "content_created",
-    "type": "RECORD"
+    "mode": "REPEATED",
+    "name": "clinical_trial_number",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
+    "mode": "REPEATED",
+    "name": "alternative_id",
+    "type": "STRING",
+    "description": "Other identifiers for the work provided by the depositing member"
   },
   {
     "fields": [
       {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "doi_asserted_by",
+        "type": "STRING",
+        "description": "One of crossref or publisher."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "issue",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "first_page",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "volume",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "edition",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "component",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "standard_designator",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "standards_body",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "author",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "year",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "unstructured",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "journal_title",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "article_title",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "series_title",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "volume_title",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ISSN",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "issn_type",
+        "type": "STRING",
+        "description": "One of pissn or eissn"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ISBN",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "isbn_type",
+        "type": "STRING",
+        "description": ""
       }
     ],
-    "mode": "NULLABLE",
-    "name": "content_updated",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "DOI",
-    "type": "STRING"
+    "mode": "REPEATED",
+    "name": "reference",
+    "type": "RECORD",
+    "description": "List of references made by the work"
   },
   {
     "fields": [
       {
         "mode": "NULLABLE",
         "name": "crossmark_restriction",
-        "type": "BOOLEAN"
+        "type": "BOOLEAN",
+        "description": ""
       },
       {
         "mode": "REPEATED",
         "name": "domain",
-        "type": "STRING"
+        "type": "STRING",
+        "description": ""
       }
     ],
     "mode": "NULLABLE",
     "name": "content_domain",
-    "type": "RECORD"
+    "type": "RECORD",
+    "description": "Information on domains that support Crossmark for this work."
   },
   {
     "fields": [
@@ -1248,478 +1935,68 @@
     ],
     "mode": "NULLABLE",
     "name": "relation",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "content_version",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "delay_in_days",
-        "type": "INTEGER"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "timestamp",
-            "type": "INTEGER"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "date_time",
-            "type": "STRING"
-          },
-          {
-            "mode": "REPEATED",
-            "name": "date_parts",
-            "type": "INTEGER"
-          }
-        ],
-        "mode": "NULLABLE",
-        "name": "start",
-        "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "URL",
-        "type": "STRING"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "license",
-    "type": "RECORD"
+    "type": "RECORD",
+    "description": "Relations to other works."
   },
   {
     "mode": "NULLABLE",
-    "name": "volume",
-    "type": "STRING"
+    "name": "publisher_location",
+    "type": "STRING",
+    "description": "Location of work's publisher"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "score",
+    "type": "STRING",
+    "description": ""
   },
   {
     "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "DOI",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "doi_asserted_by",
-        "type": "STRING"
-      },
       {
         "mode": "REPEATED",
-        "name": "award",
-        "type": "STRING"
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
       }
     ],
-    "mode": "REPEATED",
-    "name": "funder",
-    "type": "RECORD"
+    "mode": "NULLABLE",
+    "name": "approved",
+    "type": "RECORD",
+    "description": "description NA"
   },
   {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
     "mode": "NULLABLE",
-    "name": "is_referenced_by_count",
-    "type": "INTEGER"
+    "name": "content_created",
+    "type": "RECORD",
+    "description": "description NA"
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "content_updated",
+    "type": "RECORD",
+    "description": "description NA"
   },
   {
     "mode": "REPEATED",
     "name": "degree",
-    "type": "STRING"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "subtitle",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "issue",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reference_count",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "type",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "page",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "update_policy",
-    "type": "STRING"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "title",
-    "type": "STRING"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publisher",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "timestamp",
-        "type": "INTEGER"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "date_time",
-        "type": "TIMESTAMP"
-      },
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "created",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "prefix",
-    "type": "FLOAT"
-  },
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "name",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "affiliation",
-        "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "family",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "given",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "suffix",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ORCID",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "authenticated_orcid",
-        "type": "BOOLEAN"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "author",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "name",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "affiliation",
-        "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "family",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "given",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "suffix",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ORCID",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "authenticated_orcid",
-        "type": "BOOLEAN"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "editor",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "name",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "affiliation",
-        "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "family",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "given",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "suffix",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ORCID",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "authenticated_orcid",
-        "type": "BOOLEAN"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "translator",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "name",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "affiliation",
-        "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "family",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "given",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "suffix",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ORCID",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "authenticated_orcid",
-        "type": "BOOLEAN"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "chair",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "member",
-    "type": "INTEGER"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "short_container_title",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "unstructured",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "key",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "journal_title",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "first_page",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ISBN",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "doi_asserted_by",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "series_title",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "article_title",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "volume",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "author",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "year",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "DOI",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ISSN",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "issn_type",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "isbn_type",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "volume_title",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "issue",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "edition",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "component",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "standards_body",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "standard_designator",
-        "type": "STRING"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "reference",
-    "type": "RECORD"
+    "type": "STRING",
+    "description": "description NA"
   },
   {
     "fields": [
@@ -1758,7 +2035,8 @@
           {
             "mode": "REPEATED",
             "name": "date_parts",
-            "type": "INTEGER"
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
           }
         ],
         "mode": "NULLABLE",
@@ -1770,7 +2048,8 @@
           {
             "mode": "REPEATED",
             "name": "date_parts",
-            "type": "INTEGER"
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
           }
         ],
         "mode": "NULLABLE",
@@ -1797,126 +2076,7 @@
     ],
     "mode": "NULLABLE",
     "name": "standards_body",
-    "type": "RECORD"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "container_title",
-    "type": "STRING"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "short_title",
-    "type": "STRING"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "original_title",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "published_online",
-    "type": "RECORD"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "url",
-        "type": "STRING"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "name",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "label",
-            "type": "STRING"
-          }
-        ],
-        "mode": "NULLABLE",
-        "name": "group",
-        "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "label",
-        "type": "STRING"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "URL",
-            "type": "STRING"
-          }
-        ],
-        "mode": "NULLABLE",
-        "name": "explanation",
-        "type": "RECORD"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "order",
-        "type": "INTEGER"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "assertion",
-    "type": "RECORD"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "article_number",
-    "type": "STRING"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "archive",
-    "type": "STRING"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "clinical_trial_number",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "registry",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "type",
-        "type": "STRING"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "clinical_trial_number",
-    "type": "RECORD"
+    "type": "RECORD",
+    "description": ""
   }
 ]


### PR DESCRIPTION
Descriptions are obtained from https://github.com/Crossref/rest-api-doc/blob/master/api_format.md

**Empty descriptions**
Some fields have empty descriptions, I left these descriptions empty in the schema as well.

**Field order**
I changed the order of the fields, so they are more sensible and match the order on the github reference. Unfortunately that does probably make it look like the whole schema changed in the git overview of changed files.

**Field mode (required/nullable)**
This page also lists whether a field is required or not, currently all field modes are set to 'NULLABLE' or 'REPEATED' in the schema.
Perhaps it would be good to update the field mode as well. I have a crossref metadata release in a bucket I could use for testing, but I'm not sure how thorough we should test and if one release is sufficient.

I also noticed earlier for crossref events that a field that was marked as required by them was not available (https://github.com/The-Academic-Observatory/observatory-platform/issues/236) and I'm not sure if by now we have a general approach on what to do in such cases; e.g. change the respective field mode or ditch the respective data entries?

**Missing fields**
There are also some fields in the schema that I could not find back in the crossref github page. @rhosking Do you recall how the schema was originally created? I don't think I made the original schema myself, but got it maybe from you or an old instance of crossref metadata somewhere?

These are the fields in the schema I can't find in the github reference:
![image](https://user-images.githubusercontent.com/22207600/102182623-884c4780-3ee7-11eb-80d8-a651c39b53a6.png)

Also, the 'relation' field is in the github reference, but only with 3 nested fields, while in our schema there are ~30 nested fields. I don't know where they come from. I checked in the table that they are actually populated.

Then there is the 'review' field that is listed on github, but is not in our schema. Uploading the release I have stored in the bucket does not give any issues though, suggesting that at least in that release there are no 'review' fields.