### PR TITLE
Observatory test environment

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,6 +56,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_application_credentials.json
           TESTS_TERRAFORM_TOKEN: ${{ secrets.TESTS_TERRAFORM_TOKEN }}
           TESTS_TERRAFORM_ORGANISATION: ${{ secrets.TESTS_TERRAFORM_ORGANISATION }}
+          TESTS_DATA_LOCATION: ${{ secrets.TESTS_DATA_LOCATION }}
         run: |
           echo "${TESTS_GOOGLE_APPLICATION_CREDENTIALS_BASE64}" | base64 --decode > /tmp/google_application_credentials.json
           coverage run -m unittest discover

--- a/observatory-platform/observatory/platform/utils/config_utils.py
+++ b/observatory-platform/observatory/platform/utils/config_utils.py
@@ -47,17 +47,24 @@ def observatory_home(*subdirs) -> str:
     """ Get the .observatory Observatory Platform home directory or subdirectory on the host machine. The home
     directory and subdirectories will be created if they do not exist.
 
+    The default path: ~/.observatory can be overridden with the environment variable OBSERVATORY_HOME.
+
     :param: subdirs: an optional list of subdirectories.
     :return: the path.
     """
 
-    user_home = str(pathlib.Path.home())
-    observatory_home_ = os.path.join(user_home, ".observatory", *subdirs)
+    obs_home = os.environ.get('OBSERVATORY_HOME', None)
+    if obs_home is not None:
+        path = os.path.join(os.path.expanduser(obs_home), *subdirs)
+    else:
+        user_home = str(pathlib.Path.home())
+        path = os.path.join(user_home, ".observatory", *subdirs)
 
-    if not os.path.exists(observatory_home_):
-        os.makedirs(observatory_home_, exist_ok=True)
+    if not os.path.exists(path):
+        os.makedirs(path, exist_ok=True)
 
-    return observatory_home_
+    return path
+
 
 
 def terraform_credentials_path() -> str:

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -265,6 +265,7 @@ class ObservatoryEnvironment:
             os.makedirs(settings.DAGS_FOLDER, exist_ok=True)
             airflow_db_path = os.path.join(self.temp_dir, 'airflow.db')
             settings.SQL_ALCHEMY_CONN = f"sqlite:///{airflow_db_path}"
+            logging.info(f'SQL_ALCHEMY_CONN: {settings.SQL_ALCHEMY_CONN}')
             settings.configure_orm(disable_connection_pool=True)
             self.session = settings.Session
             db.initdb()

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -46,7 +46,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Source: https://github.com/apache/airflow/blob/ffb472cf9e630bd70f51b74b0d0ea4ab98635572/airflow/cli/commands/task_command.py
+# Sources:
+# * https://github.com/apache/airflow/blob/ffb472cf9e630bd70f51b74b0d0ea4ab98635572/airflow/cli/commands/task_command.py
+# * https://github.com/apache/airflow/blob/master/docs/apache-airflow/best-practices.rst
 
 # Copyright 2021 Curtin University
 #

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -1,0 +1,448 @@
+# Copyright 2014 Pallets
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# 3.  Neither the name of the copyright holder nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Source: https://github.com/pallets/click/blob/c76fea1696c0ffe7edff8a36cadd4686cda8cbfb/src/click/testing.py#L384-L410
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Source: https://github.com/apache/airflow/blob/ffb472cf9e630bd70f51b74b0d0ea4ab98635572/airflow/cli/commands/task_command.py
+
+# Copyright 2021 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: James Diprose
+
+import contextlib
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+import uuid
+from functools import partial
+from typing import Dict
+
+import httpretty
+import pendulum
+from airflow import settings
+from airflow.models import DagBag
+from airflow.models.connection import Connection
+from airflow.models.dag import DAG
+from airflow.models.taskinstance import TaskInstance
+from airflow.models.variable import Variable
+from airflow.utils import db
+from google.cloud import bigquery, storage
+from google.cloud.exceptions import NotFound
+
+from observatory.platform.utils.airflow_utils import AirflowVars
+from observatory.platform.utils.config_utils import module_file_path
+from observatory.platform.utils.file_utils import crc32c_base64_hash, gzip_file_crc, _hash_file
+from observatory.platform.utils.template_utils import blob_name
+
+
+def random_id():
+    """ Generate a random id for bucket name.
+
+    :return: a random string id.
+    """
+    return str(uuid.uuid4()).replace("-", "")
+
+
+def test_fixtures_path(*subdirs) -> str:
+    """ Get the path to the Observatory Platform test data directory.
+
+    :return: he Observatory Platform test data directory.
+    """
+
+    base_path = module_file_path('tests.fixtures')
+    return os.path.join(base_path, *subdirs)
+
+
+class ObservatoryEnvironment:
+    OBSERVATORY_HOME_KEY = 'OBSERVATORY_HOME'
+
+    def __init__(self, project_id: str, data_location: str):
+        """ Constructor for an Observatory environment.
+
+        To create an Observatory environment:
+        env = ObservatoryEnvironment(...)
+        with env.create():
+            pass
+
+        :param project_id: the Google Cloud project id.
+        :param data_location: the Google Cloud data location.
+        """
+
+        self.project_id = project_id
+        self.data_location = data_location
+        self.buckets = []
+        self.datasets = []
+        self.download_bucket = self.add_bucket()
+        self.transform_bucket = self.add_bucket()
+        self.data_path = None
+        self.storage_client = storage.Client()
+        self.bigquery_client = bigquery.Client()
+        self.session = None
+        self.temp_dir = None
+
+    def add_bucket(self) -> str:
+        """ Add a Google Cloud Storage Bucket to the Observatory environment.
+
+        The bucket will be created when create() is called and deleted when the Observatory
+        environment is closed.
+
+        :return: returns the bucket name.
+        """
+
+        bucket_name = random_id()
+        self.buckets.append(bucket_name)
+        return bucket_name
+
+    def _create_bucket(self, bucket_id: str) -> None:
+        """ Create a Google Cloud Storage Bucket.
+
+        :param bucket_id: the bucket identifier.
+        :return: None.
+        """
+
+        self.storage_client.create_bucket(bucket_id, location=self.data_location)
+
+    def _delete_bucket(self, bucket_id: str) -> None:
+        """ Delete a Google Cloud Storage Bucket.
+
+        :param bucket_id: the bucket identifier.
+        :return: None.
+        """
+
+        bucket = self.storage_client.get_bucket(bucket_id)
+        bucket.delete(force=True)
+
+    def add_dataset(self) -> str:
+        """ Add a BigQuery dataset to the Observatory environment.
+
+        The BigQuery dataset will be deleted when the Observatory environment is closed.
+
+        :return: the BigQuery dataset identifier.
+        """
+
+        dataset_id = random_id()
+        self.datasets.append(dataset_id)
+        return dataset_id
+
+    def _delete_dataset(self, dataset_id: str) -> None:
+        """ Delete a BigQuery dataset.
+
+        :param dataset_id: the BigQuery dataset identifier.
+        :return: None.
+        """
+
+        self.bigquery_client.delete_dataset(dataset_id, not_found_ok=True, delete_contents=True)
+
+    def add_variable(self, var: Variable) -> None:
+        """ Add an Airflow variable to the Observatory environment.
+
+        :param var: the Airflow variable.
+        :return: None.
+        """
+
+        self.session.add(var)
+        self.session.commit()
+
+    def add_connection(self, conn: Connection):
+        """ Add an Airflow connection to the Observatory environment.
+
+        :param conn: the Airflow connection.
+        :return: None.
+        """
+
+        self.session.add(conn)
+        self.session.commit()
+
+    def run_task(self, dag: DAG, task_id: str, execution_date: pendulum.Pendulum) -> TaskInstance:
+        """ Run an Airflow task.
+
+        :param dag: the Airflow DAG instance.
+        :param task_id: the Airflow task identifier.
+        :param execution_date: the execution date of the DAG.
+        :return: None.
+        """
+
+        task = dag.get_task(task_id=task_id)
+        ti = TaskInstance(task, execution_date)
+        ti.refresh_from_db()
+        ti.init_run_context(raw=True)
+        ti._run_raw_task()
+
+        return ti
+
+    @contextlib.contextmanager
+    def create(self):
+        """ Make and destroy an Observatory isolated environment, which involves:
+        * Creating a temporary directory.
+        * Setting the OBSERVATORY_HOME environment variable.
+        * Initialising a temporary Airflow database.
+        * Creating download and transform Google Cloud Storage buckets.
+        * Creating default Airflow Variables: AirflowVars.DATA_PATH, AirflowVars.PROJECT_ID, AirflowVars.DATA_LOCATION,
+          AirflowVars.DOWNLOAD_BUCKET and AirflowVars.TRANSFORM_BUCKET.
+        * Cleaning up all resources when the environment is closed.
+
+        :yield: Observatory environment temporary directory.
+        """
+
+        # Make temporary directory
+        cwd = os.getcwd()
+        self.temp_dir = tempfile.mkdtemp()
+        os.chdir(self.temp_dir)
+
+        # Prepare environment
+        new_env = {
+            self.OBSERVATORY_HOME_KEY: os.path.join(self.temp_dir, '.observatory')
+        }
+        prev_env = dict(os.environ)
+
+        try:
+            os.chdir(cwd)
+
+            # Update environment
+            os.environ.update(new_env)
+
+            # Create Airflow SQLite database
+            settings.DAGS_FOLDER = os.path.join(self.temp_dir, 'airflow', 'dags')
+            os.makedirs(settings.DAGS_FOLDER, exist_ok=True)
+            airflow_db_path = os.path.join(self.temp_dir, 'airflow.db')
+            settings.SQL_ALCHEMY_CONN = f"sqlite:///{airflow_db_path}"
+            settings.configure_orm(disable_connection_pool=True)
+            self.session = settings.Session
+            db.initdb()
+
+            # Create buckets
+            for bucket_id in self.buckets:
+                self._create_bucket(bucket_id)
+
+            # Add default Airflow variables
+            self.data_path = os.path.join(self.temp_dir, 'data')
+            self.add_variable(Variable(key=AirflowVars.DATA_PATH, val=self.data_path))
+            self.add_variable(Variable(key=AirflowVars.PROJECT_ID, val=self.project_id))
+            self.add_variable(Variable(key=AirflowVars.DATA_LOCATION, val=self.data_location))
+            self.add_variable(Variable(key=AirflowVars.DOWNLOAD_BUCKET, val=self.download_bucket))
+            self.add_variable(Variable(key=AirflowVars.TRANSFORM_BUCKET, val=self.transform_bucket))
+
+            yield self.temp_dir
+        finally:
+            # Remove temporary folder
+            try:
+                shutil.rmtree(self.temp_dir)
+            except (OSError, IOError):  # noqa: B014
+                pass
+
+            # Revert environment
+            os.environ.clear()
+            os.environ.update(prev_env)
+
+            # Remove Google Cloud Storage buckets
+            for bucket_id in self.buckets:
+                self._delete_bucket(bucket_id)
+
+            # Remove BigQuery datasets
+            for dataset_id in self.datasets:
+                self._delete_dataset(dataset_id)
+
+
+class ObservatoryTestCase(unittest.TestCase):
+    """ Common test functions for testing Observatory Platform DAGs """
+
+    def __init__(self, *args, **kwargs):
+        """ Constructor which sets up variables used by tests.
+
+        :param args: arguments.
+        :param kwargs: keyword arguments.
+        """
+
+        super(ObservatoryTestCase, self).__init__(*args, **kwargs)
+        self.storage_client = storage.Client()
+        self.bigquery_client = bigquery.Client()
+
+        # Turn logging to warning because vcr prints too much at info level
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.WARNING)
+
+    def assert_dag_structure(self, expected: Dict, dag: DAG):
+        """ Assert the DAG structure.
+
+        :param expected: a dictionary of DAG task ids as keys and values which should be a list of downstream task ids.
+        :param dag: the DAG.
+        :return: None.
+        """
+
+        self.assertEqual(expected.keys(), dag.task_dict.keys())
+
+        for task_id, downstream_list in expected.items():
+            self.assertTrue(dag.has_task(task_id))
+            task = dag.get_task(task_id)
+            self.assertEqual(set(downstream_list), task.downstream_task_ids)
+
+    def assert_dag_load(self, dag_id: str, dag_folder: str = module_file_path('observatory.dags.dags')):
+        """ Assert that the given DAG loads from a DagBag.
+
+        :param dag_id: the DAG id.
+        :param dag_folder: the folder to load the DAG from.
+        :return: None.
+        """
+
+        dag_bag = DagBag(dag_folder=dag_folder)
+        dag = dag_bag.get_dag(dag_id=dag_id)
+        self.assertEqual({}, dag_bag.import_errors)
+        self.assertIsNotNone(dag)
+        self.assertEqual(1, len(dag.tasks))
+
+    def assert_blob_integrity(self, bucket_id: str, local_file_path: str):
+        """ Assert whether the blob uploaded and that it has the expected hash.
+
+        :param bucket_id: the Google Cloud Storage bucket id.
+        :param local_file_path: the path to the local file.
+        :return: whether the blob uploaded and that it has the expected hash.
+        """
+
+        # Get blob
+        bucket = self.storage_client.get_bucket(bucket_id)
+        blob = bucket.blob(blob_name(local_file_path))
+        result = blob.exists()
+
+        # Check that blob hash matches if it exists
+        if result:
+            # Get blob hash
+            blob.reload()
+            expected_hash = blob.crc32c
+
+            # Check actual file
+            actual_hash = crc32c_base64_hash(local_file_path)
+            result = expected_hash == actual_hash
+
+        self.assertTrue(result)
+
+    def assert_table_integrity(self, table_id: str, expected_rows: int):
+        """ Assert whether a BigQuery table exists and has the expected number of rows.
+
+        :param table_id: the BigQuery table id.
+        :param expected_rows: the expected number of rows.
+        :return: whether the table exists and has the expected number of rows.
+        """
+
+        result = False
+        try:
+            table = self.bigquery_client.get_table(table_id)
+            result = expected_rows == table.num_rows
+        except NotFound:
+            pass
+
+        self.assertTrue(result)
+
+    def assert_file_integrity(self, file_path: str, expected_hash: str, algorithm: str):
+        """ Assert that a file exists and it has the correct hash.
+
+        :param file_path: the path to the file.
+        :param expected_hash: the expected hash.
+        :param algorithm: the algorithm to use when hashing, either md5 or gzip crc
+        :return: None.
+        """
+
+        self.assertTrue(os.path.isfile(file_path))
+
+        if algorithm == 'md5':
+            hash_func = partial(_hash_file, algorithm='md5')
+        elif algorithm == 'gzip_crc':
+            hash_func = gzip_file_crc
+        else:
+            raise ValueError(f'Unknown hash algorithm: {algorithm}')
+
+        actual_hash = hash_func(file_path)
+        self.assertEqual(expected_hash, actual_hash)
+
+    def assert_cleanup(self, download_folder: str, extract_folder: str, transform_folder: str):
+        """ Assert that the download, extracted and transformed folders were cleaned up.
+
+        :param download_folder: the path to the DAGs download folder.
+        :param extract_folder: the path to the DAGs extract folder.
+        :param transform_folder: the path to the DAGs transform folder.
+        :return: None.
+        """
+
+        self.assertFalse(os.path.exists(download_folder))
+        self.assertFalse(os.path.exists(extract_folder))
+        self.assertFalse(os.path.exists(transform_folder))
+
+    def setup_mock_file_download(self, uri: str, file_path: str, headers: Dict = None) -> None:
+        """ Use httpretty to mock a file download.
+
+        This function must be called from within an httpretty.enabled() block, for instance:
+
+        with httpretty.enabled():
+            self.setup_mock_file_download('https://example.com/file.zip', path_to_file)
+
+        :param uri: the URI of the file download to mock.
+        :param file_path: the path to the file on the local system.
+        :param headers: the response headers.
+        :return: None.
+        """
+
+        if headers is None:
+            headers = {}
+
+        with open(file_path, 'rb') as f:
+            body = f.read()
+
+        httpretty.register_uri(httpretty.GET, uri,
+                               adding_headers=headers,
+                               body=body)

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -385,9 +385,10 @@ class ObservatoryTestCase(unittest.TestCase):
         self.assertIsNotNone(dag)
         self.assertEqual(1, len(dag.tasks))
 
-    def assert_blob_integrity(self, bucket_id: str, local_file_path: str):
+    def assert_blob_integrity(self, bucket_id: str, blob_name: str, local_file_path: str):
         """ Assert whether the blob uploaded and that it has the expected hash.
 
+        :param blob_name: the Google Cloud Blob name, i.e. the entire path to the blob on the Cloud Storage bucket.
         :param bucket_id: the Google Cloud Storage bucket id.
         :param local_file_path: the path to the local file.
         :return: whether the blob uploaded and that it has the expected hash.
@@ -395,7 +396,7 @@ class ObservatoryTestCase(unittest.TestCase):
 
         # Get blob
         bucket = self.storage_client.get_bucket(bucket_id)
-        blob = bucket.blob(blob_name(local_file_path))
+        blob = bucket.blob(blob_name)
         result = blob.exists()
 
         # Check that blob hash matches if it exists

--- a/tests/fixtures/utils/gc_utils/people.csv.gz
+++ b/tests/fixtures/utils/gc_utils/people.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b45e07f5bab5f4936da0889fc97c54ef20258eb2de8a7700cf2e4d728321f0d
+size 141

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -1,0 +1,237 @@
+# Copyright 2021 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: James Diprose
+
+import datetime
+import os
+import unittest
+from typing import Union, List
+
+import httpretty
+import pendulum
+from airflow.models.connection import Connection
+from airflow.models.variable import Variable
+from click.testing import CliRunner
+from google.cloud.exceptions import NotFound
+
+from observatory.platform.telescopes.telescope import Telescope, AbstractRelease
+from observatory.platform.utils.airflow_utils import AirflowVars
+from observatory.platform.utils.gc_utils import create_bigquery_dataset
+from observatory.platform.utils.test_utils import ObservatoryEnvironment, random_id, ObservatoryTestCase
+from observatory.platform.utils.url_utils import retry_session
+
+DAG_ID = 'telescope-test'
+MY_VAR_ID = 'my-variable'
+MY_CONN_ID = 'my-connection'
+DAG_FILE_CONTENT = """
+# The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
+# https://airflow.apache.org/docs/stable/faq.html
+
+from tests.observatory.platform.utils.test_test_utils import TelescopeTest
+
+telescope = TelescopeTest()
+globals()['test-telescope'] = telescope.make_dag()
+"""
+
+
+class TelescopeTest(Telescope):
+    """ A telescope for testing purposes """
+
+    def __init__(self, dag_id: str = DAG_ID,
+                 start_date: datetime = datetime.datetime(2020, 9, 1),
+                 schedule_interval: str = '@weekly'):
+        airflow_vars = [AirflowVars.DATA_PATH, AirflowVars.PROJECT_ID, AirflowVars.DATA_LOCATION,
+                        AirflowVars.DOWNLOAD_BUCKET, AirflowVars.TRANSFORM_BUCKET, MY_VAR_ID]
+        airflow_conns = [MY_CONN_ID]
+        super().__init__(dag_id, start_date, schedule_interval, airflow_vars=airflow_vars, airflow_conns=airflow_conns)
+        self.add_setup_task(self.check_dependencies)
+
+    def make_release(self, **kwargs) -> Union['AbstractRelease', List['AbstractRelease']]:
+        pass
+
+
+class TestObservatoryEnvironment(unittest.TestCase):
+    """ Test the ObservatoryEnvironment """
+
+    def __init__(self, *args, **kwargs):
+        super(TestObservatoryEnvironment, self).__init__(*args, **kwargs)
+        self.project_id = os.getenv('TESTS_GOOGLE_CLOUD_PROJECT_ID')
+        self.data_location = os.getenv('TESTS_DATA_LOCATION')
+
+    def test_add_bucket(self):
+        """ Test the add_bucket method """
+
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
+
+        # The download and transform buckets are added in the constructor
+        self.assertEqual(2, len(env.buckets))
+        self.assertEqual(env.download_bucket, env.buckets[0])
+        self.assertEqual(env.transform_bucket, env.buckets[1])
+
+        # Test that calling add bucket adds a new bucket to the buckets list
+        name = env.add_bucket()
+        self.assertEqual(name, env.buckets[-1])
+
+    def test_create_delete_bucket(self):
+        """ Test _create_bucket and _delete_bucket """
+
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        bucket_id = random_id()
+
+        # Create bucket
+        env._create_bucket(bucket_id)
+        bucket = env.storage_client.bucket(bucket_id)
+        self.assertTrue(bucket.exists())
+
+        # Delete bucket
+        env._delete_bucket(bucket_id)
+        self.assertFalse(bucket.exists())
+
+    def test_delete_dataset(self):
+        """ Test _delete_dataset """
+
+        # Create dataset
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        dataset_id = random_id()
+        create_bigquery_dataset(self.project_id, dataset_id, self.data_location)
+
+        # Check that dataset exists: should not raise NotFound exception
+        env.bigquery_client.get_dataset(dataset_id)
+
+        # Delete dataset
+        env._delete_dataset(dataset_id)
+
+        # Check that dataset doesn't exist
+        with self.assertRaises(NotFound):
+            env.bigquery_client.get_dataset(dataset_id)
+
+    def test_create(self):
+        """ Tests create, add_variable, add_connection and run_task """
+
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
+
+        # Setup Telescope
+        execution_date = pendulum.datetime(year=2020, month=11, day=1)
+        telescope = TelescopeTest()
+        dag = telescope.make_dag()
+
+        with env.create():
+            # Test add_variable
+            env.add_variable(Variable(key=MY_VAR_ID, val='hello'))
+
+            # Test add_connection
+            conn = Connection(conn_id=MY_CONN_ID)
+            conn.parse_from_uri('mysql://login:password@host:8080/schema?param1=val1&param2=val2')
+            env.add_connection(conn)
+
+            # Test run task
+            env.run_task(dag, telescope.check_dependencies.__name__, execution_date)
+
+
+class TestObservatoryTestCase(unittest.TestCase):
+    """ Test the ObservatoryTestCase class """
+
+    def __init__(self, *args, **kwargs):
+        super(TestObservatoryTestCase, self).__init__(*args, **kwargs)
+
+    def test_assert_dag_structure(self):
+        """ Test assert_dag_structure """
+
+        test_case = ObservatoryTestCase()
+        telescope = TelescopeTest()
+        dag = telescope.make_dag()
+
+        # No assertion error
+        expected = {'check_dependencies': []}
+        test_case.assert_dag_structure(expected, dag)
+
+        # Raise assertion error
+        with self.assertRaises(AssertionError):
+            expected = {'check_dependencies': ['list_releases'],
+                        'list_releases': []}
+            test_case.assert_dag_structure(expected, dag)
+
+    def test_assert_dag_load(self):
+        """ Test assert_dag_load """
+
+        test_case = ObservatoryTestCase()
+        with CliRunner().isolated_filesystem() as temp_dir:
+            # Write DAG into temp_dir
+            file_path = os.path.join(temp_dir, f'telescope_test.py')
+            with open(file_path, mode='w') as f:
+                f.write(DAG_FILE_CONTENT)
+
+            # DAG loaded successfully: should be not errors
+            test_case.assert_dag_load(DAG_ID, dag_folder=temp_dir)
+
+            # Remove DAG from temp_dir
+            os.unlink(file_path)
+
+            # DAG not loaded
+            with self.assertRaises(AssertionError):
+                test_case.assert_dag_load(DAG_ID, dag_folder=temp_dir)
+
+    def test_assert_blob_integrity(self):
+        pass
+
+    def test_assert_table_integrity(self):
+        pass
+
+    def test_assert_file_integrity(self):
+        pass
+
+    def test_assert_cleanup(self):
+        """ Test assert_cleanup """
+
+        with CliRunner().isolated_filesystem() as temp_dir:
+            download = os.path.join(temp_dir, 'download')
+            extract = os.path.join(temp_dir, 'extract')
+            transform = os.path.join(temp_dir, 'transform')
+
+            # Make download, extract and transform folders
+            os.makedirs(download)
+            os.makedirs(extract)
+            os.makedirs(transform)
+
+            # Check that assertion is raised when folders exist
+            test_case = ObservatoryTestCase()
+            with self.assertRaises(AssertionError):
+                test_case.assert_cleanup(download, extract, transform)
+
+            # Delete folders
+            os.rmdir(download)
+            os.rmdir(extract)
+            os.rmdir(transform)
+
+            # No error when folders deleted
+            test_case.assert_cleanup(download, extract, transform)
+
+    def test_setup_mock_file_download(self):
+        """ Test mocking a file download """
+
+        with CliRunner().isolated_filesystem() as temp_dir:
+            # Write data into temp_dir
+            expected_data = "Hello World!"
+            file_path = os.path.join(temp_dir, f'content.txt')
+            with open(file_path, mode='w') as f:
+                f.write(expected_data)
+
+            # Check that content was downloaded from test file
+            test_case = ObservatoryTestCase()
+            url = "https://example.com"
+            with httpretty.enabled():
+                test_case.setup_mock_file_download(url, file_path)
+                response = retry_session().get(url)
+                self.assertEqual(expected_data, response.content.decode("utf-8"))

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -14,6 +14,8 @@
 
 # Author: James Diprose
 
+from __future__ import annotations
+
 import datetime
 import os
 import unittest
@@ -58,7 +60,7 @@ class TelescopeTest(Telescope):
         super().__init__(dag_id, start_date, schedule_interval, airflow_vars=airflow_vars, airflow_conns=airflow_conns)
         self.add_setup_task(self.check_dependencies)
 
-    def make_release(self, **kwargs) -> Union['AbstractRelease', List['AbstractRelease']]:
+    def make_release(self, **kwargs) -> Union[AbstractRelease, List[AbstractRelease]]:
         pass
 
 
@@ -173,7 +175,7 @@ class TestObservatoryTestCase(unittest.TestCase):
             with open(file_path, mode='w') as f:
                 f.write(DAG_FILE_CONTENT)
 
-            # DAG loaded successfully: should be not errors
+            # DAG loaded successfully: should be no errors
             test_case.assert_dag_load(DAG_ID, dag_folder=temp_dir)
 
             # Remove DAG from temp_dir

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -169,7 +169,7 @@ class TestObservatoryTestCase(unittest.TestCase):
         """ Test assert_dag_load """
 
         test_case = ObservatoryTestCase()
-        with CliRunner().isolated_filesystem() as temp_dir:
+        with ObservatoryEnvironment().create() as temp_dir:
             # Write DAG into temp_dir
             file_path = os.path.join(temp_dir, f'telescope_test.py')
             with open(file_path, mode='w') as f:
@@ -186,12 +186,18 @@ class TestObservatoryTestCase(unittest.TestCase):
                 test_case.assert_dag_load(DAG_ID, dag_folder=temp_dir)
 
     def test_assert_blob_integrity(self):
+        """ Test assert_blob_integrity """
+
         pass
 
     def test_assert_table_integrity(self):
+        """ Test assert_table_integrity """
+
         pass
 
     def test_assert_file_integrity(self):
+        """ Test assert_file_integrity """
+
         pass
 
     def test_assert_cleanup(self):

--- a/tests/observatory/test_utils.py
+++ b/tests/observatory/test_utils.py
@@ -14,6 +14,7 @@
 
 # Author: James Diprose
 
+import os
 import pathlib
 import uuid
 
@@ -28,12 +29,12 @@ def random_id():
     return str(uuid.uuid4()).replace("-", "")
 
 
-def test_fixtures_path() -> str:
+def test_fixtures_path(*subdirs) -> str:
     """ Get the path to the Observatory Platform test data directory.
 
     :return: he Observatory Platform test data directory.
     """
 
     file_path = pathlib.Path(tests.fixtures.__file__).resolve()
-    path = pathlib.Path(*file_path.parts[:-1])
-    return str(path.resolve())
+    base_path = str(pathlib.Path(*file_path.parts[:-1]).resolve())
+    return os.path.join(base_path, *subdirs)


### PR DESCRIPTION
This pull request adds a test environment which allows Apache Airflow DAGs to be tested with unit tests. The test environment creates all required resources to test a DAG and then deletes them when it is finished. The following Apache Airflow DAG features can be tested / used:
* Loading a DAG with a DagBag.
* Running DAG tasks.
* Pulling and pushing XComs.
* Reading and writing Apache Airflow Variables and Connections.

To enable DAGs to be tested the following resources are created by the test environment:
* A temporary directory in the `/tmp/<random id>` folder where all resources are kept.
* A temporary Apache Airflow SQLite database, stored at `/tmp/<random id>/airflow.db`
* The following Airflow Variables are automatically added: AirflowVars.DATA_PATH, AirflowVars.PROJECT_ID, AirflowVars.DATA_LOCATION, AirflowVars.DOWNLOAD_BUCKET and AirflowVars.TRANSFORM_BUCKET. The Google Cloud related variables are added only if the project_id and data_location are specified.
* Set the OBSERVATORY_HOME environment variable to within temporary test directory.
* If Google Cloud parameters are set, then the download and transform Google Cloud Storage buckets.
* The following can be optionally added:
  * Google Cloud datasets (so that they are destroyed on shutdown).
  * Apache Airflow variables
  * Apache Airflow connections 

When the test environment shuts down, the following occurs:
* Temporary directory deleted.
* Airflow database deleted.
* Environment variables are reset.
* All Google Cloud resources destroyed. 

A pre-filled ObservatoryTestCase class has also been provided to make testing DAGs more straightforward, it includes methods for testing:
* DAG structure.
* Loading a DAG from a DagBag.
* Setting up a mock file download.
* Asserting common things, e.g. files, cleanup, BigQuery tables, blobs etc.

A more through example of how to use these features will be provided in a following pull request, where the Geonames DAG is tested.