### PR TITLE
Add initialize_sftp_connection function

### DIFF
--- a/observatory-platform/observatory/platform/utils/airflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/airflow_utils.py
@@ -55,6 +55,7 @@ class AirflowConns:
     SLACK = "slack"
     ELASTIC = "elastic"
     KIBANA = "kibana"
+    SFTP_SERVICE = "sftp_service"
 
 
 def get_variable(key: str) -> Optional[str]:

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -25,3 +25,5 @@ requests==2.20.0
 pyjwt==1.7.1
 idna==2.7
 marshmallow==2.21.0
+pysftp==0.2.*
+paramiko==2.7.*

--- a/tests/observatory/platform/utils/test_telescope_utils.py
+++ b/tests/observatory/platform/utils/test_telescope_utils.py
@@ -22,6 +22,7 @@ import paramiko
 import pendulum
 import pysftp
 from airflow.models.connection import Connection
+
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.telescope_utils import (PeriodCount, ScheduleOptimiser, initialize_sftp_connection)
 
@@ -74,7 +75,8 @@ class TestScheduleOptimiser(unittest.TestCase):
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 1, 1), end=pendulum.date(1000, 1, 1)), 0),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 2, 1), end=pendulum.date(1000, 2, 1)), 1),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 3, 1), end=pendulum.date(1000, 3, 1)), 2),
-            PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 1)), 3), ]
+            PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 1)), 3)
+        ]
 
     def test_get_num_calls(self):
         """ Test the num_call calculation. """
@@ -110,7 +112,8 @@ class TestScheduleOptimiser(unittest.TestCase):
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 1, 1), end=pendulum.date(1000, 1, 1)), 0),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 1, 1), end=pendulum.date(1000, 1, 1)), 0),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 1, 1), end=pendulum.date(1000, 1, 1)), 0),
-            PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 21)), 1), ]
+            PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 21)), 1)
+        ]
 
         schedule, min_calls = ScheduleOptimiser.optimise(self.max_per_call, self.max_per_query, historic_counts)
         self.assertEqual(len(schedule), 1)
@@ -122,7 +125,8 @@ class TestScheduleOptimiser(unittest.TestCase):
     def test_optimise_leading_zeros2(self):
         historic_counts = [
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 1, 1), end=pendulum.date(1000, 1, 1)), 0),
-            PeriodCount(pendulum.Period(start=pendulum.date(1000, 1, 1), end=pendulum.date(1000, 1, 1)), 0), ]
+            PeriodCount(pendulum.Period(start=pendulum.date(1000, 1, 1), end=pendulum.date(1000, 1, 1)), 0)
+        ]
 
         schedule, min_calls = ScheduleOptimiser.optimise(self.max_per_call, self.max_per_query, historic_counts)
         self.assertEqual(len(schedule), 1)
@@ -143,7 +147,8 @@ class TestScheduleOptimiser(unittest.TestCase):
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 1, 1), end=pendulum.date(1000, 1, 1)), 10),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 2, 1), end=pendulum.date(1000, 2, 1)), 1),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 3, 1), end=pendulum.date(1000, 3, 1)), 2),
-            PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 1)), 3), ]
+            PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 1)), 3)
+        ]
 
         schedule, min_calls = ScheduleOptimiser.optimise(self.max_per_call, self.max_per_query, historic_counts)
         self.assertEqual(len(schedule), 2)
@@ -159,7 +164,8 @@ class TestScheduleOptimiser(unittest.TestCase):
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 2, 1), end=pendulum.date(1000, 2, 1)), 6),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 3, 1), end=pendulum.date(1000, 3, 1)), 0),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 1)), 10),
-            PeriodCount(pendulum.Period(start=pendulum.date(1000, 5, 1), end=pendulum.date(1000, 5, 1)), 2), ]
+            PeriodCount(pendulum.Period(start=pendulum.date(1000, 5, 1), end=pendulum.date(1000, 5, 1)), 2)
+        ]
 
         schedule, min_calls = ScheduleOptimiser.optimise(self.max_per_call, self.max_per_query, historic_counts)
         self.assertEqual(len(schedule), 4)  # Naive is 5
@@ -179,7 +185,8 @@ class TestScheduleOptimiser(unittest.TestCase):
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 2, 1), end=pendulum.date(1000, 2, 1)), 1),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 3, 1), end=pendulum.date(1000, 3, 1)), 0),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 1)), 1),
-            PeriodCount(pendulum.Period(start=pendulum.date(1000, 5, 1), end=pendulum.date(1000, 5, 1)), 2), ]
+            PeriodCount(pendulum.Period(start=pendulum.date(1000, 5, 1), end=pendulum.date(1000, 5, 1)), 2)
+        ]
 
         schedule, min_calls = ScheduleOptimiser.optimise(self.max_per_call, self.max_per_query, historic_counts)
         self.assertEqual(len(schedule), 1)  # Naive is 5
@@ -193,7 +200,8 @@ class TestScheduleOptimiser(unittest.TestCase):
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 2, 1), end=pendulum.date(1000, 2, 1)), 3),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 3, 1), end=pendulum.date(1000, 3, 1)), 3),
             PeriodCount(pendulum.Period(start=pendulum.date(1000, 4, 1), end=pendulum.date(1000, 4, 1)), 1),
-            PeriodCount(pendulum.Period(start=pendulum.date(1000, 5, 1), end=pendulum.date(1000, 5, 1)), 3), ]
+            PeriodCount(pendulum.Period(start=pendulum.date(1000, 5, 1), end=pendulum.date(1000, 5, 1)), 3)
+        ]
 
         schedule, min_calls = ScheduleOptimiser.optimise(self.max_per_call, self.max_per_query, historic_counts)
         self.assertEqual(len(schedule), 2)  # Naive is 5


### PR DESCRIPTION
Add the initialize_sftp_connection() function to telescope_utils.py. This can be used for various telescopes that want to make a connection to a sftp server.

Example airflow connection:
`sftp_service: ssh://<username>:<password>@<host>?host_key=<host_key>`