### PR TITLE
Add ONIX telescope

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,18 +14,20 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
-        os: [ubuntu-18.04]
+        python-version: [ 3.7 ]
+        os: [ ubuntu-18.04 ]
 
     steps:
       - name: Checkout ${{ matrix.python-version }}
         uses: actions/checkout@v2
         with:
           lfs: true
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -33,6 +35,13 @@ jobs:
           pip install -e observatory-platform
           pip install -e observatory-dags
           pip install -e observatory-reports
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
       - name: Check licenses
         run: |
           # stop the build if there are licensing issues
@@ -40,12 +49,14 @@ jobs:
           liccheck --sfile strategy.ini --rfile observatory-platform/requirements.txt --level CAUTIOUS --reporting liccheck-output.txt --no-deps
           liccheck --sfile strategy.ini --rfile observatory-dags/requirements.txt --level CAUTIOUS --reporting liccheck-output.txt --no-deps
           liccheck --sfile strategy.ini --rfile observatory-reports/requirements.txt --level CAUTIOUS --reporting liccheck-output.txt --no-deps
+
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
       - name: Run unit tests with coverage
         env:
           TESTS_AZURE_CONTAINER_NAME: ${{ secrets.TESTS_AZURE_CONTAINER_NAME }}
@@ -63,6 +74,7 @@ jobs:
           echo "${TESTS_GOOGLE_APPLICATION_CREDENTIALS_BASE64}" | base64 --decode > /tmp/google_application_credentials.json
           coverage run -m unittest discover
           coverage xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/observatory-dags/observatory/dags/dags/onix.py
+++ b/observatory-dags/observatory/dags/dags/onix.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: James Diprose
+
+# The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
+# https://airflow.apache.org/docs/stable/faq.html
+
+
+from observatory.api.client.identifiers import TelescopeTypes
+from observatory.dags.telescopes.onix import OnixTelescope
+from observatory.platform.utils.telescope_utils import make_observatory_api
+
+# Fetch all ONIX telescopes
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=TelescopeTypes.onix)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+
+# Make all ONIX telescopes
+for telescope in telescopes:
+    onix_telescope = OnixTelescope(telescope.organisation)
+    globals()[onix_telescope.dag_id] = onix_telescope.make_dag()

--- a/observatory-dags/observatory/dags/database/schema/onix_2020-03-30.json
+++ b/observatory-dags/observatory/dags/database/schema/onix_2020-03-30.json
@@ -1,0 +1,613 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "RecordRef",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "WorkRelationCode",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "WorkIDType",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "IDValue",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "IDTypeName",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "WorkIdentifiers",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "RelatedWorks",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "TextType",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "Text",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "TextContent",
+    "type": "RECORD"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "CityOfPublications",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "DOI",
+    "type": "STRING"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "EditionType",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "ImprintIDType",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "IDValue",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "IDTypeName",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "ImprintIdentifiers",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ImprintName",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Imprints",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "ProductForm",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ISBN13",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "PID_Proprietary",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "GTIN_13",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "ProductRelationCodes",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "RelatedProducts",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "PublisherName",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REPEATED",
+            "name": "WebsiteDescriptions",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "WebsiteRole",
+            "type": "STRING"
+          },
+          {
+            "mode": "REPEATED",
+            "name": "WebsiteLinks",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "Websites",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "PublishingRole",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Publishers",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "PID_Proprietary",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ISBN10",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ISBN13",
+    "type": "INTEGER"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "TitleStatement",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "TitleWithoutPrefix_TextCaseFlags",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Subtitle_Language",
+            "type": "STRING"
+          },
+          {
+            "fields": [
+              {
+                "mode": "NULLABLE",
+                "name": "Value",
+                "type": "STRING"
+              }
+            ],
+            "mode": "NULLABLE",
+            "name": "TitlePrefix",
+            "type": "RECORD"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "TitleText_TextCaseFlags",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Subtitle_TextCaseFlags",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "TitleText_Language",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "TitleElementLevel",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "SequenceNumber",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "TitleWithoutPrefix",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Subtitle",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "TitleText",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "TitleElements",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "TitleType",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "TitleDetails",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "CountryOfManufacture",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "fields": [
+          {
+            "fields": [
+              {
+                "fields": [
+                  {
+                    "mode": "NULLABLE",
+                    "name": "Value",
+                    "type": "STRING"
+                  }
+                ],
+                "mode": "NULLABLE",
+                "name": "PartNumber",
+                "type": "RECORD"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "TitleElementLevel",
+                "type": "STRING"
+              },
+              {
+                "mode": "NULLABLE",
+                "name": "TitleText",
+                "type": "STRING"
+              }
+            ],
+            "mode": "REPEATED",
+            "name": "TitleElements",
+            "type": "RECORD"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "TitleType",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "TitleDetails",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "IDTypeName",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "IDValue",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "CollectionIdType",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "CollectionIdentifers",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "CollectionType",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Collections",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "RecordSourceType",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "EditionNumber",
+    "type": "INTEGER"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "PublishingDateRole",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "Date",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "PublishingDates",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "LanguageRole",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "LanguageCode",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Languages",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ProductForm",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "GTIN_13",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "RecordSourceName",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "NameType",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "Proprietary",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "ProfessionalAffiliations",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "PersonName",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "Places",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "TextFormat",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Note",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "BiographicalNotes",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "TitlesBeforeNames",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "Roles",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "Websites",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "PersonNameInverted",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "Date",
+            "type": "INTEGER"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "Role",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "Dates",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "CorprorateName",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "SequenceNumber",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "PrefixToKey",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "KeyNames",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "AlternativeNames",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "NamesBeforeKey",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ISNI",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Contributors",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "COKI_ID",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "ExtentValueRoman",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ExtentType",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ExtentValue",
+        "type": "INTEGER"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ExtentUnit",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Extent",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "SubjectSchemeName",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "SubjectHeadingText",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "SubjectSchemeIdentifier",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "SubjectSchemeVersion",
+        "type": "FLOAT"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "SubjectCode",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "MainSubject",
+        "type": "BOOLEAN"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "Subjects",
+    "type": "RECORD"
+  }
+]

--- a/observatory-dags/observatory/dags/telescopes/onix.py
+++ b/observatory-dags/observatory/dags/telescopes/onix.py
@@ -223,18 +223,17 @@ def list_release_info(sftp_upload_folder: str) -> List[Dict]:
     """
 
     results = []
-    sftp = make_sftp_connection()
-    sftp.makedirs(sftp_upload_folder)
-    files = sftp.listdir(sftp_upload_folder)
-    for file_name in files:
-        if re.match(OnixRelease.DOWNLOAD_FILES_REGEX, file_name):
-            date_str = file_name[:8]
-            release_date = pendulum.strptime(date_str, '%Y%m%d')
-            results.append({
-                'release_date': release_date,
-                'file_name': file_name
-            })
-    sftp.close()
+    with make_sftp_connection() as sftp:
+        sftp.makedirs(sftp_upload_folder)
+        files = sftp.listdir(sftp_upload_folder)
+        for file_name in files:
+            if re.match(OnixRelease.DOWNLOAD_FILES_REGEX, file_name):
+                date_str = file_name[:8]
+                release_date = pendulum.strptime(date_str, '%Y%m%d')
+                results.append({
+                    'release_date': release_date,
+                    'file_name': file_name
+                })
     return results
 
 

--- a/observatory-dags/observatory/dags/telescopes/onix.py
+++ b/observatory-dags/observatory/dags/telescopes/onix.py
@@ -1,0 +1,283 @@
+# Copyright 2021 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: James Diprose
+
+
+import os
+import re
+from datetime import datetime
+from typing import List, Optional, Dict
+
+import pendulum
+from airflow.models.taskinstance import TaskInstance
+from google.cloud.bigquery import SourceFormat
+from pendulum import Pendulum
+
+from observatory.api.client.model.organisation import Organisation
+from observatory.platform.telescopes.snapshot_telescope import SnapshotRelease, SnapshotTelescope
+from observatory.platform.utils.airflow_utils import AirflowVars, AirflowConns
+from observatory.platform.utils.template_utils import upload_files_from_list
+from observatory.platform.utils.telescope_utils import make_dag_id, make_sftp_connection
+
+class OnixRelease(SnapshotRelease):
+    RELEASE_INFO = 'releases'
+    DOWNLOAD_FILES_REGEX = r"\d{8}[_A-Z]+\.xml"
+    TRANSFORM_FILES_REGEX = "full.jsonl"
+
+    def __init__(self, dag_id: str, release_date: Pendulum, file_name: str, organisation: Organisation):
+        """ Construct an OnixRelease.
+
+        :param release_date: the release date.
+        :param file_name: the ONIX file name.
+        :param organisation: the Organisation.
+        """
+
+        super().__init__(dag_id, release_date, self.DOWNLOAD_FILES_REGEX, None, self.TRANSFORM_FILES_REGEX)
+        self.organisation = organisation
+        self.file_name = file_name
+
+    @property
+    def sftp_home(self):
+        """ The organisation's SFTP home folder.
+
+        :return: path to folder.
+        """
+
+        return sftp_home(self.organisation.name)
+
+    @property
+    def sftp_upload_file(self):
+        """ The organisation's SFTP upload folder.
+
+        :return: path to folder.
+        """
+
+        return os.path.join(self.sftp_home, 'upload', self.file_name)
+
+    @property
+    def sftp_in_progress_file(self):
+        """ The organisation's SFTP in_progress folder.
+
+        :return: path to folder.
+        """
+
+        return os.path.join(self.sftp_home, 'in_progress', self.file_name)
+
+    @property
+    def sftp_finished_file(self):
+        """ The organisation's SFTP finished folder.
+
+        :return: path to folder.
+        """
+
+        return os.path.join(self.sftp_home, 'finished', self.file_name)
+
+    @property
+    def download_file(self) -> str:
+        """ Get the path to the downloaded file.
+
+        :return: the file path.
+        """
+
+        return os.path.join(self.download_folder, self.file_name)
+
+    def move_files_to_in_progress(self):
+        """ Move ONIX file to in-progress folder
+
+        :return: None.
+        """
+
+        with make_sftp_connection() as sftp:
+            sftp.rename(self.sftp_upload_file, self.sftp_in_progress_file)
+
+    def download(self):
+        """ Downloads an individual ONIX release from the SFTP server.
+
+        :return: None.
+        """
+
+        with make_sftp_connection() as sftp:
+            sftp.get(self.sftp_in_progress_file, localpath=self.download_file)
+
+    def move_files_to_finished(self):
+        """ Move ONIX file to finished folder
+
+        :return: None.
+        """
+
+        with make_sftp_connection() as sftp:
+            sftp.rename(self.sftp_in_progress_file, self.sftp_finished_file)
+
+
+def sftp_home(organisation_name: str) -> str:
+    """ Make the SFTP home folder for an organisation.
+
+    :param organisation_name: the organisation name.
+    :return: the path to the folder.
+    """
+
+    return os.path.join('/telescopes', 'onix', organisation_name.strip().replace(' ', '_').lower())
+
+
+def list_release_info(sftp_upload_folder: str) -> List[Dict]:
+    """ List the ONIX release info, a release date and a file name for each release.
+
+    :param sftp_upload_folder: the SFTP upload folder.
+    :return: the release information.
+    """
+
+    results = []
+    sftp = make_sftp_connection()
+    files = sftp.listdir(sftp_upload_folder)
+    for file_name in files:
+        if re.match(OnixRelease.DOWNLOAD_FILES_REGEX, file_name):
+            date_str = file_name[:8]
+            release_date = pendulum.strptime(date_str, '%Y%m%d')
+            results.append({
+                'release_date': release_date,
+                'file_name': file_name
+            })
+    sftp.close()
+    return results
+
+
+class OnixTelescope(SnapshotTelescope):
+    DAG_ID_PREFIX = 'onix'
+
+    def __init__(self, organisation: Organisation, dag_id: Optional[str] = None,
+                 start_date: datetime = datetime(2021, 3, 28), schedule_interval: str = '@weekly',
+                 dataset_id: str = 'onix', source_format: str = SourceFormat.NEWLINE_DELIMITED_JSON,
+                 catchup: bool = False, airflow_vars: List = None, airflow_conns: List = None):
+        """ Construct an OnixTelescope instance.
+
+        :param organisation: the Organisation the ONIX DAG will process.
+        :param dag_id: the id of the DAG, by default this is automatically generated based on the DAG_ID_PREFIX
+        and the organisation name.
+        :param start_date: the start date of the DAG.
+        :param schedule_interval: the schedule interval of the DAG.
+        :param dataset_id: the BigQuery dataset id.
+        :param source_format: the format of the data to load into BigQuery.
+        :param catchup: whether to catchup the DAG or not.
+        :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow
+        """
+
+        if airflow_vars is None:
+            airflow_vars = [AirflowVars.DATA_PATH, AirflowVars.PROJECT_ID, AirflowVars.DATA_LOCATION,
+                            AirflowVars.DOWNLOAD_BUCKET, AirflowVars.TRANSFORM_BUCKET]
+
+        if airflow_conns is None:
+            airflow_conns = [AirflowConns.SFTP_SERVICE]
+
+        if dag_id is None:
+            dag_id = make_dag_id(self.DAG_ID_PREFIX, organisation.name)
+
+        dataset_description = f'{organisation.name} ONIX feeds'
+
+        super().__init__(dag_id, start_date, schedule_interval, dataset_id,
+                         source_format=source_format,
+                         dataset_description=dataset_description,
+                         catchup=catchup,
+                         airflow_vars=airflow_vars,
+                         airflow_conns=airflow_conns)
+        self.organisation = organisation
+        self.add_setup_task(self.check_dependencies)
+        self.add_setup_task(self.list_release_info)
+        self.add_task(self.move_files_to_in_progress)
+        self.add_task(self.download)
+        self.add_task(self.upload_downloaded)
+        self.add_task(self.move_files_to_finished)
+        self.add_task(self.cleanup)
+
+    def list_release_info(self, **kwargs):
+        """ Lists all ONIX releases and publishes their file names as an XCom.
+
+        :param kwargs: the context passed from the BranchPythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html
+        for a list of the keyword arguments that are passed to this argument.
+        :return: the identifier of the task to execute next.
+        """
+
+        # List release dates
+        sftp_upload_folder = os.path.join(sftp_home(self.organisation.name), 'upload')
+        release_info = list_release_info(sftp_upload_folder)
+
+        # Publish XCom
+        continue_dag = len(release_info)
+        if continue_dag:
+            ti: TaskInstance = kwargs['ti']
+            ti.xcom_push(OnixTelescope.RELEASE_INFO, release_info, kwargs['execution_date'])
+
+        return continue_dag
+
+    def make_release(self, **kwargs) -> List[OnixRelease]:
+        """ Make release instances. The release is passed as an argument to the function (TelescopeFunction) that is
+        called in 'task_callable'.
+
+        :param kwargs: the context passed from the PythonOperator. See
+        https://airflow.apache.org/docs/stable/macros-ref.html for a list of the keyword arguments that are
+        passed to this argument.
+        :return: a list of GeonamesRelease instances.
+        """
+
+        ti: TaskInstance = kwargs['ti']
+        records = ti.xcom_pull(key=OnixRelease.RELEASE_INFO,
+                               task_ids=self.list_release_info.__name__,
+                               include_prior_dates=False)
+        releases = []
+        for record in records:
+            release_date = record['release_date']
+            file_name = record['file_name']
+            releases.append(OnixRelease(self.dag_id, release_date, file_name, self.organisation))
+        return releases
+
+    def move_files_to_in_progress(self, releases: List[OnixRelease], **kwargs):
+        """ Move ONIX files to SFTP in-progress folder.
+
+        :param releases: a list of ONIX releases.
+        :return: None.
+        """
+
+        for release in releases:
+            release.move_files_to_in_progress()
+
+    def download(self, releases: List[OnixRelease], **kwargs):
+        """ Task to download the ONIX releases.
+
+        :param releases: a list of ONIX releases.
+        :return: None.
+        """
+
+        for release in releases:
+            release.download()
+
+    def upload_downloaded(self, releases: List[OnixRelease], **kwargs):
+        """ Task to upload the downloaded ONIX releases.
+
+        :param releases: a list of ONIX releases.
+        :return: None.
+        """
+
+        for release in releases:
+            upload_files_from_list(release.download_files, release.download_bucket)
+
+    def move_files_to_finished(self, releases: List[OnixRelease], **kwargs):
+        """ Move ONIX files to SFTP finished folder.
+
+        :param releases: a list of ONIX releases.
+        :return: None.
+        """
+
+        for release in releases:
+            release.move_files_to_finished()

--- a/observatory-platform/observatory/platform/docker/Dockerfile.observatory.jinja2
+++ b/observatory-platform/observatory/platform/docker/Dockerfile.observatory.jinja2
@@ -22,7 +22,10 @@ ARG OBSERVATORY_HOME=/opt/observatory
 
 # Install git which is required when installing dependencies with pip
 USER root
-RUN apt-get update -yqq && apt-get install git build-essential pigz mawk unzip -y
+RUN apt-get update -yqq && apt-get install git build-essential pigz mawk unzip openjdk-11-jre -y
+
+# Set Java home
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 # Change airflow user's user id to the hosts user id
 RUN usermod -u ${HOST_USER_ID} airflow
@@ -33,12 +36,16 @@ RUN groupmod -g ${HOST_GROUP_ID} airflow
 # Install Python dependencies for Observatory Platform as airflow user
 USER airflow
 
-# Set working directory to observatory-platform
+# Install observatory api requirements
+ARG WORKING_DIR=${OBSERVATORY_HOME}/observatory-api
+WORKDIR ${WORKING_DIR}
+COPY ./requirements.observatory-api.txt requirements.txt
+RUN pip3 install -r requirements.txt --user
+
+# Install observatory platform requirements
 ARG WORKING_DIR=${OBSERVATORY_HOME}/observatory-platform
 WORKDIR ${WORKING_DIR}
-
-# Install observatory platform
-COPY ./requirements.txt requirements.txt
+COPY ./requirements.observatory-platform.txt requirements.txt
 RUN pip3 install -r requirements.txt --user
 
 # Install dependencies for DAGs projects for local projects and intall entire projects for git and PyPI based projects

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -30,7 +30,8 @@ version: '3.8'
 {%- set host_logs_path="${HOST_LOGS_PATH}" -%}
 {%- set host_dags_path="${HOST_DAGS_PATH}" -%}
 {%- set host_data_path="${HOST_DATA_PATH}" -%}
-{%- set host_package_path="${HOST_PACKAGE_PATH}" -%}
+{%- set host_platform_package_path="${HOST_PLATFORM_PACKAGE_PATH}" -%}
+{%- set host_api_package_path="${HOST_API_PACKAGE_PATH}" -%}
 {%- set host_postgres_path="${HOST_POSTGRES_PATH}" -%}
 {%- set google_application_credentials="${HOST_GOOGLE_APPLICATION_CREDENTIALS}" -%}
 
@@ -45,7 +46,8 @@ version: '3.8'
 {%- set host_logs_path="/opt/airflow/logs" -%}
 {%- set host_dags_path="/opt/observatory-platform/observatory/platform/dags" -%}
 {%- set host_data_path="/opt/observatory/data" -%}
-{%- set host_package_path="/opt/observatory-platform" -%}
+{%- set host_platform_package_path="/opt/observatory-platform" -%}
+{%- set host_api_package_path="/opt/observatory-api" -%}
 {%- set google_application_credentials="/opt/observatory/google_application_credentials.json" -%}
 
 {%- endif -%}
@@ -102,7 +104,8 @@ x-volumes: &volumes
   - "{{ host_logs_path }}:/opt/airflow/logs"
   - "{{ host_dags_path }}:/opt/airflow/dags"
   - "{{ host_data_path }}:/opt/observatory/data"
-  - "{{ host_package_path }}:/opt/observatory-platform"
+  - "{{ host_platform_package_path }}:/opt/observatory-platform"
+  - "{{ host_api_package_path }}:/opt/observatory-api"
   # Volume mappings for DAGs projects:
   {%- for project in config.dags_projects %}
   {%- if project.type == 'local' %}

--- a/observatory-platform/observatory/platform/docker/entrypoint-airflow.sh.jinja2
+++ b/observatory-platform/observatory/platform/docker/entrypoint-airflow.sh.jinja2
@@ -27,14 +27,23 @@ if [ $1="webserver" ]; then
   airflow users create -r Admin -u ${AIRFLOW_UI_USER_EMAIL} -e ${AIRFLOW_UI_USER_EMAIL} -f Observatory -l Admin -p ${AIRFLOW_UI_USER_PASSWORD}
 fi
 
+# Set PBR version for installing packages
+export PBR_VERSION=0.0.1
+
+###############################
+# Install observatory-api
+###############################
+# Enter observatory platform folder
+cd /opt/observatory-api
+
+# Install the Observatory API Python package
+pip3 install -e . --user
+
 ###############################
 # Install observatory-platform
 ###############################
 # Enter observatory platform folder
 cd /opt/observatory-platform
-
-# Set PBR version for installing packages
-export PBR_VERSION=0.0.1
 
 # Install the Observatory Platform Python package
 pip3 install -e . --user

--- a/observatory-platform/observatory/platform/platform_builder.py
+++ b/observatory-platform/observatory/platform/platform_builder.py
@@ -89,7 +89,8 @@ class PlatformBuilder:
         self.host_uid = host_uid
         self.host_gid = host_gid
         self.debug = debug
-        self.package_path = module_file_path('observatory.platform', nav_back_steps=-3)
+        self.platform_package_path = module_file_path('observatory.platform', nav_back_steps=-3)
+        self.api_package_path = module_file_path('observatory.api', nav_back_steps=-3)
         self.docker_build_path = os.path.join(build_path, 'docker')
         os.makedirs(self.docker_build_path, exist_ok=True)
         self.redis_port = redis_port
@@ -225,9 +226,14 @@ class PlatformBuilder:
         :return: None.
         """
 
-        # Copy observatory requirements.txt
-        input_file = os.path.join(self.package_path, 'requirements.txt')
-        output_file = os.path.join(self.docker_build_path, 'requirements.txt')
+        # Copy observatory platform requirements.txt
+        input_file = os.path.join(self.platform_package_path, 'requirements.txt')
+        output_file = os.path.join(self.docker_build_path, 'requirements.observatory-platform.txt')
+        shutil.copy(input_file, output_file)
+
+        # Copy observatory api requirements.txt
+        input_file = os.path.join(self.api_package_path, 'requirements.txt')
+        output_file = os.path.join(self.docker_build_path, 'requirements.observatory-api.txt')
         shutil.copy(input_file, output_file)
 
         # Copy all project requirements files for local projects
@@ -256,7 +262,8 @@ class PlatformBuilder:
         env['HOST_DAGS_PATH'] = self.dags_path
         env['HOST_DATA_PATH'] = self.data_path
         env['HOST_POSTGRES_PATH'] = self.postgres_path
-        env['HOST_PACKAGE_PATH'] = self.package_path
+        env['HOST_PLATFORM_PACKAGE_PATH'] = self.platform_package_path
+        env['HOST_API_PACKAGE_PATH'] = self.api_package_path
         env['HOST_REDIS_PORT'] = str(self.redis_port)
         env['HOST_FLOWER_UI_PORT'] = str(self.flower_ui_port)
         env['HOST_AIRFLOW_UI_PORT'] = str(self.airflow_ui_port)

--- a/observatory-platform/observatory/platform/telescopes/snapshot_telescope.py
+++ b/observatory-platform/observatory/platform/telescopes/snapshot_telescope.py
@@ -88,11 +88,14 @@ class SnapshotTelescope(Telescope):
         :param kwargs:
         :return:
         """
+
         for release in releases:
             upload_files_from_list(release.transform_files, release.transform_bucket)
 
     def bq_load(self, releases: List[SnapshotRelease], **kwargs):
         """ Task to load each transformed release to BigQuery.
+
+        The table_id is set to the file name without the extension.
 
         :param releases: a list of releases.
         :return: None.

--- a/observatory-platform/observatory/platform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform_builder.py
@@ -50,7 +50,8 @@ class TerraformBuilder:
         self.backend_type = BackendType.terraform
         self.config_path = config_path
         self.build_path = build_path
-        self.package_path = module_file_path('observatory.platform', nav_back_steps=-3)
+        self.platform_package_path = module_file_path('observatory.platform', nav_back_steps=-3)
+        self.api_package_path = module_file_path('observatory.api', nav_back_steps=-3)
         self.terraform_path = module_file_path('observatory.platform.terraform')
         self.api_package_path = module_file_path('observatory.api', nav_back_steps=-3)
         self.api_path = module_file_path('observatory.api.server')
@@ -102,11 +103,11 @@ class TerraformBuilder:
 
         # Copy Observatory Platform
         destination_path = os.path.join(self.packages_build_path, 'observatory-platform')
-        copy_dir(self.package_path, destination_path, ignore)
+        copy_dir(self.platform_package_path, destination_path, ignore)
 
         # Copy Observatory API
         destination_path = os.path.join(self.packages_build_path, 'observatory-api')
-        copy_dir(self.package_path, destination_path, ignore)
+        copy_dir(self.api_package_path, destination_path, ignore)
 
         # Copy DAGs projects
         for dags_project in self.config.dags_projects:

--- a/observatory-platform/observatory/platform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform_builder.py
@@ -104,6 +104,10 @@ class TerraformBuilder:
         destination_path = os.path.join(self.packages_build_path, 'observatory-platform')
         copy_dir(self.package_path, destination_path, ignore)
 
+        # Copy Observatory API
+        destination_path = os.path.join(self.packages_build_path, 'observatory-api')
+        copy_dir(self.package_path, destination_path, ignore)
+
         # Copy DAGs projects
         for dags_project in self.config.dags_projects:
             destination_path = os.path.join(self.packages_build_path, dags_project.package_name)

--- a/observatory-platform/observatory/platform/utils/gc_utils.py
+++ b/observatory-platform/observatory/platform/utils/gc_utils.py
@@ -136,7 +136,8 @@ def load_bigquery_table(uri: str, dataset_id: str, location: str, table: str, sc
                         csv_allow_quoted_newlines: bool = False, csv_skip_leading_rows: int = 0,
                         partition: bool = False, partition_field: Union[None, str] = None,
                         partition_type: str = bigquery.TimePartitioningType.DAY, require_partition_filter=True,
-                        write_disposition: str = bigquery.WriteDisposition.WRITE_TRUNCATE, description: str = '') -> bool:
+                        write_disposition: str = bigquery.WriteDisposition.WRITE_TRUNCATE, description: str = '',
+                        project_id: str = None) -> bool:
     """ Load a BigQuery table from an object on Google Cloud Storage.
 
     :param uri: the uri of the object to load from Google Cloud Storage into BigQuery.
@@ -155,6 +156,7 @@ def load_bigquery_table(uri: str, dataset_id: str, location: str, table: str, sc
     :param require_partition_filter: whether the partition filter is required or not when querying the table.
     :param write_disposition: whether to append, overwrite or throw an error when data already exists in the table.
     :param description: the description of the table.
+    :param project_id: Google Cloud project id.
     Default is to overwrite.
     :return:
     """
@@ -167,7 +169,9 @@ def load_bigquery_table(uri: str, dataset_id: str, location: str, table: str, sc
     logging.info(f"{func_name}: load bigquery table {msg}")
 
     client = bigquery.Client()
-    dataset = client.dataset(dataset_id)
+    if project_id is None:
+        project_id = client.project
+    dataset = bigquery.Dataset(f'{project_id}.{dataset_id}')
 
     # Create load job
     job_config = LoadJobConfig()

--- a/observatory-platform/observatory/platform/utils/template_utils.py
+++ b/observatory-platform/observatory/platform/utils/template_utils.py
@@ -267,6 +267,7 @@ def bq_load_shard_v2(project_id: str, transform_bucket: str, transform_blob: str
     logging.info(f"URI: {uri}")
 
     success = load_bigquery_table(uri, dataset_id, dataset_location, table_id, schema_file_path, source_format,
+                                  project_id=project_id,
                                   **load_bigquery_table_kwargs)
     if not success:
         raise AirflowException()

--- a/tests/fixtures/telescopes/onix/20210330_CURTINPRESS_ONIX.xml
+++ b/tests/fixtures/telescopes/onix/20210330_CURTINPRESS_ONIX.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dcc9fee554f514bef85543f91ce79d450e19b8a3d59399361d04e537a173bf6
+size 7704

--- a/tests/fixtures/telescopes/onix/20210330_CURTINPRESS_ONIX.xml
+++ b/tests/fixtures/telescopes/onix/20210330_CURTINPRESS_ONIX.xml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4dcc9fee554f514bef85543f91ce79d450e19b8a3d59399361d04e537a173bf6
-size 7704
+oid sha256:7c65be82816f49e14321b2026cace0e42fd852a3637a520f60e1261915a92e11
+size 8127

--- a/tests/observatory/dags/telescopes/test_onix.py
+++ b/tests/observatory/dags/telescopes/test_onix.py
@@ -1,0 +1,189 @@
+# Copyright 2021 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: James Diprose
+
+import os
+import shutil
+
+import observatory.api.server.orm as orm
+import pendulum
+from airflow.models.connection import Connection
+from observatory.api.client.identifiers import TelescopeTypes
+from observatory.api.client.model.organisation import Organisation
+from observatory.dags.telescopes.onix import OnixTelescope
+from observatory.platform.utils.airflow_utils import AirflowConns
+from observatory.platform.utils.file_utils import _hash_file
+from observatory.platform.utils.template_utils import telescope_path, SubFolder, blob_name
+from observatory.platform.utils.test_utils import (ObservatoryEnvironment, ObservatoryTestCase, SftpServer,
+                                                   test_fixtures_path)
+
+
+class TestOnix(ObservatoryTestCase):
+    """ Tests for the ONIX telescope """
+
+    def __init__(self, *args, **kwargs):
+        """ Constructor which sets up variables used by tests.
+
+        :param args: arguments.
+        :param kwargs: keyword arguments.
+        """
+
+        super(TestOnix, self).__init__(*args, **kwargs)
+        self.host = "localhost"
+        self.api_port = 5000
+        self.sftp_port = 3373
+        self.project_id = os.getenv('TESTS_GOOGLE_CLOUD_PROJECT_ID')
+        self.data_location = os.getenv('TESTS_DATA_LOCATION')
+        self.organisation_name = 'Curtin Press'
+        self.organisation_folder = 'curtin_press'
+
+    def test_dag_structure(self):
+        """ Test that the ONIX DAG has the correct structure.
+
+        :return: None
+        """
+
+        organisation = Organisation(name=self.organisation_name)
+        dag = OnixTelescope(organisation).make_dag()
+        self.assert_dag_structure({
+            'check_dependencies': ['list_release_info'],
+            'list_release_info': ['move_files_to_in_progress'],
+            'move_files_to_in_progress': ['download'],
+            'download': ['upload_downloaded'],
+            'upload_downloaded': ['move_files_to_finished'],
+            'move_files_to_finished': ['cleanup'],
+            'cleanup': []
+        }, dag)
+
+    def test_dag_load(self):
+        """ Test that the Geonames DAG can be loaded from a DAG bag.
+
+        :return: None
+        """
+
+        env = ObservatoryEnvironment(self.project_id, self.data_location,
+                                     api_host=self.host, api_port=self.api_port)
+        with env.create():
+            # Add Observatory API connection
+            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API,
+                              uri=f'http://:password@{self.host}:{self.api_port}')
+            env.add_connection(conn)
+
+            # Add an ONIX telescope
+            dt = pendulum.utcnow()
+            telescope_type = orm.TelescopeType(name='ONIX Telescope',
+                                               type_id=TelescopeTypes.onix,
+                                               created=dt,
+                                               modified=dt)
+            env.api_session.add(telescope_type)
+            organisation = orm.Organisation(name='Curtin Press',
+                                            created=dt,
+                                            modified=dt)
+            env.api_session.add(organisation)
+            telescope = orm.Telescope(name='Curtin Press ONIX Telescope',
+                                      telescope_type=telescope_type,
+                                      organisation=organisation,
+                                      modified=dt,
+                                      created=dt)
+            env.api_session.add(telescope)
+            env.api_session.commit()
+
+            self.assert_dag_load('onix_curtin_press')
+
+    def test_telescope(self):
+        """ Test the ONIX telescope end to end.
+
+        :return: None.
+        """
+
+        # Setup Observatory environment
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        sftp_server = SftpServer(host=self.host, port=self.sftp_port)
+        dataset_id = env.add_dataset()
+
+        # Create the Observatory environment and run tests
+        with env.create():
+            with sftp_server.create() as sftp_root:
+                # Setup Telescope
+                execution_date = pendulum.datetime(year=2021, month=3, day=31)
+                org = Organisation(name=self.organisation_name,
+                                   gcp_project_id=self.project_id,
+                                   gcp_download_bucket=env.download_bucket,
+                                   gcp_transform_bucket=env.transform_bucket)
+                telescope = OnixTelescope(org, dataset_id=dataset_id)
+                dag = telescope.make_dag()
+
+                # Release settings
+                release_date = pendulum.datetime(year=2021, month=3, day=30)
+                release_id = f'{telescope.dag_id}_{release_date.strftime("%Y_%m_%d")}'
+                download_folder = telescope_path(SubFolder.downloaded, telescope.dag_id, release_id)
+                extract_folder = telescope_path(SubFolder.extracted, telescope.dag_id, release_id)
+                transform_folder = telescope_path(SubFolder.transformed, telescope.dag_id, release_id)
+
+                # Add SFTP connection
+                conn = Connection(conn_id=AirflowConns.SFTP_SERVICE,
+                                  uri=f'ssh://:password@{self.host}:{self.sftp_port}')
+                env.add_connection(conn)
+
+                # Test that all dependencies are specified: no error should be thrown
+                env.run_task(dag, telescope.check_dependencies.__name__, execution_date)
+
+                # Add ONIX file to SFTP server
+                onix_file_name = '20210330_CURTINPRESS_ONIX.xml'
+                onix_test_file = os.path.join(test_fixtures_path('telescopes', 'onix'), onix_file_name)
+                org_path = os.path.join(sftp_root, 'telescopes', 'onix', self.organisation_folder)
+                upload_path = os.path.join(org_path, 'upload')
+                os.makedirs(upload_path, exist_ok=True)
+                onix_file_dst = os.path.join(upload_path, onix_file_name)
+                shutil.copy(onix_test_file, onix_file_dst)
+
+                # Get release info from SFTP server and check that the correct release info is returned via Xcom
+                ti = env.run_task(dag, telescope.list_release_info.__name__, execution_date)
+                expected_release_info = [
+                    {
+                        'release_date': release_date,
+                        'file_name': onix_file_name
+                    }
+                ]
+                release_info = ti.xcom_pull(key=OnixTelescope.RELEASE_INFO,
+                                            task_ids=telescope.list_release_info.__name__,
+                                            include_prior_dates=False)
+                self.assertEqual(expected_release_info, release_info)
+
+                # Test move file to in progress
+                env.run_task(dag, telescope.move_files_to_in_progress.__name__, execution_date)
+                in_progress_path = os.path.join(org_path, 'in_progress', onix_file_name)
+                self.assertFalse(os.path.isfile(onix_file_dst))
+                self.assertTrue(os.path.isfile(in_progress_path))
+
+                # Test download
+                env.run_task(dag, telescope.download.__name__, execution_date)
+                download_file_path = os.path.join(download_folder, onix_file_name)
+                expected_file_hash = _hash_file(onix_test_file, algorithm='md5')
+                self.assert_file_integrity(download_file_path, expected_file_hash, 'md5')
+
+                # Test upload downloaded
+                env.run_task(dag, telescope.upload_downloaded.__name__, execution_date)
+                self.assert_blob_integrity(env.download_bucket, blob_name(download_file_path), download_file_path)
+
+                # Test move files to finished
+                env.run_task(dag, telescope.move_files_to_finished.__name__, execution_date)
+                finished_path = os.path.join(org_path, 'finished', onix_file_name)
+                self.assertFalse(os.path.isfile(in_progress_path))
+                self.assertTrue(os.path.isfile(finished_path))
+
+                # Test cleanup
+                env.run_task(dag, telescope.cleanup.__name__, execution_date)
+                self.assert_cleanup(download_folder, extract_folder, transform_folder)

--- a/tests/observatory/dags/telescopes/test_onix.py
+++ b/tests/observatory/dags/telescopes/test_onix.py
@@ -27,7 +27,7 @@ from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import _hash_file
 from observatory.platform.utils.template_utils import telescope_path, SubFolder, blob_name
 from observatory.platform.utils.test_utils import (ObservatoryEnvironment, ObservatoryTestCase, SftpServer,
-                                                   test_fixtures_path)
+                                                   test_fixtures_path, module_file_path)
 
 
 class TestOnix(ObservatoryTestCase):
@@ -100,7 +100,8 @@ class TestOnix(ObservatoryTestCase):
             env.api_session.add(telescope)
             env.api_session.commit()
 
-            self.assert_dag_load('onix_curtin_press')
+            dag_file = os.path.join(module_file_path('observatory.dags.dags'), 'onix.py')
+            self.assert_dag_load('onix_curtin_press', dag_file)
 
     def test_telescope(self):
         """ Test the ONIX telescope end to end.

--- a/tests/observatory/dags/telescopes/test_onix.py
+++ b/tests/observatory/dags/telescopes/test_onix.py
@@ -120,8 +120,9 @@ class TestOnix(ObservatoryTestCase):
         dataset_id = env.add_dataset()
 
         # Create the Observatory environment and run tests
-        with sftp_server.create() as sftp_root:
-            with env.create():
+
+        with env.create():
+            with sftp_server.create() as sftp_root:
                 # Setup Telescope
                 execution_date = pendulum.datetime(year=2021, month=3, day=31)
                 org = Organisation(name=self.organisation_name,

--- a/tests/observatory/platform/test_platform_builder.py
+++ b/tests/observatory/platform/test_platform_builder.py
@@ -152,7 +152,8 @@ class TestPlatformBuilder(unittest.TestCase):
 
             # Test that the expected files have been written
             build_file_names = ['docker-compose.observatory.yml', 'Dockerfile.observatory', 'elasticsearch.yml',
-                                'entrypoint-airflow.sh', 'entrypoint-root.sh', 'requirements.txt']
+                                'entrypoint-airflow.sh', 'entrypoint-root.sh', 'requirements.observatory-platform.txt',
+                                'requirements.observatory-api.txt']
             for file_name in build_file_names:
                 path = os.path.join(self.build_path, 'docker', file_name)
                 self.assertTrue(os.path.isfile(path))
@@ -173,7 +174,8 @@ class TestPlatformBuilder(unittest.TestCase):
                 'HOST_DAGS_PATH': self.dags_path,
                 'HOST_DATA_PATH': self.data_path,
                 'HOST_POSTGRES_PATH': self.postgres_path,
-                'HOST_PACKAGE_PATH': module_file_path('observatory.platform', nav_back_steps=-3),
+                'HOST_PLATFORM_PACKAGE_PATH': module_file_path('observatory.platform', nav_back_steps=-3),
+                'HOST_API_PACKAGE_PATH': module_file_path('observatory.api', nav_back_steps=-3),
                 'HOST_REDIS_PORT': str(REDIS_PORT),
                 'HOST_FLOWER_UI_PORT': str(FLOWER_UI_PORT),
                 'HOST_AIRFLOW_UI_PORT': str(AIRFLOW_UI_PORT),
@@ -215,7 +217,8 @@ class TestPlatformBuilder(unittest.TestCase):
                 'HOST_DAGS_PATH': self.dags_path,
                 'HOST_DATA_PATH': self.data_path,
                 'HOST_POSTGRES_PATH': self.postgres_path,
-                'HOST_PACKAGE_PATH': module_file_path('observatory.platform', nav_back_steps=-3),
+                'HOST_PLATFORM_PACKAGE_PATH': module_file_path('observatory.platform', nav_back_steps=-3),
+                'HOST_API_PACKAGE_PATH': module_file_path('observatory.api', nav_back_steps=-3),
                 'HOST_REDIS_PORT': str(REDIS_PORT),
                 'HOST_FLOWER_UI_PORT': str(FLOWER_UI_PORT),
                 'HOST_AIRFLOW_UI_PORT': str(AIRFLOW_UI_PORT),

--- a/tests/observatory/platform/test_terraform_builder.py
+++ b/tests/observatory/platform/test_terraform_builder.py
@@ -172,7 +172,8 @@ class TestTerraformBuilder(unittest.TestCase):
 
             # Test that the expected Docker files have been written
             build_file_names = ['docker-compose.observatory.yml', 'Dockerfile.observatory', 'elasticsearch.yml',
-                                'entrypoint-airflow.sh', 'entrypoint-root.sh', 'requirements.txt']
+                                'entrypoint-airflow.sh', 'entrypoint-root.sh', 'requirements.observatory-platform.txt',
+                                'requirements.observatory-api.txt']
             for file_name in build_file_names:
                 path = os.path.join(self.build_path, 'docker', file_name)
                 self.assertTrue(os.path.isfile(path))

--- a/tests/observatory/platform/test_terraform_builder.py
+++ b/tests/observatory/platform/test_terraform_builder.py
@@ -170,6 +170,12 @@ class TestTerraformBuilder(unittest.TestCase):
                 path = os.path.join(self.build_path, 'terraform', file_name)
                 self.assertTrue(os.path.isfile(path))
 
+            # Test that expected packages exists
+            packages = ['observatory-api', 'observatory-platform']
+            for package in packages:
+                path = os.path.join(self.build_path, 'packages', package)
+                self.assertTrue(os.path.exists(path))
+
             # Test that the expected Docker files have been written
             build_file_names = ['docker-compose.observatory.yml', 'Dockerfile.observatory', 'elasticsearch.yml',
                                 'entrypoint-airflow.sh', 'entrypoint-root.sh', 'requirements.observatory-platform.txt',
@@ -270,7 +276,8 @@ class TestTerraformBuilder(unittest.TestCase):
             args = ['docker', 'build', '.']
             print('Executing subprocess:')
 
-            proc: Popen = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cmd.api_package_path)
+            proc: Popen = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                           cwd=cmd.api_package_path)
             output, error = stream_process(proc, True)
 
             # Assert that the image built


### PR DESCRIPTION
This pull request adds the ONIX telescope. A DAG is created for each ONIX telescope that has been added via the Observatory REST API. Some of the code, e.g. bq_load, could be tidied up a bit and merged into the SnapshotTelscope, but I think this would be better done in another pull request, as we might need to change other telescopes as well.

JDK 11 has been added to the following so that ONIX parser can run (which is a java jar):
* Github Actions unit-tests.yml
* Dockerfile

The Docker related files and the local and Terraform platform builders have been modified to include the observatory-api package in the Docker builds.