### PR TITLE
Fix not using 'max_retries' for telescope template

### DIFF
--- a/observatory-platform/observatory/platform/telescopes/telescope.py
+++ b/observatory-platform/observatory/platform/telescopes/telescope.py
@@ -178,7 +178,8 @@ class Telescope(AbstractTelescope):
         self.default_args = {
             "owner": "airflow",
             "start_date": self.start_date,
-            'on_failure_callback': on_failure_callback
+            'on_failure_callback': on_failure_callback,
+            'retries': self.max_retries
         }
         self.description = self.__doc__
         self.dag = DAG(dag_id=self.dag_id, schedule_interval=self.schedule_interval, default_args=self.default_args,


### PR DESCRIPTION
Noticed that the default number of 'max_retries' that is set for the telescope template is not actually assigned to the task. Added the max_retries to default_args of task.