### PR TITLE
Fix for the Crossref Prefix type from FLOAT to STRING

### DIFF
--- a/observatory-dags/observatory/dags/database/schema/crossref_metadata_2021-01-01.json
+++ b/observatory-dags/observatory/dags/database/schema/crossref_metadata_2021-01-01.json
@@ -56,7 +56,7 @@
   {
     "mode": "NULLABLE",
     "name": "prefix",
-    "type": "FLOAT",
+    "type": "STRING",
     "description": "DOI prefix identifier of the form http://id.crossref.org/prefix/DOI_PREFIX."
   },
   {


### PR DESCRIPTION
The type for the ingest of the Crossref Prefix should be a STRING not a float. This fix changes that.

Closes #397