### PR TITLE
Update telescope template 'make_dag'

### DIFF
--- a/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
@@ -229,10 +229,7 @@ class OapenIrusUkTelescope(SnapshotTelescope):
 
         self.add_setup_task(self.check_dependencies)
         # create PythonOperator with task concurrency of 1, so tasks to create cloud function never run in parallel
-        self.add_task(partial(PythonOperator, task_id=self.create_cloud_function.__name__,
-                              python_callable=partial(self.task_callable, self.create_cloud_function),
-                              queue=self.queue, default_args=self.default_args, provide_context=True,
-                              task_concurrency=1))
+        self.add_task(self.create_cloud_function, task_concurrency=1)
         self.add_task(self.call_cloud_function)
         self.add_task(self.transfer)
         self.add_task(self.download_transform)

--- a/observatory-dags/observatory/dags/telescopes/oapen_metadata.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_metadata.py
@@ -135,9 +135,10 @@ class OapenMetadataTelescope(StreamTelescope):
                              self.transform,
                              self.upload_transformed,
                              self.bq_load_partition])
-        self.add_task_chain(self.make_operators([self.bq_delete_old,
-                                                 self.bq_append_new,
-                                                 self.cleanup]))
+        self.add_task_chain([self.bq_delete_old,
+                             self.bq_append_new,
+                             self.cleanup],
+                            trigger_rule='none_failed')
 
     def make_release(self, **kwargs) -> OapenMetadataRelease:
         # Make Release instance

--- a/observatory-platform/observatory/platform/telescopes/stream_telescope.py
+++ b/observatory-platform/observatory/platform/telescopes/stream_telescope.py
@@ -102,29 +102,6 @@ class StreamTelescope(Telescope):
         self.dataset_description = dataset_description
         self.table_descriptions = table_descriptions if table_descriptions else dict()
 
-    def make_operator(self, func: Callable) -> Callable:
-        """ Make a partial PythonOperator that can be attached to an airflow DAG. This PythonOperator differs from
-        the one used in the Telescope class in it's 'trigger_rule'.
-        :param func: A callable function
-        :return: The partial PythonOperator
-        """
-        operator = partial(PythonOperator, task_id=func.__name__, python_callable=partial(self.task_callable, func),
-                           queue=self.queue, trigger_rule='none_failed', default_args=self.default_args,
-                           provide_context=True)
-
-        return operator
-
-    def make_operators(self, funcs: List[Callable]) -> List[Callable]:
-        """ Make a partial PythonOperator for each function in the funcs list.
-        :param funcs: A list of callable functions
-        :return: A list of partial PythonOperators
-        """
-        operators = []
-        for func in funcs:
-            operator = self.make_operator(func)
-            operators.append(operator)
-        return operators
-
     def get_release_info(self, **kwargs) -> bool:
         """ Create a release instance and update the xcom value with the last start date.
         :param kwargs: The context passed from the PythonOperator.

--- a/observatory-platform/observatory/platform/utils/template_utils.py
+++ b/observatory-platform/observatory/platform/utils/template_utils.py
@@ -52,21 +52,6 @@ data_path = None
 test_data_path_val_ = None
 
 
-def is_partial_operator(func: Callable) -> bool:
-    """ Check if the function passed to 'make_dag' is a partial airflow operator.
-
-    :param func: Callable function.
-    :return: Whether function is a partial airflow operator
-    """
-    result = False
-    if isinstance(func, functools.partial):
-        try:
-            result = issubclass(func.func, BaseOperator)
-        except TypeError:
-            return result
-    return result
-
-
 def reset_variables():
     """ Rest Airflow variables.
 

--- a/tests/observatory/platform/test_telescope.py
+++ b/tests/observatory/platform/test_telescope.py
@@ -12,25 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: Tuan Chien
+# Author: Tuan Chien, Aniek Roelofs
 
 from datetime import datetime, timedelta, timezone
+from functools import partial
 
-from airflow.models.connection import Connection
+from airflow import DAG
+from airflow.models.baseoperator import BaseOperator
+from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
 from airflow.sensors.time_delta_sensor import TimeDeltaSensor
-from observatory.platform.telescopes.telescope import Telescope
-from observatory.platform.utils.airflow_utils import AirflowConns
-from observatory.platform.utils.gc_utils import bigquery_partitioned_table_id
-from observatory.platform.utils.template_utils import (
-    SubFolder,
-    blob_name,
-    telescope_path,
-)
+from observatory.platform.telescopes.telescope import Release, Telescope
 from observatory.platform.utils.test_utils import (
-    ObservatoryEnvironment,
     ObservatoryTestCase,
-    module_file_path,
-    test_fixtures_path,
 )
 
 
@@ -41,10 +34,92 @@ class MockTelescope(Telescope):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.dag_id = "dag_id"
+        self.release_id = "release_id"
 
-    def make_release(self) -> None:
-        """ Not needed. """
-        return None
+    def make_release(self) -> Release:
+        return Release(self.dag_id, self.release_id)
+
+    def setup_task(self, **kwargs) -> bool:
+        return True
+
+    def task(self, release: Release, **kwargs):
+        pass
+
+
+class TestTelescope(ObservatoryTestCase):
+    """ Tests the Telescope. """
+
+    def __init__(self, *args, **kwargs):
+        """Constructor which sets up variables used by tests.
+
+        :param args: arguments.
+        :param kwargs: keyword arguments.
+        """
+
+        super().__init__(*args, **kwargs)
+        self.dag_id = "dag_id"
+        self.start_date = datetime(2020, 1, 1)
+        self.schedule_interval = "@weekly"
+
+    def test_make_dag(self):
+        """ Test making DAG """
+        # Test adding tasks from Telescope methods
+        telescope = MockTelescope(self.dag_id, self.start_date, self.schedule_interval)
+        telescope.add_setup_task(telescope.setup_task)
+        telescope.add_task(telescope.task)
+        dag = telescope.make_dag()
+        self.assertIsInstance(dag, DAG)
+        self.assertEqual(2, len(dag.tasks))
+        for task in dag.tasks:
+            self.assertIsInstance(task, BaseOperator)
+
+        # Test adding tasks from partial Telescope methods
+        telescope = MockTelescope(self.dag_id, self.start_date, self.schedule_interval)
+        for i in range(2):
+            task = partial(telescope.task, somearg="test")
+            task.__name__ = f"task_{i}"
+            telescope.add_task(task)
+        for i in range(2):
+            setup_task = partial(telescope.task, somearg="test")
+            setup_task.__name__ = f"setup_task_{i}"
+            telescope.add_setup_task(setup_task)
+        dag = telescope.make_dag()
+        self.assertIsInstance(dag, DAG)
+        self.assertEqual(4, len(dag.tasks))
+        for task in dag.tasks:
+            self.assertIsInstance(task, BaseOperator)
+
+        # Test adding tasks from partial operators
+        telescope = MockTelescope(self.dag_id, self.start_date, self.schedule_interval)
+        func = telescope.setup_task
+        telescope.add_setup_task(
+            partial(
+                ShortCircuitOperator,
+                task_id=func.__name__,
+                python_callable=func,
+                queue=telescope.queue,
+                default_args=telescope.default_args,
+                provide_context=True,
+            )
+        )
+        func = telescope.task
+        telescope.add_task(
+            partial(
+                PythonOperator,
+                task_id=func.__name__,
+                python_callable=partial(telescope.task_callable, func),
+                queue=telescope.queue,
+                default_args=telescope.default_args,
+                provide_context=True,
+            )
+        )
+
+        dag = telescope.make_dag()
+        self.assertIsInstance(dag, DAG)
+        self.assertEqual(2, len(dag.tasks))
+        for task in dag.tasks:
+            self.assertIsInstance(task, BaseOperator)
 
 
 class TestAddSensorsTelescope(ObservatoryTestCase):
@@ -64,40 +139,58 @@ class TestAddSensorsTelescope(ObservatoryTestCase):
 
     def test_add_sensor(self):
         mt = MockTelescope(
-            dag_id="1", start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc), schedule_interval="daily"
+            dag_id="1",
+            start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+            schedule_interval="daily",
         )
         mt.add_task(self.dummy_func)
         tds = TimeDeltaSensor(
-            delta=timedelta(seconds=5), task_id="test", start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+            delta=timedelta(seconds=5),
+            task_id="test",
+            start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
         )
         tds2 = TimeDeltaSensor(
-            delta=timedelta(seconds=5), task_id="test2", start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+            delta=timedelta(seconds=5),
+            task_id="test2",
+            start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
         )
         mt.add_sensor(tds)
         mt.add_sensor(tds2)
         dag = mt.make_dag()
 
-        self.assert_dag_structure({"dummy_func": [], "test": ["dummy_func"], "test2": ["dummy_func"]}, dag)
+        self.assert_dag_structure(
+            {"dummy_func": [], "test": ["dummy_func"], "test2": ["dummy_func"]}, dag
+        )
 
     def test_add_sensors(self):
         mt = MockTelescope(
-            dag_id="1", start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc), schedule_interval="daily"
+            dag_id="1",
+            start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+            schedule_interval="daily",
         )
         mt.add_task(self.dummy_func)
         tds = TimeDeltaSensor(
-            delta=timedelta(seconds=5), task_id="test", start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+            delta=timedelta(seconds=5),
+            task_id="test",
+            start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
         )
         tds2 = TimeDeltaSensor(
-            delta=timedelta(seconds=5), task_id="test2", start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+            delta=timedelta(seconds=5),
+            task_id="test2",
+            start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
         )
         mt.add_sensors([tds, tds2])
         dag = mt.make_dag()
 
-        self.assert_dag_structure({"dummy_func": [], "test": ["dummy_func"], "test2": ["dummy_func"]}, dag)
+        self.assert_dag_structure(
+            {"dummy_func": [], "test": ["dummy_func"], "test2": ["dummy_func"]}, dag
+        )
 
     def test_add_sensors_empty(self):
         mt = MockTelescope(
-            dag_id="1", start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc), schedule_interval="daily"
+            dag_id="1",
+            start_date=datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+            schedule_interval="daily",
         )
         mt.add_task(self.dummy_func)
         mt.add_sensors([])


### PR DESCRIPTION
Add functionality to check whether a function part of 'setup_task_funcs' or 'task_funcs' is a partial operator.
Previously this only checked whether it is a partial function.

This makes it possible to pass on a partial function to the PythonOperator, instead of assuming that the partial function is an airflow operator.