### PR TITLE
Add functionality to use dag run in test environment.

### DIFF
--- a/observatory-platform/observatory/platform/telescopes/stream_telescope.py
+++ b/observatory-platform/observatory/platform/telescopes/stream_telescope.py
@@ -118,7 +118,7 @@ class StreamTelescope(Telescope):
         else:
             # set start date to end date of previous DAG run
             start_date = release_info[1]
-        end_date = pendulum.now('UTC') - timedelta(days=1)
+        end_date = pendulum.today('UTC') - timedelta(days=1)
         logging.info(f'Start date: {start_date}, end date: {end_date}, first release: {first_release}')
 
         ti.xcom_push(self.RELEASE_INFO, (start_date, end_date, first_release))

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -268,7 +268,7 @@ class ObservatoryEnvironment:
         # If dag or execution date are not set, get corresponding values from dag run
         if not (dag and execution_date):
             if self.dag_run is None:
-                raise Exception(
+                raise TypeError(
                     "Either dag and execution date should be set, or task should be run within a DagRun environment."
                 )
             dag = self.dag_run.dag

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -25,6 +25,7 @@ requests==2.20.0
 pyjwt==1.7.1
 idna==2.7
 marshmallow==2.21.0
+freezegun==1.1.*
 pysftp==0.2.*
 google-auth-oauthlib==0.4.*
 paramiko==2.7.*

--- a/tests/observatory/dags/telescopes/test_google_analytics.py
+++ b/tests/observatory/dags/telescopes/test_google_analytics.py
@@ -140,7 +140,7 @@ class TestGoogleAnalytics(ObservatoryTestCase):
             env.add_connection(conn)
 
             # Test that all dependencies are specified: no error should be thrown
-            env.run_task(dag, telescope.check_dependencies.__name__, execution_date)
+            env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
 
             # Use release to check tasks
             cron_schedule = dag.normalized_schedule_interval
@@ -149,7 +149,7 @@ class TestGoogleAnalytics(ObservatoryTestCase):
             release = GoogleAnalyticsRelease(telescope.dag_id, execution_date, end_date, organisation)
 
             # Test download_transform task
-            env.run_task(dag, telescope.download_transform.__name__, execution_date)
+            env.run_task(telescope.download_transform.__name__, dag, execution_date)
             for file in release.transform_files:
                 self.assertTrue(os.path.isfile(file))
                 # Use frozenset to test results are as expected, many dict transformations re-order items in dict
@@ -181,12 +181,12 @@ class TestGoogleAnalytics(ObservatoryTestCase):
                 self.assertEqual(2, len(actual_list))
 
             # Test that transformed file uploaded
-            env.run_task(dag, telescope.upload_transformed.__name__, execution_date)
+            env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
             for file in release.transform_files:
                 self.assert_blob_integrity(env.transform_bucket, blob_name(file), file)
 
             # Test that data loaded into BigQuery
-            env.run_task(dag, telescope.bq_load.__name__, execution_date)
+            env.run_task(telescope.bq_load.__name__, dag, execution_date)
             for file in release.transform_files:
                 table_id, _ = table_ids_from_path(file)
                 table_id = f'{self.project_id}.{telescope.dataset_id}.' \
@@ -197,7 +197,7 @@ class TestGoogleAnalytics(ObservatoryTestCase):
             # Test that all telescope data deleted
             download_folder, extract_folder, transform_folder = release.download_folder, release.extract_folder, \
                                                                 release.transform_folder
-            env.run_task(dag, telescope.cleanup.__name__, execution_date)
+            env.run_task(telescope.cleanup.__name__, dag, execution_date)
             self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
 

--- a/tests/observatory/dags/telescopes/test_google_books.py
+++ b/tests/observatory/dags/telescopes/test_google_books.py
@@ -26,8 +26,13 @@ from observatory.dags.telescopes.google_books import GoogleBooksRelease, GoogleB
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.telescope_utils import SftpFolders
 from observatory.platform.utils.template_utils import bigquery_partitioned_table_id, blob_name, table_ids_from_path
-from observatory.platform.utils.test_utils import (ObservatoryEnvironment, ObservatoryTestCase, SftpServer,
-                                                   module_file_path, test_fixtures_path)
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    SftpServer,
+    module_file_path,
+    test_fixtures_path,
+)
 
 from tests.observatory.test_utils import test_fixtures_path
 
@@ -36,7 +41,7 @@ class TestGoogleBooks(ObservatoryTestCase):
     """ Tests for the GoogleBooks telescope """
 
     def __init__(self, *args, **kwargs):
-        """ Constructor which sets up variables used by tests.
+        """Constructor which sets up variables used by tests.
         :param args: arguments.
         :param kwargs: keyword arguments.
         """
@@ -45,79 +50,81 @@ class TestGoogleBooks(ObservatoryTestCase):
         self.host = "localhost"
         self.api_port = 5000
         self.sftp_port = 3373
-        self.project_id = os.getenv('TEST_GCP_PROJECT_ID')
-        self.data_location = os.getenv('TEST_GCP_DATA_LOCATION')
-        self.organisation_name = 'anu-press'
-        self.organisation_folder = 'anu-press'
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+        self.organisation_name = "anu-press"
+        self.organisation_folder = "anu-press"
 
-        self.test_files = {'GoogleBooksTrafficReport_2020_02.csv':
-                               os.path.join(test_fixtures_path('telescopes', 'google_books'),
-                                            'GoogleBooksTrafficReport_2020_02.csv'),
-                           'GoogleSalesTransactionReport_2020_02.csv':
-                               os.path.join(test_fixtures_path('telescopes', 'google_books'),
-                                            'GoogleSalesTransactionReport_2020_02.csv')}
-        self.traffic_download_hash = 'db4dca44d5231e0c4e2ad95db41b79b6'
-        self.traffic_transform_hash = '63d7f678'
-        self.sales_download_hash = '9d1981aaffcb0249ee9a625a879d2f95'
-        self.sales_transform_hash = 'dc177c5a'
+        self.test_files = {
+            "GoogleBooksTrafficReport_2020_02.csv": os.path.join(
+                test_fixtures_path("telescopes", "google_books"), "GoogleBooksTrafficReport_2020_02.csv"
+            ),
+            "GoogleSalesTransactionReport_2020_02.csv": os.path.join(
+                test_fixtures_path("telescopes", "google_books"), "GoogleSalesTransactionReport_2020_02.csv"
+            ),
+        }
+        self.traffic_download_hash = "db4dca44d5231e0c4e2ad95db41b79b6"
+        self.traffic_transform_hash = "63d7f678"
+        self.sales_download_hash = "9d1981aaffcb0249ee9a625a879d2f95"
+        self.sales_transform_hash = "dc177c5a"
 
     def test_dag_structure(self):
-        """ Test that the Google Books DAG has the correct structure.
+        """Test that the Google Books DAG has the correct structure.
         :return: None
         """
 
         organisation = Organisation(name=self.organisation_name)
         dag = GoogleBooksTelescope(organisation).make_dag()
-        self.assert_dag_structure({
-            'check_dependencies': ['list_release_info'],
-            'list_release_info': ['move_files_to_in_progress'],
-            'move_files_to_in_progress': ['download'],
-            'download': ['upload_downloaded'],
-            'upload_downloaded': ['transform'],
-            'transform': ['upload_transformed'],
-            'upload_transformed': ['bq_load'],
-            'bq_load': ['move_files_to_finished'],
-            'move_files_to_finished': ['cleanup'],
-            'cleanup': []
-        }, dag)
+        self.assert_dag_structure(
+            {
+                "check_dependencies": ["list_release_info"],
+                "list_release_info": ["move_files_to_in_progress"],
+                "move_files_to_in_progress": ["download"],
+                "download": ["upload_downloaded"],
+                "upload_downloaded": ["transform"],
+                "transform": ["upload_transformed"],
+                "upload_transformed": ["bq_load"],
+                "bq_load": ["move_files_to_finished"],
+                "move_files_to_finished": ["cleanup"],
+                "cleanup": [],
+            },
+            dag,
+        )
 
     def test_dag_load(self):
-        """ Test that the Google Books DAG can be loaded from a DAG bag.
+        """Test that the Google Books DAG can be loaded from a DAG bag.
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location,
-                                     api_host=self.host, api_port=self.api_port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.api_port)
         with env.create():
             # Add Observatory API connection
-            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API,
-                              uri=f'http://:password@{self.host}:{self.api_port}')
+            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.api_port}")
             env.add_connection(conn)
 
             # Add a Google Books telescope
             dt = pendulum.utcnow()
-            telescope_type = orm.TelescopeType(name='Google Books Telescope',
-                                               type_id=TelescopeTypes.google_books,
-                                               created=dt,
-                                               modified=dt)
+            telescope_type = orm.TelescopeType(
+                name="Google Books Telescope", type_id=TelescopeTypes.google_books, created=dt, modified=dt
+            )
             env.api_session.add(telescope_type)
-            organisation = orm.Organisation(name='anu-press',
-                                            created=dt,
-                                            modified=dt)
+            organisation = orm.Organisation(name="anu-press", created=dt, modified=dt)
             env.api_session.add(organisation)
-            telescope = orm.Telescope(name='anu-press Google Books Telescope',
-                                      telescope_type=telescope_type,
-                                      organisation=organisation,
-                                      modified=dt,
-                                      created=dt)
+            telescope = orm.Telescope(
+                name="anu-press Google Books Telescope",
+                telescope_type=telescope_type,
+                organisation=organisation,
+                modified=dt,
+                created=dt,
+            )
             env.api_session.add(telescope)
             env.api_session.commit()
 
-            dag_file = os.path.join(module_file_path('observatory.dags.dags'), 'google_books.py')
-            self.assert_dag_load('google_books_anu-press', dag_file)
+            dag_file = os.path.join(module_file_path("observatory.dags.dags"), "google_books.py")
+            self.assert_dag_load("google_books_anu-press", dag_file)
 
     def test_telescope(self):
-        """ Test the Google Books telescope end to end.
+        """Test the Google Books telescope end to end.
 
         :return: None.
         """
@@ -132,16 +139,19 @@ class TestGoogleBooks(ObservatoryTestCase):
             with sftp_server.create() as sftp_root:
                 # Setup Telescope
                 execution_date = pendulum.datetime(year=2021, month=3, day=31)
-                org = Organisation(name=self.organisation_name,
-                                   gcp_project_id=self.project_id,
-                                   gcp_download_bucket=env.download_bucket,
-                                   gcp_transform_bucket=env.transform_bucket)
+                org = Organisation(
+                    name=self.organisation_name,
+                    gcp_project_id=self.project_id,
+                    gcp_download_bucket=env.download_bucket,
+                    gcp_transform_bucket=env.transform_bucket,
+                )
                 telescope = GoogleBooksTelescope(org, dataset_id=dataset_id)
                 dag = telescope.make_dag()
 
                 # Add SFTP connection
-                conn = Connection(conn_id=AirflowConns.SFTP_SERVICE,
-                                  uri=f'ssh://:password@{self.host}:{self.sftp_port}')
+                conn = Connection(
+                    conn_id=AirflowConns.SFTP_SERVICE, uri=f"ssh://:password@{self.host}:{self.sftp_port}"
+                )
                 env.add_connection(conn)
 
                 # Test that all dependencies are specified: no error should be thrown
@@ -156,14 +166,17 @@ class TestGoogleBooks(ObservatoryTestCase):
 
                 # Get release info from SFTP server and check that the correct release info is returned via Xcom
                 ti = env.run_task(telescope.list_release_info.__name__, dag, execution_date)
-                release_info = ti.xcom_pull(key=GoogleBooksTelescope.RELEASE_INFO,
-                                            task_ids=telescope.list_release_info.__name__,
-                                            include_prior_dates=False)
+                release_info = ti.xcom_pull(
+                    key=GoogleBooksTelescope.RELEASE_INFO,
+                    task_ids=telescope.list_release_info.__name__,
+                    include_prior_dates=False,
+                )
 
                 from collections import defaultdict
+
                 expected_release_files = []
                 for file_name, file_path in self.test_files.items():
-                    expected_release_date = pendulum.strptime(file_name[-11:].strip('.csv'), '%Y_%m')
+                    expected_release_date = pendulum.strptime(file_name[-11:].strip(".csv"), "%Y_%m")
                     expected_release_files.append(os.path.join(telescope.sftp_folders.in_progress, file_name))
                 expected_release_info = defaultdict(list, {expected_release_date: expected_release_files})
                 self.assertEqual(expected_release_info, release_info)
@@ -188,11 +201,11 @@ class TestGoogleBooks(ObservatoryTestCase):
                 env.run_task(telescope.download.__name__, dag, execution_date)
                 for release in releases:
                     for file in release.download_files:
-                        if 'traffic' in file:
+                        if "traffic" in file:
                             expected_file_hash = self.traffic_download_hash
                         else:
                             expected_file_hash = self.sales_download_hash
-                        self.assert_file_integrity(file, expected_file_hash, 'md5')
+                        self.assert_file_integrity(file, expected_file_hash, "md5")
 
                 # Test upload downloaded
                 env.run_task(telescope.upload_downloaded.__name__, dag, execution_date)
@@ -204,11 +217,11 @@ class TestGoogleBooks(ObservatoryTestCase):
                 env.run_task(telescope.transform.__name__, dag, execution_date)
                 for release in releases:
                     for file in release.transform_files:
-                        if 'traffic' in file:
+                        if "traffic" in file:
                             expected_file_hash = self.traffic_transform_hash
                         else:
                             expected_file_hash = self.sales_transform_hash
-                        self.assert_file_integrity(file, expected_file_hash, 'gzip_crc')
+                        self.assert_file_integrity(file, expected_file_hash, "gzip_crc")
 
                 # Test that transformed file uploaded
                 env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
@@ -221,7 +234,7 @@ class TestGoogleBooks(ObservatoryTestCase):
                 for release in releases:
                     for file in release.transform_files:
                         table_id, _ = table_ids_from_path(file)
-                        table_id = f'{self.project_id}.{telescope.dataset_id}.{bigquery_partitioned_table_id(table_id, release.release_date)}'
+                        table_id = f"{self.project_id}.{telescope.dataset_id}.{bigquery_partitioned_table_id(table_id, release.release_date)}"
                         expected_rows = 4
                         self.assert_table_integrity(table_id, expected_rows)
 
@@ -237,7 +250,10 @@ class TestGoogleBooks(ObservatoryTestCase):
                         self.assertTrue(os.path.isfile(finished_file))
 
                 # Test cleanup
-                download_folder, extract_folder, transform_folder = release.download_folder, release.extract_folder, \
-                                                                    release.transform_folder
+                download_folder, extract_folder, transform_folder = (
+                    release.download_folder,
+                    release.extract_folder,
+                    release.transform_folder,
+                )
                 env.run_task(telescope.cleanup.__name__, dag, execution_date)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)

--- a/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
+++ b/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
@@ -29,90 +29,101 @@ from googleapiclient.http import HttpMockSequence
 from observatory.api.client.identifiers import TelescopeTypes
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.server import orm
-from observatory.dags.telescopes.oapen_irus_uk import OapenIrusUkRelease, OapenIrusUkTelescope, cloud_function_exists, \
-    create_cloud_function, upload_source_code_to_bucket
+from observatory.dags.telescopes.oapen_irus_uk import (
+    OapenIrusUkRelease,
+    OapenIrusUkTelescope,
+    cloud_function_exists,
+    create_cloud_function,
+    upload_source_code_to_bucket,
+)
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.gc_utils import upload_file_to_cloud_storage
 from observatory.platform.utils.template_utils import bigquery_partitioned_table_id, blob_name, table_ids_from_path
-from observatory.platform.utils.test_utils import ObservatoryEnvironment, ObservatoryTestCase, module_file_path, \
-    random_id, test_fixtures_path
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    module_file_path,
+    random_id,
+    test_fixtures_path,
+)
 
 
 class TestOapenIrusUk(ObservatoryTestCase):
     """ Tests for the Oapen Irus Uk telescope """
 
     def __init__(self, *args, **kwargs):
-        """ Constructor which sets up variables used by tests.
+        """Constructor which sets up variables used by tests.
         :param args: arguments.
         :param kwargs: keyword arguments.
         """
         super(TestOapenIrusUk, self).__init__(*args, **kwargs)
-        self.project_id = os.getenv('TEST_GCP_PROJECT_ID')
-        self.data_location = os.getenv('TEST_GCP_DATA_LOCATION')
-        self.organisation_name = 'ucl_press'
-        self.extra = {'publisher_id': quote("UCL Press")}
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+        self.organisation_name = "ucl_press"
+        self.extra = {"publisher_id": quote("UCL Press")}
         self.host = "localhost"
         self.api_port = 5000
-        self.download_path = test_fixtures_path('telescopes', 'oapen_irus_uk', 'download_2021_02.jsonl.gz')
-        self.transform_hash = '07d2dd2e'
+        self.download_path = test_fixtures_path("telescopes", "oapen_irus_uk", "download_2021_02.jsonl.gz")
+        self.transform_hash = "07d2dd2e"
 
     def test_dag_structure(self):
-        """ Test that the Oapen Irus Uk DAG has the correct structure.
+        """Test that the Oapen Irus Uk DAG has the correct structure.
         :return: None
         """
         organisation = Organisation(name=self.organisation_name)
-        dag = OapenIrusUkTelescope(organisation, self.extra.get('publisher_id')).make_dag()
-        self.assert_dag_structure({
-            'check_dependencies': ['create_cloud_function'],
-            'create_cloud_function': ['call_cloud_function'],
-            'call_cloud_function': ['transfer'],
-            'transfer': ['download_transform'],
-            'download_transform': ['upload_transformed'],
-            'upload_transformed': ['bq_load'],
-            'bq_load': ['cleanup'],
-            'cleanup': []
-        }, dag)
+        dag = OapenIrusUkTelescope(organisation, self.extra.get("publisher_id")).make_dag()
+        self.assert_dag_structure(
+            {
+                "check_dependencies": ["create_cloud_function"],
+                "create_cloud_function": ["call_cloud_function"],
+                "call_cloud_function": ["transfer"],
+                "transfer": ["download_transform"],
+                "download_transform": ["upload_transformed"],
+                "upload_transformed": ["bq_load"],
+                "bq_load": ["cleanup"],
+                "cleanup": [],
+            },
+            dag,
+        )
 
     def test_dag_load(self):
-        """ Test that the Oapen Irus Uk DAG can be loaded from a DAG bag.
+        """Test that the Oapen Irus Uk DAG can be loaded from a DAG bag.
         :return: None
         """
 
         env = ObservatoryEnvironment(self.project_id, self.data_location)
         with env.create():
             # Add Observatory API connection
-            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API,
-                              uri=f'http://:password@{self.host}:{self.api_port}')
+            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.api_port}")
             env.add_connection(conn)
 
             # Add a telescope
             dt = pendulum.utcnow()
-            telescope_type = orm.TelescopeType(name='OAPEN Irus UK Telescope',
-                                               type_id=TelescopeTypes.oapen_irus_uk,
-                                               created=dt,
-                                               modified=dt)
+            telescope_type = orm.TelescopeType(
+                name="OAPEN Irus UK Telescope", type_id=TelescopeTypes.oapen_irus_uk, created=dt, modified=dt
+            )
             env.api_session.add(telescope_type)
-            organisation = orm.Organisation(name='UCL Press',
-                                            created=dt,
-                                            modified=dt)
+            organisation = orm.Organisation(name="UCL Press", created=dt, modified=dt)
             env.api_session.add(organisation)
-            telescope = orm.Telescope(name='UCL Press OAPEN Irus UK Telescope',
-                                      telescope_type=telescope_type,
-                                      organisation=organisation,
-                                      modified=dt,
-                                      created=dt,
-                                      extra=self.extra)
+            telescope = orm.Telescope(
+                name="UCL Press OAPEN Irus UK Telescope",
+                telescope_type=telescope_type,
+                organisation=organisation,
+                modified=dt,
+                created=dt,
+                extra=self.extra,
+            )
             env.api_session.add(telescope)
             env.api_session.commit()
 
-            dag_file = os.path.join(module_file_path('observatory.dags.dags'), 'oapen_irus_uk.py')
-            self.assert_dag_load('oapen_irus_uk_ucl_press', dag_file)
+            dag_file = os.path.join(module_file_path("observatory.dags.dags"), "oapen_irus_uk.py")
+            self.assert_dag_load("oapen_irus_uk_ucl_press", dag_file)
 
-    @patch('observatory.dags.telescopes.oapen_irus_uk.build')
-    @patch('observatory.dags.telescopes.oapen_irus_uk.ServiceAccountCredentials')
-    @patch('observatory.dags.telescopes.oapen_irus_uk.AuthorizedSession.post')
+    @patch("observatory.dags.telescopes.oapen_irus_uk.build")
+    @patch("observatory.dags.telescopes.oapen_irus_uk.ServiceAccountCredentials")
+    @patch("observatory.dags.telescopes.oapen_irus_uk.AuthorizedSession.post")
     def test_telescope(self, mock_authorized_session, mock_account_credentials, mock_build):
-        """ Test the Oapen Irus Uk telescope end to end.
+        """Test the Oapen Irus Uk telescope end to end.
         :return: None.
         """
         # Setup Observatory environment
@@ -121,26 +132,49 @@ class TestOapenIrusUk(ObservatoryTestCase):
 
         # Setup Telescope
         execution_date = pendulum.datetime(year=2021, month=2, day=1)
-        organisation = Organisation(name=self.organisation_name,
-                                    gcp_project_id=self.project_id,
-                                    gcp_download_bucket=env.download_bucket,
-                                    gcp_transform_bucket=env.transform_bucket)
-        telescope = OapenIrusUkTelescope(organisation=organisation, publisher_id=self.extra.get('publisher_id'),
-                                         dataset_id=dataset_id)
+        organisation = Organisation(
+            name=self.organisation_name,
+            gcp_project_id=self.project_id,
+            gcp_download_bucket=env.download_bucket,
+            gcp_transform_bucket=env.transform_bucket,
+        )
+        telescope = OapenIrusUkTelescope(
+            organisation=organisation, publisher_id=self.extra.get("publisher_id"), dataset_id=dataset_id
+        )
         # Fake oapen project and bucket
         OapenIrusUkTelescope.OAPEN_PROJECT_ID = env.project_id
         OapenIrusUkTelescope.OAPEN_BUCKET = random_id()
 
         # Mock the Google Cloud Functions API service
-        mock_account_credentials.from_json_keyfile_dict.return_value = ''
-        http = HttpMockSequence([({'status': '200'}, json.dumps({'functions': [{
-            'name': f'projects/{OapenIrusUkTelescope.OAPEN_PROJECT_ID}/locations/{OapenIrusUkTelescope.FUNCTION_REGION}/functions/'
-                    f'{OapenIrusUkTelescope.FUNCTION_NAME}'}]})),
-                                 ({'status': '200'}, json.dumps({
-                                     'name': 'operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc',
-                                     'done': True, 'response': {'message': 'response'}}))
-                                 ])
-        mock_build.return_value = build('cloudfunctions', 'v1', http=http)
+        mock_account_credentials.from_json_keyfile_dict.return_value = ""
+        http = HttpMockSequence(
+            [
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "functions": [
+                                {
+                                    "name": f"projects/{OapenIrusUkTelescope.OAPEN_PROJECT_ID}/locations/{OapenIrusUkTelescope.FUNCTION_REGION}/functions/"
+                                    f"{OapenIrusUkTelescope.FUNCTION_NAME}"
+                                }
+                            ]
+                        }
+                    ),
+                ),
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "name": "operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc",
+                            "done": True,
+                            "response": {"message": "response"},
+                        }
+                    ),
+                ),
+            ]
+        )
+        mock_build.return_value = build("cloudfunctions", "v1", http=http)
 
         dag = telescope.make_dag()
 
@@ -150,14 +184,11 @@ class TestOapenIrusUk(ObservatoryTestCase):
         # Create the Observatory environment and run tests
         with env.create():
             # Add airflow connections
-            conn = Connection(conn_id=AirflowConns.GEOIP_LICENSE_KEY,
-                              uri='mysql://email_address:password@')
+            conn = Connection(conn_id=AirflowConns.GEOIP_LICENSE_KEY, uri="mysql://email_address:password@")
             env.add_connection(conn)
-            conn = Connection(conn_id=AirflowConns.OAPEN_IRUS_UK_API,
-                              uri='mysql://requestor_id:api_key@')
+            conn = Connection(conn_id=AirflowConns.OAPEN_IRUS_UK_API, uri="mysql://requestor_id:api_key@")
             env.add_connection(conn)
-            conn = Connection(conn_id=AirflowConns.OAPEN_IRUS_UK_LOGIN,
-                              uri='mysql://user_id:license_key@')
+            conn = Connection(conn_id=AirflowConns.OAPEN_IRUS_UK_LOGIN, uri="mysql://user_id:license_key@")
             env.add_connection(conn)
 
             # Test that all dependencies are specified: no error should be thrown
@@ -169,15 +200,13 @@ class TestOapenIrusUk(ObservatoryTestCase):
             # Test call cloud function task: no error should be thrown
             with httpretty.enabled():
                 # mock response of getting publisher uuid
-                url = f'https://library.oapen.org/rest/search?query=publisher.name:{release.organisation_id}&expand=metadata'
-                httpretty.register_uri(httpretty.GET, url,
-                                       body='[{"uuid":"df73bf94-b818-494c-a8dd-6775b0573bc2"}]')
+                url = f"https://library.oapen.org/rest/search?query=publisher.name:{release.organisation_id}&expand=metadata"
+                httpretty.register_uri(httpretty.GET, url, body='[{"uuid":"df73bf94-b818-494c-a8dd-6775b0573bc2"}]')
                 # mock response of cloud function
                 mock_authorized_session.return_value.status_code = 200
-                mock_authorized_session.return_value.reason = 'unit test'
-                url = f'https://{OapenIrusUkTelescope.FUNCTION_REGION}-{OapenIrusUkTelescope.OAPEN_PROJECT_ID}.cloudfunctions.net/{OapenIrusUkTelescope.FUNCTION_NAME}'
-                httpretty.register_uri(httpretty.POST, url,
-                                       body="")
+                mock_authorized_session.return_value.reason = "unit test"
+                url = f"https://{OapenIrusUkTelescope.FUNCTION_REGION}-{OapenIrusUkTelescope.OAPEN_PROJECT_ID}.cloudfunctions.net/{OapenIrusUkTelescope.FUNCTION_NAME}"
+                httpretty.register_uri(httpretty.POST, url, body="")
                 env.run_task(telescope.call_cloud_function.__name__, dag, execution_date)
 
             # Test transfer task
@@ -188,7 +217,7 @@ class TestOapenIrusUk(ObservatoryTestCase):
             # Test download_transform task
             env.run_task(telescope.download_transform.__name__, dag, execution_date)
             for file in release.transform_files:
-                self.assert_file_integrity(file, self.transform_hash, 'gzip_crc')
+                self.assert_file_integrity(file, self.transform_hash, "gzip_crc")
 
             # Test that transformed file uploaded
             env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
@@ -199,25 +228,30 @@ class TestOapenIrusUk(ObservatoryTestCase):
             env.run_task(telescope.bq_load.__name__, dag, execution_date)
             for file in release.transform_files:
                 table_id, _ = table_ids_from_path(file)
-                table_id = f'{self.project_id}.{telescope.dataset_id}.' \
-                           f'{bigquery_partitioned_table_id(telescope.DAG_ID_PREFIX, release.release_date)}'
+                table_id = (
+                    f"{self.project_id}.{telescope.dataset_id}."
+                    f"{bigquery_partitioned_table_id(telescope.DAG_ID_PREFIX, release.release_date)}"
+                )
                 expected_rows = 4
                 self.assert_table_integrity(table_id, expected_rows)
 
             # Test that all telescope data deleted
-            download_folder, extract_folder, transform_folder = release.download_folder, release.extract_folder, \
-                                                                release.transform_folder
+            download_folder, extract_folder, transform_folder = (
+                release.download_folder,
+                release.extract_folder,
+                release.transform_folder,
+            )
             env.run_task(telescope.cleanup.__name__, dag, execution_date)
             self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
             # Delete oapen bucket
             env._delete_bucket(OapenIrusUkTelescope.OAPEN_BUCKET)
 
-    @patch('observatory.dags.telescopes.oapen_irus_uk.upload_file_to_cloud_storage')
-    @patch('observatory.dags.telescopes.oapen_irus_uk.create_cloud_storage_bucket')
-    @patch('observatory.platform.utils.template_utils.AirflowVariable.get')
+    @patch("observatory.dags.telescopes.oapen_irus_uk.upload_file_to_cloud_storage")
+    @patch("observatory.dags.telescopes.oapen_irus_uk.create_cloud_storage_bucket")
+    @patch("observatory.platform.utils.template_utils.AirflowVariable.get")
     def test_upload_source_code_to_bucket(self, mock_variable_get, mock_create_bucket, mock_upload_to_bucket):
-        """ Test getting source code from oapen irus uk release and uploading to storage bucket.
+        """Test getting source code from oapen irus uk release and uploading to storage bucket.
         Test expected results both when md5 hashes match and when they don't.
 
         :return: None.
@@ -225,34 +259,50 @@ class TestOapenIrusUk(ObservatoryTestCase):
         mock_create_bucket.return_value = True
         mock_upload_to_bucket.return_value = True, True
         organisation = Organisation(name=self.organisation_name)
-        telescope = OapenIrusUkTelescope(organisation, self.extra.get('publisher_id'))
+        telescope = OapenIrusUkTelescope(organisation, self.extra.get("publisher_id"))
         with CliRunner().isolated_filesystem():
             mock_variable_get.return_value = os.getcwd()
-            success, upload = upload_source_code_to_bucket(OapenIrusUkTelescope.FUNCTION_SOURCE_URL,
-                                                           OapenIrusUkTelescope.OAPEN_PROJECT_ID,
-                                                           OapenIrusUkTelescope.OAPEN_BUCKET,
-                                                           OapenIrusUkTelescope.FUNCTION_BLOB_NAME)
+            success, upload = upload_source_code_to_bucket(
+                OapenIrusUkTelescope.FUNCTION_SOURCE_URL,
+                OapenIrusUkTelescope.OAPEN_PROJECT_ID,
+                OapenIrusUkTelescope.OAPEN_BUCKET,
+                OapenIrusUkTelescope.FUNCTION_BLOB_NAME,
+            )
             self.assertEqual(success, True)
             self.assertEqual(upload, True)
 
-            OapenIrusUkTelescope.FUNCTION_MD5_HASH = 'different'
+            OapenIrusUkTelescope.FUNCTION_MD5_HASH = "different"
             with self.assertRaises(AirflowException):
-                upload_source_code_to_bucket(OapenIrusUkTelescope.FUNCTION_SOURCE_URL,
-                                             OapenIrusUkTelescope.OAPEN_PROJECT_ID,
-                                             OapenIrusUkTelescope.OAPEN_BUCKET,
-                                             OapenIrusUkTelescope.FUNCTION_BLOB_NAME)
+                upload_source_code_to_bucket(
+                    OapenIrusUkTelescope.FUNCTION_SOURCE_URL,
+                    OapenIrusUkTelescope.OAPEN_PROJECT_ID,
+                    OapenIrusUkTelescope.OAPEN_BUCKET,
+                    OapenIrusUkTelescope.FUNCTION_BLOB_NAME,
+                )
 
     def test_cloud_function_exists(self):
-        """ Test the function that checks whether the cloud function exists
+        """Test the function that checks whether the cloud function exists
         :return: None.
         """
-        http = HttpMockSequence([({'status': '200'}, json.dumps(
-            {'functions': [{'name': 'projects/project-id/locations/us-central1/functions/function-1'}]})),
-                                 ({'status': '200'}, json.dumps({'functions': [
-                                     {'name': 'projects/project-id/locations/us-central1/functions/function-2'}]}))])
-        service = build('cloudfunctions', 'v1', http=http)
-        location = 'projects/project-id/locations/us-central1'
-        full_name = 'projects/project-id/locations/us-central1/functions/function-2'
+        http = HttpMockSequence(
+            [
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {"functions": [{"name": "projects/project-id/locations/us-central1/functions/function-1"}]}
+                    ),
+                ),
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {"functions": [{"name": "projects/project-id/locations/us-central1/functions/function-2"}]}
+                    ),
+                ),
+            ]
+        )
+        service = build("cloudfunctions", "v1", http=http)
+        location = "projects/project-id/locations/us-central1"
+        full_name = "projects/project-id/locations/us-central1/functions/function-2"
         # With http where cloud function does not exists
         exists = cloud_function_exists(service, location=location, full_name=full_name)
         self.assertFalse(exists)
@@ -262,50 +312,98 @@ class TestOapenIrusUk(ObservatoryTestCase):
         self.assertTrue(exists)
 
     def test_create_cloud_function(self):
-        location = 'projects/project-id/locations/us-central1'
-        full_name = 'projects/project-id/locations/us-central1/functions/function-2'
-        source_bucket = 'oapen_bucket'
-        blob_name = 'source_code.zip'
+        location = "projects/project-id/locations/us-central1"
+        full_name = "projects/project-id/locations/us-central1/functions/function-2"
+        source_bucket = "oapen_bucket"
+        blob_name = "source_code.zip"
         max_active_runs = 1
 
         # Test creating cloud function, no error
-        http = HttpMockSequence([({'status': '200'}, json.dumps(
-            {'name': 'operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc'})),
-                                 ({'status': '200'}, json.dumps({
-                                     'name': 'operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc',
-                                     'done': True,
-                                     'response': {'message': 'response'}}))
-                                 ])
-        service = build('cloudfunctions', 'v1', http=http)
-        success, msg = create_cloud_function(service, location, full_name, source_bucket, blob_name, max_active_runs,
-                                             update=False)
+        http = HttpMockSequence(
+            [
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "name": "operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc"
+                        }
+                    ),
+                ),
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "name": "operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc",
+                            "done": True,
+                            "response": {"message": "response"},
+                        }
+                    ),
+                ),
+            ]
+        )
+        service = build("cloudfunctions", "v1", http=http)
+        success, msg = create_cloud_function(
+            service, location, full_name, source_bucket, blob_name, max_active_runs, update=False
+        )
         self.assertTrue(success)
-        self.assertDictEqual({'message': 'response'}, msg)
+        self.assertDictEqual({"message": "response"}, msg)
 
         # Test updating/patching cloud function, no error
-        http = HttpMockSequence([({'status': '200'}, json.dumps(
-            {'name': 'operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc'})),
-                                 ({'status': '200'}, json.dumps({
-                                     'name': 'operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc',
-                                     'done': True,
-                                     'response': {'message': 'response'}}))
-                                 ])
-        service = build('cloudfunctions', 'v1', http=http)
-        success, msg = create_cloud_function(service, location, full_name, source_bucket, blob_name, max_active_runs,
-                                             update=True)
+        http = HttpMockSequence(
+            [
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "name": "operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc"
+                        }
+                    ),
+                ),
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "name": "operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc",
+                            "done": True,
+                            "response": {"message": "response"},
+                        }
+                    ),
+                ),
+            ]
+        )
+        service = build("cloudfunctions", "v1", http=http)
+        success, msg = create_cloud_function(
+            service, location, full_name, source_bucket, blob_name, max_active_runs, update=True
+        )
         self.assertTrue(success)
-        self.assertDictEqual({'message': 'response'}, msg)
+        self.assertDictEqual({"message": "response"}, msg)
 
         # Test creating cloud function, error
-        http = HttpMockSequence([({'status': '200'}, json.dumps(
-            {'name': 'operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc'})),
-                                 ({'status': '200'}, json.dumps({
-                                     'name': 'operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc',
-                                     'done': True,
-                                     'error': {'message': 'error'}}))
-                                 ])
-        service = build('cloudfunctions', 'v1', http=http)
-        success, msg = create_cloud_function(service, location, full_name, source_bucket, blob_name, max_active_runs,
-                                             update=False)
+        http = HttpMockSequence(
+            [
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "name": "operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc"
+                        }
+                    ),
+                ),
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "name": "operations/d29ya2Zsb3dzLWRldi91cy1jZW50cmFsMS9vYXBlbl9hY2Nlc3Nfc3RhdHMvWnlmSEdWZDBHTGc",
+                            "done": True,
+                            "error": {"message": "error"},
+                        }
+                    ),
+                ),
+            ]
+        )
+        service = build("cloudfunctions", "v1", http=http)
+        success, msg = create_cloud_function(
+            service, location, full_name, source_bucket, blob_name, max_active_runs, update=False
+        )
         self.assertFalse(success)
-        self.assertDictEqual({'message': 'error'}, msg)
+        self.assertDictEqual({"message": "error"}, msg)

--- a/tests/observatory/dags/telescopes/test_onix.py
+++ b/tests/observatory/dags/telescopes/test_onix.py
@@ -29,15 +29,20 @@ from observatory.platform.utils.file_utils import _hash_file
 from observatory.platform.utils.gc_utils import bigquery_partitioned_table_id
 from observatory.platform.utils.telescope_utils import SftpFolders
 from observatory.platform.utils.template_utils import SubFolder, blob_name, telescope_path
-from observatory.platform.utils.test_utils import (ObservatoryEnvironment, ObservatoryTestCase, SftpServer,
-                                                   module_file_path, test_fixtures_path)
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    SftpServer,
+    module_file_path,
+    test_fixtures_path,
+)
 
 
 class TestOnix(ObservatoryTestCase):
     """ Tests for the ONIX telescope """
 
     def __init__(self, *args, **kwargs):
-        """ Constructor which sets up variables used by tests.
+        """Constructor which sets up variables used by tests.
 
         :param args: arguments.
         :param kwargs: keyword arguments.
@@ -47,70 +52,70 @@ class TestOnix(ObservatoryTestCase):
         self.host = "localhost"
         self.api_port = 5000
         self.sftp_port = 3373
-        self.project_id = os.getenv('TEST_GCP_PROJECT_ID')
-        self.data_location = os.getenv('TEST_GCP_DATA_LOCATION')
-        self.organisation_name = 'Curtin Press'
-        self.organisation_folder = 'curtin_press'
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+        self.organisation_name = "Curtin Press"
+        self.organisation_folder = "curtin_press"
 
     def test_dag_structure(self):
-        """ Test that the ONIX DAG has the correct structure.
+        """Test that the ONIX DAG has the correct structure.
 
         :return: None
         """
 
         organisation = Organisation(name=self.organisation_name)
         dag = OnixTelescope(organisation).make_dag()
-        self.assert_dag_structure({
-            'check_dependencies': ['list_release_info'],
-            'list_release_info': ['move_files_to_in_progress'],
-            'move_files_to_in_progress': ['download'],
-            'download': ['upload_downloaded'],
-            'upload_downloaded': ['transform'],
-            'transform': ['upload_transformed'],
-            'upload_transformed': ['bq_load'],
-            'bq_load': ['move_files_to_finished'],
-            'move_files_to_finished': ['cleanup'],
-            'cleanup': []
-        }, dag)
+        self.assert_dag_structure(
+            {
+                "check_dependencies": ["list_release_info"],
+                "list_release_info": ["move_files_to_in_progress"],
+                "move_files_to_in_progress": ["download"],
+                "download": ["upload_downloaded"],
+                "upload_downloaded": ["transform"],
+                "transform": ["upload_transformed"],
+                "upload_transformed": ["bq_load"],
+                "bq_load": ["move_files_to_finished"],
+                "move_files_to_finished": ["cleanup"],
+                "cleanup": [],
+            },
+            dag,
+        )
 
     def test_dag_load(self):
-        """ Test that the Geonames DAG can be loaded from a DAG bag.
+        """Test that the Geonames DAG can be loaded from a DAG bag.
 
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location,
-                                     api_host=self.host, api_port=self.api_port)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.api_port)
         with env.create():
             # Add Observatory API connection
-            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API,
-                              uri=f'http://:password@{self.host}:{self.api_port}')
+            conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.api_port}")
             env.add_connection(conn)
 
             # Add an ONIX telescope
             dt = pendulum.utcnow()
-            telescope_type = orm.TelescopeType(name='ONIX Telescope',
-                                               type_id=TelescopeTypes.onix,
-                                               created=dt,
-                                               modified=dt)
+            telescope_type = orm.TelescopeType(
+                name="ONIX Telescope", type_id=TelescopeTypes.onix, created=dt, modified=dt
+            )
             env.api_session.add(telescope_type)
-            organisation = orm.Organisation(name='Curtin Press',
-                                            created=dt,
-                                            modified=dt)
+            organisation = orm.Organisation(name="Curtin Press", created=dt, modified=dt)
             env.api_session.add(organisation)
-            telescope = orm.Telescope(name='Curtin Press ONIX Telescope',
-                                      telescope_type=telescope_type,
-                                      organisation=organisation,
-                                      modified=dt,
-                                      created=dt)
+            telescope = orm.Telescope(
+                name="Curtin Press ONIX Telescope",
+                telescope_type=telescope_type,
+                organisation=organisation,
+                modified=dt,
+                created=dt,
+            )
             env.api_session.add(telescope)
             env.api_session.commit()
 
-            dag_file = os.path.join(module_file_path('observatory.dags.dags'), 'onix.py')
-            self.assert_dag_load('onix_curtin_press', dag_file)
+            dag_file = os.path.join(module_file_path("observatory.dags.dags"), "onix.py")
+            self.assert_dag_load("onix_curtin_press", dag_file)
 
     def test_telescope(self):
-        """ Test the ONIX telescope end to end.
+        """Test the ONIX telescope end to end.
 
         :return: None.
         """
@@ -126,10 +131,12 @@ class TestOnix(ObservatoryTestCase):
             with sftp_server.create() as sftp_root:
                 # Setup Telescope
                 execution_date = pendulum.datetime(year=2021, month=3, day=31)
-                org = Organisation(name=self.organisation_name,
-                                   gcp_project_id=self.project_id,
-                                   gcp_download_bucket=env.download_bucket,
-                                   gcp_transform_bucket=env.transform_bucket)
+                org = Organisation(
+                    name=self.organisation_name,
+                    gcp_project_id=self.project_id,
+                    gcp_download_bucket=env.download_bucket,
+                    gcp_transform_bucket=env.transform_bucket,
+                )
                 telescope = OnixTelescope(org, dataset_id=dataset_id)
                 dag = telescope.make_dag()
 
@@ -141,16 +148,17 @@ class TestOnix(ObservatoryTestCase):
                 transform_folder = telescope_path(SubFolder.transformed, telescope.dag_id, release_id)
 
                 # Add SFTP connection
-                conn = Connection(conn_id=AirflowConns.SFTP_SERVICE,
-                                  uri=f'ssh://:password@{self.host}:{self.sftp_port}')
+                conn = Connection(
+                    conn_id=AirflowConns.SFTP_SERVICE, uri=f"ssh://:password@{self.host}:{self.sftp_port}"
+                )
                 env.add_connection(conn)
 
                 # Test that all dependencies are specified: no error should be thrown
-                env.run_task(dag, telescope.check_dependencies.__name__, execution_date)
+                env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
 
                 # Add ONIX file to SFTP server
-                onix_file_name = '20210330_CURTINPRESS_ONIX.xml'
-                onix_test_file = os.path.join(test_fixtures_path('telescopes', 'onix'), onix_file_name)
+                onix_file_name = "20210330_CURTINPRESS_ONIX.xml"
+                onix_test_file = os.path.join(test_fixtures_path("telescopes", "onix"), onix_file_name)
                 # Create SftpFolders instance with local sftp_root path as root
                 local_sftp_folders = SftpFolders(telescope.dag_id, self.organisation_name, sftp_root)
                 os.makedirs(local_sftp_folders.upload, exist_ok=True)
@@ -158,56 +166,53 @@ class TestOnix(ObservatoryTestCase):
                 shutil.copy(onix_test_file, onix_file_dst)
 
                 # Get release info from SFTP server and check that the correct release info is returned via Xcom
-                ti = env.run_task(dag, telescope.list_release_info.__name__, execution_date)
-                expected_release_info = [
-                    {
-                        'release_date': release_date,
-                        'file_name': onix_file_name
-                    }
-                ]
-                release_info = ti.xcom_pull(key=OnixTelescope.RELEASE_INFO,
-                                            task_ids=telescope.list_release_info.__name__,
-                                            include_prior_dates=False)
+                ti = env.run_task(telescope.list_release_info.__name__, dag, execution_date)
+                expected_release_info = [{"release_date": release_date, "file_name": onix_file_name}]
+                release_info = ti.xcom_pull(
+                    key=OnixTelescope.RELEASE_INFO,
+                    task_ids=telescope.list_release_info.__name__,
+                    include_prior_dates=False,
+                )
                 self.assertEqual(expected_release_info, release_info)
 
                 # Test move file to in progress
-                env.run_task(dag, telescope.move_files_to_in_progress.__name__, execution_date)
+                env.run_task(telescope.move_files_to_in_progress.__name__, dag, execution_date)
                 in_progress_path = os.path.join(local_sftp_folders.in_progress, onix_file_name)
                 self.assertFalse(os.path.isfile(onix_file_dst))
                 self.assertTrue(os.path.isfile(in_progress_path))
 
                 # Test download
-                env.run_task(dag, telescope.download.__name__, execution_date)
+                env.run_task(telescope.download.__name__, dag, execution_date)
                 download_file_path = os.path.join(download_folder, onix_file_name)
-                expected_file_hash = _hash_file(onix_test_file, algorithm='md5')
-                self.assert_file_integrity(download_file_path, expected_file_hash, 'md5')
+                expected_file_hash = _hash_file(onix_test_file, algorithm="md5")
+                self.assert_file_integrity(download_file_path, expected_file_hash, "md5")
 
                 # Test upload downloaded
-                env.run_task(dag, telescope.upload_downloaded.__name__, execution_date)
+                env.run_task(telescope.upload_downloaded.__name__, dag, execution_date)
                 self.assert_blob_integrity(env.download_bucket, blob_name(download_file_path), download_file_path)
 
                 # Test transform
-                env.run_task(dag, telescope.transform.__name__, execution_date)
-                transform_file_path = os.path.join(transform_folder, 'onix.jsonl')
-                expected_file_hash = '82faa8c7940a9766376a1f3862d35828'
-                self.assert_file_integrity(transform_file_path, expected_file_hash, 'md5')
+                env.run_task(telescope.transform.__name__, dag, execution_date)
+                transform_file_path = os.path.join(transform_folder, "onix.jsonl")
+                expected_file_hash = "82faa8c7940a9766376a1f3862d35828"
+                self.assert_file_integrity(transform_file_path, expected_file_hash, "md5")
 
                 # Test upload to cloud storage
-                env.run_task(dag, telescope.upload_transformed.__name__, execution_date)
+                env.run_task(telescope.upload_transformed.__name__, dag, execution_date)
                 self.assert_blob_integrity(env.transform_bucket, blob_name(transform_file_path), transform_file_path)
 
                 # Test load into BigQuery
-                env.run_task(dag, telescope.bq_load.__name__, execution_date)
-                table_id = f'{self.project_id}.{dataset_id}.{bigquery_partitioned_table_id(telescope.DAG_ID_PREFIX, release_date)}'
+                env.run_task(telescope.bq_load.__name__, dag, execution_date)
+                table_id = f"{self.project_id}.{dataset_id}.{bigquery_partitioned_table_id(telescope.DAG_ID_PREFIX, release_date)}"
                 expected_rows = 1
                 self.assert_table_integrity(table_id, expected_rows)
 
                 # Test move files to finished
-                env.run_task(dag, telescope.move_files_to_finished.__name__, execution_date)
+                env.run_task(telescope.move_files_to_finished.__name__, dag, execution_date)
                 finished_path = os.path.join(local_sftp_folders.finished, onix_file_name)
                 self.assertFalse(os.path.isfile(local_sftp_folders.in_progress))
                 self.assertTrue(os.path.isfile(finished_path))
 
                 # Test cleanup
-                env.run_task(dag, telescope.cleanup.__name__, execution_date)
+                env.run_task(telescope.cleanup.__name__, dag, execution_date)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -21,6 +21,7 @@ import os
 import unittest
 from typing import Union, List
 
+import croniter
 import httpretty
 import pendulum
 import pysftp
@@ -31,15 +32,23 @@ from google.cloud.bigquery import SourceFormat
 from google.cloud.exceptions import NotFound
 from observatory.platform.telescopes.telescope import Telescope, AbstractRelease
 from observatory.platform.utils.airflow_utils import AirflowVars
-from observatory.platform.utils.gc_utils import (create_bigquery_dataset, upload_file_to_cloud_storage,
-                                                 load_bigquery_table)
-from observatory.platform.utils.test_utils import (ObservatoryEnvironment, random_id, ObservatoryTestCase,
-                                                   test_fixtures_path, SftpServer)
+from observatory.platform.utils.gc_utils import (
+    create_bigquery_dataset,
+    upload_file_to_cloud_storage,
+    load_bigquery_table,
+)
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    random_id,
+    ObservatoryTestCase,
+    test_fixtures_path,
+    SftpServer,
+)
 from observatory.platform.utils.url_utils import retry_session
 
-DAG_ID = 'telescope-test'
-MY_VAR_ID = 'my-variable'
-MY_CONN_ID = 'my-connection'
+DAG_ID = "telescope-test"
+MY_VAR_ID = "my-variable"
+MY_CONN_ID = "my-connection"
 DAG_FILE_CONTENT = """
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
@@ -54,11 +63,20 @@ globals()['test-telescope'] = telescope.make_dag()
 class TelescopeTest(Telescope):
     """ A telescope for testing purposes """
 
-    def __init__(self, dag_id: str = DAG_ID,
-                 start_date: datetime = datetime.datetime(2020, 9, 1),
-                 schedule_interval: str = '@weekly'):
-        airflow_vars = [AirflowVars.DATA_PATH, AirflowVars.PROJECT_ID, AirflowVars.DATA_LOCATION,
-                        AirflowVars.DOWNLOAD_BUCKET, AirflowVars.TRANSFORM_BUCKET, MY_VAR_ID]
+    def __init__(
+        self,
+        dag_id: str = DAG_ID,
+        start_date: datetime = datetime.datetime(2020, 9, 1),
+        schedule_interval: str = "@weekly",
+    ):
+        airflow_vars = [
+            AirflowVars.DATA_PATH,
+            AirflowVars.PROJECT_ID,
+            AirflowVars.DATA_LOCATION,
+            AirflowVars.DOWNLOAD_BUCKET,
+            AirflowVars.TRANSFORM_BUCKET,
+            MY_VAR_ID,
+        ]
         airflow_conns = [MY_CONN_ID]
         super().__init__(dag_id, start_date, schedule_interval, airflow_vars=airflow_vars, airflow_conns=airflow_conns)
         self.add_setup_task(self.check_dependencies)
@@ -72,8 +90,8 @@ class TestObservatoryEnvironment(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(TestObservatoryEnvironment, self).__init__(*args, **kwargs)
-        self.project_id = os.getenv('TEST_GCP_PROJECT_ID')
-        self.data_location = os.getenv('TEST_GCP_DATA_LOCATION')
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
 
     def test_add_bucket(self):
         """ Test the add_bucket method """
@@ -151,15 +169,95 @@ class TestObservatoryEnvironment(unittest.TestCase):
 
         with env.create():
             # Test add_variable
-            env.add_variable(Variable(key=MY_VAR_ID, val='hello'))
+            env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
 
             # Test add_connection
             conn = Connection(conn_id=MY_CONN_ID)
-            conn.parse_from_uri('mysql://login:password@host:8080/schema?param1=val1&param2=val2')
+            conn.parse_from_uri("mysql://login:password@host:8080/schema?param1=val1&param2=val2")
             env.add_connection(conn)
 
             # Test run task
-            env.run_task(dag, telescope.check_dependencies.__name__, execution_date)
+            env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+
+    def test_create_dagrun(self):
+        """ Tests create_dag_run """
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
+
+        # Setup Telescope
+        first_execution_date = pendulum.datetime(year=2020, month=11, day=1)
+        second_execution_date = pendulum.datetime(year=2020, month=12, day=1)
+        telescope = TelescopeTest()
+        dag = telescope.make_dag()
+
+        # Get start dates outside of
+        first_start_date = croniter.croniter(dag.normalized_schedule_interval, first_execution_date).get_next(
+            datetime.datetime
+        )
+        second_start_date = croniter.croniter(dag.normalized_schedule_interval, second_execution_date).get_next(
+            datetime.datetime
+        )
+
+        # Use DAG run with freezing time
+        with env.create():
+            # Test add_variable
+            env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
+
+            # Test add_connection
+            conn = Connection(conn_id=MY_CONN_ID)
+            conn.parse_from_uri("mysql://login:password@host:8080/schema?param1=val1&param2=val2")
+            env.add_connection(conn)
+
+            self.assertIsNone(env.dag_run)
+            # First DAG Run
+            with env.create_dag_run(dag, first_execution_date):
+                # Test DAG Run is set and has frozen start date
+                self.assertIsNotNone(env.dag_run)
+                self.assertEqual(first_start_date.date(), env.dag_run.start_date.date())
+
+                ti1 = env.run_task(telescope.check_dependencies.__name__)
+                self.assertEqual("success", ti1.state)
+                self.assertIsNone(ti1.previous_ti)
+
+            with env.create_dag_run(dag, second_execution_date):
+                # Test DAG Run is set and has frozen start date
+                self.assertIsNotNone(env.dag_run)
+                self.assertEqual(second_start_date.date(), env.dag_run.start_date.date())
+
+                ti2 = env.run_task(telescope.check_dependencies.__name__)
+                self.assertEqual("success", ti2.state)
+                # Test previous ti is set
+                self.assertEqual(ti1.job_id, ti2.previous_ti.job_id)
+
+        # Use DAG run without freezing time
+        with env.create():
+            # Test add_variable
+            env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
+
+            # Test add_connection
+            conn = Connection(conn_id=MY_CONN_ID)
+            conn.parse_from_uri("mysql://login:password@host:8080/schema?param1=val1&param2=val2")
+            env.add_connection(conn)
+
+            # First DAG Run
+            with env.create_dag_run(dag, first_execution_date, freeze=False):
+                # Test DAG Run is set and has today as start date
+                self.assertIsNotNone(env.dag_run)
+                self.assertEqual(pendulum.now().date(), env.dag_run.start_date.date())
+
+                ti1 = env.run_task(telescope.check_dependencies.__name__)
+                self.assertEqual("success", ti1.state)
+                self.assertIsNone(ti1.previous_ti)
+
+            # Second DAG Run
+            with env.create_dag_run(dag, second_execution_date, freeze=False):
+                # Test DAG Run is set and has today as start date
+                self.assertIsNotNone(env.dag_run)
+                self.assertEqual(pendulum.now().date(), env.dag_run.start_date.date())
+
+                ti2 = env.run_task(telescope.check_dependencies.__name__)
+                self.assertEqual("success", ti2.state)
+                # Test previous ti is set
+                self.assertEqual(ti1.job_id, ti2.previous_ti.job_id)
 
 
 class TestObservatoryTestCase(unittest.TestCase):
@@ -167,8 +265,8 @@ class TestObservatoryTestCase(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(TestObservatoryTestCase, self).__init__(*args, **kwargs)
-        self.project_id = os.getenv('TEST_GCP_PROJECT_ID')
-        self.data_location = os.getenv('TEST_GCP_DATA_LOCATION')
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
 
     def test_assert_dag_structure(self):
         """ Test assert_dag_structure """
@@ -178,13 +276,12 @@ class TestObservatoryTestCase(unittest.TestCase):
         dag = telescope.make_dag()
 
         # No assertion error
-        expected = {'check_dependencies': []}
+        expected = {"check_dependencies": []}
         test_case.assert_dag_structure(expected, dag)
 
         # Raise assertion error
         with self.assertRaises(AssertionError):
-            expected = {'check_dependencies': ['list_releases'],
-                        'list_releases': []}
+            expected = {"check_dependencies": ["list_releases"], "list_releases": []}
             test_case.assert_dag_structure(expected, dag)
 
     def test_assert_dag_load(self):
@@ -193,8 +290,8 @@ class TestObservatoryTestCase(unittest.TestCase):
         test_case = ObservatoryTestCase()
         with ObservatoryEnvironment().create() as temp_dir:
             # Write DAG into temp_dir
-            file_path = os.path.join(temp_dir, f'telescope_test.py')
-            with open(file_path, mode='w') as f:
+            file_path = os.path.join(temp_dir, f"telescope_test.py")
+            with open(file_path, mode="w") as f:
                 f.write(DAG_FILE_CONTENT)
 
             # DAG loaded successfully: should be no errors
@@ -213,8 +310,8 @@ class TestObservatoryTestCase(unittest.TestCase):
         env = ObservatoryEnvironment(self.project_id, self.data_location)
         with env.create():
             # Upload file to download bucket and check gzip-crc
-            file_name = 'people.csv'
-            file_path = os.path.join(test_fixtures_path('utils', 'gc_utils'), file_name)
+            file_name = "people.csv"
+            file_path = os.path.join(test_fixtures_path("utils", "gc_utils"), file_name)
             result, upload = upload_file_to_cloud_storage(env.download_bucket, file_name, file_path)
             self.assertTrue(result)
 
@@ -232,8 +329,8 @@ class TestObservatoryTestCase(unittest.TestCase):
         env = ObservatoryEnvironment(self.project_id, self.data_location)
         with env.create():
             # Upload file to download bucket and check gzip-crc
-            file_name = 'people.jsonl'
-            file_path = os.path.join(test_fixtures_path('utils', 'gc_utils'), file_name)
+            file_name = "people.jsonl"
+            file_path = os.path.join(test_fixtures_path("utils", "gc_utils"), file_name)
             result, upload = upload_file_to_cloud_storage(env.download_bucket, file_name, file_path)
             self.assertTrue(result)
 
@@ -243,27 +340,32 @@ class TestObservatoryTestCase(unittest.TestCase):
 
             # Test loading JSON newline table
             table_name = random_id()
-            schema_path = os.path.join(test_fixtures_path('utils', 'gc_utils'), 'people_schema.json')
+            schema_path = os.path.join(test_fixtures_path("utils", "gc_utils"), "people_schema.json")
             uri = f"gs://{env.download_bucket}/{file_name}"
-            result = load_bigquery_table(uri, dataset_id, self.data_location, table_name,
-                                         schema_file_path=schema_path,
-                                         source_format=SourceFormat.NEWLINE_DELIMITED_JSON)
+            result = load_bigquery_table(
+                uri,
+                dataset_id,
+                self.data_location,
+                table_name,
+                schema_file_path=schema_path,
+                source_format=SourceFormat.NEWLINE_DELIMITED_JSON,
+            )
             self.assertTrue(result)
 
             # Check BigQuery table exists and has expected rows
             test_case = ObservatoryTestCase()
-            table_id = f'{dataset_id}.{table_name}'
+            table_id = f"{dataset_id}.{table_name}"
             expected_rows = 5
             test_case.assert_table_integrity(table_id, expected_rows)
 
             # Check that BigQuery table doesn't exist
             with self.assertRaises(AssertionError):
-                table_id = f'{dataset_id}.{random_id()}'
+                table_id = f"{dataset_id}.{random_id()}"
                 test_case.assert_table_integrity(table_id, expected_rows)
 
             # Check that BigQuery table has incorrect rows
             with self.assertRaises(AssertionError):
-                table_id = f'{dataset_id}.{table_name}'
+                table_id = f"{dataset_id}.{table_name}"
                 expected_rows = 20
                 test_case.assert_table_integrity(table_id, expected_rows)
 
@@ -271,16 +373,16 @@ class TestObservatoryTestCase(unittest.TestCase):
         """ Test assert_file_integrity """
 
         test_case = ObservatoryTestCase()
-        tests_path = test_fixtures_path('utils', 'gc_utils')
+        tests_path = test_fixtures_path("utils", "gc_utils")
 
         # Test md5
-        file_path = os.path.join(tests_path, 'people.csv')
+        file_path = os.path.join(tests_path, "people.csv")
         expected_hash = "ad0d7ad3dc3434337cebd5fb543420e7"
         algorithm = "md5"
         test_case.assert_file_integrity(file_path, expected_hash, algorithm)
 
         # Test gzip-crc
-        file_path = os.path.join(tests_path, 'people.csv.gz')
+        file_path = os.path.join(tests_path, "people.csv.gz")
         expected_hash = "3beea5ac"
         algorithm = "gzip_crc"
         test_case.assert_file_integrity(file_path, expected_hash, algorithm)
@@ -289,9 +391,9 @@ class TestObservatoryTestCase(unittest.TestCase):
         """ Test assert_cleanup """
 
         with CliRunner().isolated_filesystem() as temp_dir:
-            download = os.path.join(temp_dir, 'download')
-            extract = os.path.join(temp_dir, 'extract')
-            transform = os.path.join(temp_dir, 'transform')
+            download = os.path.join(temp_dir, "download")
+            extract = os.path.join(temp_dir, "extract")
+            transform = os.path.join(temp_dir, "transform")
 
             # Make download, extract and transform folders
             os.makedirs(download)
@@ -317,8 +419,8 @@ class TestObservatoryTestCase(unittest.TestCase):
         with CliRunner().isolated_filesystem() as temp_dir:
             # Write data into temp_dir
             expected_data = "Hello World!"
-            file_path = os.path.join(temp_dir, f'content.txt')
-            with open(file_path, mode='w') as f:
+            file_path = os.path.join(temp_dir, f"content.txt")
+            with open(file_path, mode="w") as f:
                 f.write(expected_data)
 
             # Check that content was downloaded from test file
@@ -331,9 +433,8 @@ class TestObservatoryTestCase(unittest.TestCase):
 
 
 class TestSftpServer(unittest.TestCase):
-
     def setUp(self) -> None:
-        self.host = 'localhost'
+        self.host = "localhost"
         self.port = 3373
 
     def test_server(self):
@@ -344,17 +445,17 @@ class TestSftpServer(unittest.TestCase):
             # Connect to SFTP server and disable host key checking
             cnopts = pysftp.CnOpts()
             cnopts.hostkeys = None
-            sftp = pysftp.Connection(self.host, port=self.port, username='', password='', cnopts=cnopts)
+            sftp = pysftp.Connection(self.host, port=self.port, username="", password="", cnopts=cnopts)
 
             # Check that there are no files
-            files = sftp.listdir('.')
+            files = sftp.listdir(".")
             self.assertFalse(len(files))
 
             # Add a file and check that it exists
-            expected_file_name = 'onix.xml'
+            expected_file_name = "onix.xml"
             file_path = os.path.join(root_dir, expected_file_name)
-            with open(file_path, mode='w') as f:
-                f.write('hello world')
-            files = sftp.listdir('.')
+            with open(file_path, mode="w") as f:
+                f.write("hello world")
+            files = sftp.listdir(".")
             self.assertEqual(1, len(files))
             self.assertEqual(expected_file_name, files[0])


### PR DESCRIPTION
This PR adds the functionality to use a dag_run in the test environment, this is useful because:
- DAG runs might be different for a first run compared to a second run
For example for the 'StreamTelescope', there are the following tasks for loading data into BigQuery:

1. bq_load_partition. Load data into a single BigQuery partition
2. bq_delete_old. Delete old rows from the main table.
3. bq_append_new. Append new rows to the main table.

These tasks are slightly different for a first run, compared to a second (or later) run.
Task 1 is skipped for the first run, so the data is just appended to the main table in task 3. The partition and the main table would be the same. Since the first run most likely contains all data from the past up until now this can be big in size, it saves some resources to just add it to the main table and not as a partition as well.
For a later run this is where the data from that current release/file is loaded into a partition.

Task 2 is also skipped for the first run, because there is no old data.
For a later run the data from the relevant partition(s) is deleted from the main table. It can be 1 partition or multiple partitions, depending on how many partitions have been added since this task last ran (defined by bq_merge_days).

Task 3 is executed for both first and later runs, but for the first run the data is added to the table from a file, while for the later run the data is added from the partition that is created in task 1.
For a later run the data from the relevant partition(s) is added to the main table. It can be 1 partition or multiple partitions, depending on how many partitions have been added since this task last ran (defined by bq_merge_days).

- With the addition of the dag_run, tasks can be assigned to a specific dag_run and it is possible to check the state of a previous Task Instance for a certain task.
- The start date of the DAG Run can be set to a chosen point in time. This is useful, because some tasks use the number of days between the current run and the previous successful run.

Most changes were originally made in the DOAB telescope pull request (https://github.com/The-Academic-Observatory/observatory-platform/pull/381)