### PR TITLE
Update oapen irus uk schema

### DIFF
--- a/observatory-dags/observatory/dags/database/schema/oapen_irus_uk_2020-04-01.json
+++ b/observatory-dags/observatory/dags/database/schema/oapen_irus_uk_2020-04-01.json
@@ -1,8 +1,26 @@
 [
   {
-    "description": "ID for the book.",
+    "description": "Proprietary identifier of the book.",
     "mode": "NULLABLE",
-    "name": "item_id",
+    "name": "proprietary_id",
+    "type": "STRING"
+  },
+  {
+    "description": "URI of the book.",
+    "mode": "NULLABLE",
+    "name": "URI",
+    "type": "STRING"
+  },
+  {
+    "description": "DOI of the book.",
+    "mode": "NULLABLE",
+    "name": "DOI",
+    "type": "STRING"
+  },
+  {
+    "description": "ISBN of the book.",
+    "mode": "NULLABLE",
+    "name": "ISBN",
     "type": "STRING"
   },
   {

--- a/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
@@ -19,7 +19,6 @@ import logging
 import os
 import time
 from datetime import datetime
-from functools import partial
 from typing import List, Optional, Tuple
 from urllib.parse import quote
 
@@ -27,7 +26,6 @@ import pendulum
 import requests
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.operators.python_operator import PythonOperator
 from google.auth import environment_vars
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.service_account import IDTokenCredentials
@@ -187,8 +185,8 @@ class OapenIrusUkTelescope(SnapshotTelescope):
     FUNCTION_NAME = 'oapen_access_stats'  # Name of the google cloud function
     FUNCTION_REGION = 'europe-west1'  # Region of the google cloud function
     FUNCTION_SOURCE_URL = 'https://github.com/The-Academic-Observatory/oapen-irus-uk-cloud-function/releases/' \
-                          'download/v1.0.0/oapen-irus-uk-cloud-function.zip'  # URL to the zipped source code of the cloud function
-    FUNCTION_MD5_HASH = '61793f6e4864285088917b81186f125e'  # MD5 hash of the zipped source code
+                          'download/v1.0.1/oapen-irus-uk-cloud-function.zip'  # URL to the zipped source code of the cloud function
+    FUNCTION_MD5_HASH = 'a273d1b547e221a8d2165c5ac956e942'  # MD5 hash of the zipped source code
     FUNCTION_BLOB_NAME = 'cloud_function_source_code.zip'  # blob name of zipped source code
     OAPEN_API_URL = 'https://library.oapen.org/rest/search?query=publisher.name:{publisher_name}&expand=metadata'
 

--- a/tests/fixtures/telescopes/oapen_irus_uk/download_2021_02.jsonl.gz
+++ b/tests/fixtures/telescopes/oapen_irus_uk/download_2021_02.jsonl.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b210eef1f14573e1cba7658af5dad54b933214b4b34bd884dc7534b694ed21ef
-size 475
+oid sha256:73a2211ed09e83f9fec0356f5dc2de6d3dc7c05293d8ca4c565634c1c2bcdf20
+size 583

--- a/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
+++ b/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
@@ -64,7 +64,7 @@ class TestOapenIrusUk(ObservatoryTestCase):
         self.host = "localhost"
         self.api_port = 5000
         self.download_path = test_fixtures_path("telescopes", "oapen_irus_uk", "download_2021_02.jsonl.gz")
-        self.transform_hash = "07d2dd2e"
+        self.transform_hash = "5fe1ffaf"
 
     def test_dag_structure(self):
         """Test that the Oapen Irus Uk DAG has the correct structure.


### PR DESCRIPTION
Update schema to include extra identifiers.
There are some extra identifiers for the book in the output of the 'newer' oapen irus uk data that were not stored in the output file.
The following identifiers are now available:

- proprietary id
- uri (this was previously included as 'item_id')
- doi
- isbn

See https://github.com/The-Academic-Observatory/oapen-irus-uk-cloud-function/pull/3 for corresponding PR of Cloud Function.