### PR TITLE
Update oapen irus uk schedule

### DIFF
--- a/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
@@ -206,14 +206,14 @@ class OapenIrusUkTelescope(SnapshotTelescope):
     FUNCTION_NAME = 'oapen_access_stats'  # Name of the google cloud function
     FUNCTION_REGION = 'europe-west1'  # Region of the google cloud function
     FUNCTION_SOURCE_URL = 'https://github.com/The-Academic-Observatory/oapen-irus-uk-cloud-function/releases/' \
-                          'download/v1.1.0/oapen-irus-uk-cloud-function.zip'  # URL to the zipped source code of the
+                          'download/v1.1.1/oapen-irus-uk-cloud-function.zip'  # URL to the zipped source code of the
     # cloud function
-    FUNCTION_MD5_HASH = '87ba55491c00d392298c3433918ecf40'  # MD5 hash of the zipped source code
+    FUNCTION_MD5_HASH = '31283d3f8f855ecfd8407fc6d924bc92'  # MD5 hash of the zipped source code
     FUNCTION_BLOB_NAME = 'cloud_function_source_code.zip'  # blob name of zipped source code
     OAPEN_API_URL = 'https://library.oapen.org/rest/search?query=publisher.name:{publisher_name}&expand=metadata'
 
     def __init__(self, organisation: Organisation, publisher_id: str, dag_id: Optional[str] = None,
-                 start_date: datetime = datetime(2018, 1, 1), schedule_interval: str = '@monthly',
+                 start_date: datetime = datetime(2018, 1, 1), schedule_interval: str = '0 0 14 * *',
                  dataset_id: str = 'oapen', dataset_description: str = 'OAPEN dataset', table_descriptions: Dict = None,
                  catchup: bool = True, airflow_vars: List = None, airflow_conns: List = None, max_active_runs=5,
                  max_cloud_function_instances: int = 0):

--- a/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
+++ b/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
@@ -131,7 +131,7 @@ class TestOapenIrusUk(ObservatoryTestCase):
         dataset_id = env.add_dataset()
 
         # Setup Telescope
-        execution_date = pendulum.datetime(year=2021, month=2, day=1).end_of('month')
+        execution_date = pendulum.datetime(year=2021, month=2, day=14)
         organisation = Organisation(
             name=self.organisation_name,
             gcp_project_id=self.project_id,
@@ -180,7 +180,7 @@ class TestOapenIrusUk(ObservatoryTestCase):
         dag = telescope.make_dag()
 
         # Use release to check results from tasks
-        release = OapenIrusUkRelease(telescope.dag_id, execution_date, organisation)
+        release = OapenIrusUkRelease(telescope.dag_id, execution_date.end_of('month'), organisation)
 
         # Create the Observatory environment and run tests
         with env.create():


### PR DESCRIPTION
The data from the previous month was not yet available on the first day of the following month.
I checked today that the data for the month of May is available.

To make sure the data is always available during the DAG run the schedule is changed to run on every 14th day of the month.

@jdddog You initially proposed every second Sunday of the month, but I could not find a way to translate this into a cron expression, what do you think about every 14th day of the month instead?