### PR TITLE
Add option to print airflow logging info in test environment

### DIFF
--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -313,8 +313,6 @@ class ObservatoryEnvironment:
     def create(self, task_logging: bool = False):
         """Make and destroy an Observatory isolated environment, which involves:
 
-        :param task_logging: display airflow task logging
-
         * Creating a temporary directory.
         * Setting the OBSERVATORY_HOME environment variable.
         * Initialising a temporary Airflow database.
@@ -323,6 +321,7 @@ class ObservatoryEnvironment:
           AirflowVars.DOWNLOAD_BUCKET and AirflowVars.TRANSFORM_BUCKET.
         * Cleaning up all resources when the environment is closed.
 
+        :param task_logging: display airflow task logging
         :yield: Observatory environment temporary directory.
         """
 
@@ -351,7 +350,7 @@ class ObservatoryEnvironment:
                 self.session = settings.Session
                 db.initdb()
 
-                current_level = logging.getLogger().getEffectiveLevel()
+                original_log_level = logging.getLogger().getEffectiveLevel()
                 if task_logging:
                     # Set root logger to INFO level, it seems that custom 'logging.info()' statements inside a task
                     # come from root
@@ -382,7 +381,7 @@ class ObservatoryEnvironment:
                     yield self.temp_dir
             finally:
                 # Set logger settings back to original settings
-                logging.getLogger().setLevel(current_level)
+                logging.getLogger().setLevel(original_log_level)
                 logging.getLogger('airflow.task').propagate = False
 
                 # Revert environment

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: James Diprose
+# Author: James Diprose, Aniek Roelofs
 
 from __future__ import annotations
 
@@ -177,7 +177,22 @@ class TestObservatoryEnvironment(unittest.TestCase):
             env.add_connection(conn)
 
             # Test run task
-            env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+            ti = env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+            self.assertFalse(ti.logger.propagate)
+
+        # Test environment with logging enabled
+        with env.create(task_logging=True):
+            # Test add_variable
+            env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
+
+            # Test add_connection
+            conn = Connection(conn_id=MY_CONN_ID)
+            conn.parse_from_uri("mysql://login:password@host:8080/schema?param1=val1&param2=val2")
+            env.add_connection(conn)
+
+            # Test run task
+            ti = env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
+            self.assertTrue(ti.logger.propagate)
 
     def test_create_dagrun(self):
         """ Tests create_dag_run """


### PR DESCRIPTION
I find it useful to see the airflow task logging when developing/testing a telescope, so I have added a parameter in the `env.create()` method to display the airflow logs.
