### PR TITLE
added a namespace to exported tables

### DIFF
--- a/observatory-dags/observatory/dags/workflows/onix_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/onix_workflow.py
@@ -729,7 +729,7 @@ class OnixWorkflow(Telescope):
 
             create_bigquery_dataset(project_id=release.project_id, dataset_id=output_dataset, location=data_location)
 
-            table_id = bigquery_sharded_table_id(f"{release.project_id}_{output_table}", release_date)
+            table_id = bigquery_sharded_table_id(f"{release.project_id.replace('-', '_')}_{output_table}", release_date)
             template_path = os.path.join(workflow_sql_templates_path(), query_template)
 
             sql = render_template(
@@ -803,7 +803,7 @@ class OnixWorkflow(Telescope):
 
             # Un-matched Metrics
             output_table = "unmatched_book_metrics"
-            table_id = bigquery_sharded_table_id(output_table, release_date)
+            table_id = bigquery_sharded_table_id(f"{release.project_id.replace('-', '_')}_{output_table}", release_date)
             table_joining_template_file = "export_unmatched_metrics.sql.jinja2"
             template_path = os.path.join(workflow_sql_templates_path(), table_joining_template_file)
 

--- a/observatory-dags/observatory/dags/workflows/onix_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/onix_workflow.py
@@ -128,7 +128,7 @@ class OnixWorkflowRelease(AbstractRelease):
         # OAEBU Elastic tables
         self.oaebu_elastic_dataset = oaebu_elastic_dataset
         if self.oaebu_elastic_dataset is None:
-            self.oaebu_elastic_dataset = "oaebu_elastic"
+            self.oaebu_elastic_dataset = "data_export"
 
         self.oaebu_data_qa_dataset = oaebu_data_qa_dataset
         if self.oaebu_data_qa_dataset is None:

--- a/observatory-dags/observatory/dags/workflows/onix_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/onix_workflow.py
@@ -729,7 +729,7 @@ class OnixWorkflow(Telescope):
 
             create_bigquery_dataset(project_id=release.project_id, dataset_id=output_dataset, location=data_location)
 
-            table_id = bigquery_sharded_table_id(output_table, release_date)
+            table_id = bigquery_sharded_table_id(f"{release.project_id}_{output_table}", release_date)
             template_path = os.path.join(workflow_sql_templates_path(), query_template)
 
             sql = render_template(

--- a/tests/observatory/dags/workflows/test_onix_workflow.py
+++ b/tests/observatory/dags/workflows/test_onix_workflow.py
@@ -1996,10 +1996,10 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
             table_id = f"{self.gcp_project_id}.{oaebu_output_dataset}.book_product{release_suffix}"
             self.assert_table_integrity(table_id, 2)
 
-            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.book_product_list{release_suffix}"
+            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_product_list{release_suffix}"
             self.assert_table_integrity(table_id, 2)
 
-            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.book_publisher_metrics{release_suffix}"
+            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_publisher_metrics{release_suffix}"
             self.assert_table_integrity(table_id, 1)
 
             # Validate the joins worked
@@ -2153,7 +2153,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
             self.assertTrue("112" in isbns)
 
             # Check export tables
-            sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset}.book_product_list{release_suffix}"
+            sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_product_list{release_suffix}"
             records = run_bigquery_query(sql)
             isbns = set([record["product_id"] for record in records])
             self.assertEqual(len(isbns), 2)
@@ -2657,10 +2657,10 @@ class TestOnixWorkflowFunctionalWithGoogleAnalytics(ObservatoryTestCase):
             table_id = f"{self.gcp_project_id}.{oaebu_output_dataset}.book_product{release_suffix}"
             self.assert_table_integrity(table_id, 2)
 
-            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.book_product_list{release_suffix}"
+            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_product_list{release_suffix}"
             self.assert_table_integrity(table_id, 2)
 
-            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.book_publisher_metrics{release_suffix}"
+            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_publisher_metrics{release_suffix}"
             self.assert_table_integrity(table_id, 1)
 
             # Validate the joins worked
@@ -2829,7 +2829,7 @@ class TestOnixWorkflowFunctionalWithGoogleAnalytics(ObservatoryTestCase):
             self.assertTrue("112" in isbns)
 
             # Check export tables
-            sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset}.book_product_list{release_suffix}"
+            sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_product_list{release_suffix}"
             records = run_bigquery_query(sql)
             isbns = set([record["product_id"] for record in records])
             self.assertEqual(len(isbns), 2)

--- a/tests/observatory/dags/workflows/test_onix_workflow.py
+++ b/tests/observatory/dags/workflows/test_onix_workflow.py
@@ -1996,10 +1996,10 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
             table_id = f"{self.gcp_project_id}.{oaebu_output_dataset}.book_product{release_suffix}"
             self.assert_table_integrity(table_id, 2)
 
-            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_product_list{release_suffix}"
+            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id.replace('-', '_')}_book_product_list{release_suffix}"
             self.assert_table_integrity(table_id, 2)
 
-            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_publisher_metrics{release_suffix}"
+            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id.replace('-', '_')}_book_publisher_metrics{release_suffix}"
             self.assert_table_integrity(table_id, 1)
 
             # Validate the joins worked
@@ -2153,7 +2153,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
             self.assertTrue("112" in isbns)
 
             # Check export tables
-            sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_product_list{release_suffix}"
+            sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id.replace('-', '_')}_book_product_list{release_suffix}"
             records = run_bigquery_query(sql)
             isbns = set([record["product_id"] for record in records])
             self.assertEqual(len(isbns), 2)
@@ -2657,10 +2657,10 @@ class TestOnixWorkflowFunctionalWithGoogleAnalytics(ObservatoryTestCase):
             table_id = f"{self.gcp_project_id}.{oaebu_output_dataset}.book_product{release_suffix}"
             self.assert_table_integrity(table_id, 2)
 
-            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_product_list{release_suffix}"
+            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id.replace('-', '_')}_book_product_list{release_suffix}"
             self.assert_table_integrity(table_id, 2)
 
-            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_publisher_metrics{release_suffix}"
+            table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id.replace('-', '_')}_book_publisher_metrics{release_suffix}"
             self.assert_table_integrity(table_id, 1)
 
             # Validate the joins worked
@@ -2829,7 +2829,7 @@ class TestOnixWorkflowFunctionalWithGoogleAnalytics(ObservatoryTestCase):
             self.assertTrue("112" in isbns)
 
             # Check export tables
-            sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id}_book_product_list{release_suffix}"
+            sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset}.{self.gcp_project_id.replace('-', '_')}_book_product_list{release_suffix}"
             records = run_bigquery_query(sql)
             isbns = set([record["product_id"] for record in records])
             self.assertEqual(len(isbns), 2)


### PR DESCRIPTION
simple change put a namespace in oaebu indexes (as part of the table names), and additionally each publishers table will also be name-spaced to ensure clarity