### PR TITLE
Remove date check from SQL merge query

### DIFF
--- a/observatory-dags/observatory/dags/database/sql/merge_delete_matched.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/merge_delete_matched.sql.jinja2
@@ -16,8 +16,8 @@
 MERGE
   `{{ dataset }}.{{ main_table }}` M
 USING
-  (SELECT {{ merge_condition_field }} AS id, {{ updated_date_field }} AS date FROM `{{ dataset }}.{{ partitioned_table }}` WHERE _PARTITIONDATE > '{{ start_date }}' AND _PARTITIONDATE <= '{{ end_date }}') P
+  (SELECT {{ merge_condition_field }} AS id FROM `{{ dataset }}.{{ partitioned_table }}` WHERE _PARTITIONDATE > '{{ start_date }}' AND _PARTITIONDATE <= '{{ end_date }}') P
 ON
   M.{{ merge_condition_field }} = P.id
-WHEN MATCHED AND M.{{ updated_date_field }} <= P.date OR M.{{ updated_date_field }} is null THEN
+WHEN MATCHED THEN
   DELETE

--- a/observatory-dags/observatory/dags/telescopes/crossref_events.py
+++ b/observatory-dags/observatory/dags/telescopes/crossref_events.py
@@ -182,9 +182,9 @@ class CrossrefEventsTelescope(StreamTelescope):
     def __init__(self, dag_id: str = DAG_ID, start_date: datetime = datetime(2018, 5, 14),
                  schedule_interval: str = '@weekly', dataset_id: str = 'crossref',
                  dataset_description: str = 'The Crossref Events dataset: https://www.eventdata.crossref.org/guide/',
-                 merge_partition_field: str = 'id', updated_date_field: str = 'timestamp',
-                 bq_merge_days: int = 7, batch_load: bool = True, airflow_vars: List = None,
-                 mailto: str = 'aniek.roelofs@curtin.edu.au', max_processes: int = min(32, os.cpu_count() + 4)):
+                 merge_partition_field: str = 'id', bq_merge_days: int = 7, batch_load: bool = True,
+                 airflow_vars: List = None, mailto: str = 'aniek.roelofs@curtin.edu.au',
+                 max_processes: int = min(32, os.cpu_count() + 4)):
         """ Construct a CrossrefEventsTelescope instance.
 
         :param dag_id: the id of the DAG.
@@ -193,7 +193,6 @@ class CrossrefEventsTelescope(StreamTelescope):
         :param dataset_id: the dataset id.
         :param dataset_description: the dataset description.
         :param merge_partition_field: the BigQuery field used to match partitions for a merge
-        :param updated_date_field: the BigQuery field used to determine newest entry for a merge
         :param bq_merge_days: how often partitions should be merged (every x days)
         :param batch_load: whether all files in the transform folder are loaded into 1 table at once
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow
@@ -204,9 +203,8 @@ class CrossrefEventsTelescope(StreamTelescope):
         if airflow_vars is None:
             airflow_vars = [AirflowVars.DATA_PATH, AirflowVars.PROJECT_ID, AirflowVars.DATA_LOCATION,
                             AirflowVars.DOWNLOAD_BUCKET, AirflowVars.TRANSFORM_BUCKET]
-        super().__init__(dag_id, start_date, schedule_interval, dataset_id, merge_partition_field,
-                         updated_date_field, bq_merge_days, dataset_description=dataset_description,
-                         airflow_vars=airflow_vars, batch_load=batch_load)
+        super().__init__(dag_id, start_date, schedule_interval, dataset_id, merge_partition_field, bq_merge_days,
+                         dataset_description=dataset_description, batch_load=batch_load, airflow_vars=airflow_vars)
         self.mailto = mailto
         self.max_processes = max_processes
 

--- a/observatory-dags/observatory/dags/telescopes/doab.py
+++ b/observatory-dags/observatory/dags/telescopes/doab.py
@@ -164,7 +164,6 @@ class DoabTelescope(StreamTelescope):
         schedule_interval: str = "@monthly",
         dataset_id: str = "doab",
         merge_partition_field: str = "id",
-        updated_date_field: str = "dc.date.accessioned",
         bq_merge_days: int = 7,
         airflow_vars: list = None,
     ):
@@ -176,16 +175,8 @@ class DoabTelescope(StreamTelescope):
                 AirflowVars.DOWNLOAD_BUCKET,
                 AirflowVars.TRANSFORM_BUCKET,
             ]
-        super().__init__(
-            dag_id,
-            start_date,
-            schedule_interval,
-            dataset_id,
-            merge_partition_field,
-            updated_date_field,
-            bq_merge_days,
-            airflow_vars=airflow_vars,
-        )
+        super().__init__(dag_id, start_date, schedule_interval, dataset_id, merge_partition_field, bq_merge_days,
+                         airflow_vars=airflow_vars)
 
         self.add_setup_task_chain([self.check_dependencies, self.get_release_info])
         self.add_task_chain(

--- a/observatory-dags/observatory/dags/telescopes/oapen_metadata.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_metadata.py
@@ -140,7 +140,6 @@ class OapenMetadataTelescope(StreamTelescope):
         schedule_interval: str = "@weekly",
         dataset_id: str = "oapen",
         merge_partition_field: str = "id",
-        updated_date_field: str = "dc.date.available",
         bq_merge_days: int = 7,
         schema_prefix: str = "oapen_",
         airflow_vars: List = None,
@@ -152,7 +151,6 @@ class OapenMetadataTelescope(StreamTelescope):
         :param schedule_interval: the schedule interval of the DAG.
         :param dataset_id: the dataset id.
         :param merge_partition_field: the BigQuery field used to match partitions for a merge
-        :param updated_date_field: the BigQuery field used to determine newest entry for a merge
         :param bq_merge_days: how often partitions should be merged (every x days)
         :param schema_prefix: the prefix used to find the schema path
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow
@@ -166,17 +164,8 @@ class OapenMetadataTelescope(StreamTelescope):
                 AirflowVars.DOWNLOAD_BUCKET,
                 AirflowVars.TRANSFORM_BUCKET,
             ]
-        super().__init__(
-            dag_id,
-            start_date,
-            schedule_interval,
-            dataset_id,
-            merge_partition_field,
-            updated_date_field,
-            bq_merge_days,
-            schema_prefix=schema_prefix,
-            airflow_vars=airflow_vars,
-        )
+        super().__init__(dag_id, start_date, schedule_interval, dataset_id, merge_partition_field, bq_merge_days,
+                         schema_prefix=schema_prefix, airflow_vars=airflow_vars)
 
         self.add_setup_task_chain([self.check_dependencies, self.get_release_info])
         self.add_task_chain(

--- a/observatory-platform/observatory/platform/telescopes/stream_telescope.py
+++ b/observatory-platform/observatory/platform/telescopes/stream_telescope.py
@@ -58,12 +58,12 @@ class StreamRelease(Release):
 
 class StreamTelescope(Telescope):
     def __init__(self, dag_id: str, start_date: datetime, schedule_interval: str, dataset_id: str,
-                 merge_partition_field: str, updated_date_field: str, bq_merge_days: int, catchup: bool = False,
-                 queue: str = 'default', max_retries: int = 3, max_active_runs: int = 1, source_format: SourceFormat =
-                 SourceFormat.NEWLINE_DELIMITED_JSON, schema_prefix: str = '',
-                 schema_version: str = None, load_bigquery_table_kwargs: Dict = None,
-                 dataset_description: str = '', table_descriptions: Dict[str, str] = None, batch_load: bool = False,
-                 airflow_vars: list = None, airflow_conns: list = None):
+                 merge_partition_field: str, bq_merge_days: int, catchup: bool = False, queue: str = 'default',
+                 max_retries: int = 3, max_active_runs: int = 1,
+                 source_format: SourceFormat = SourceFormat.NEWLINE_DELIMITED_JSON, schema_prefix: str = '',
+                 schema_version: str = None, load_bigquery_table_kwargs: Dict = None, dataset_description: str = '',
+                 table_descriptions: Dict[str, str] = None, batch_load: bool = False, airflow_vars: list = None,
+                 airflow_conns: list = None):
         """ Construct a StreamTelescope instance.
 
         :param dag_id: the id of the DAG.
@@ -71,7 +71,6 @@ class StreamTelescope(Telescope):
         :param schedule_interval: the schedule interval of the DAG.
         :param dataset_id: the dataset id.
         :param merge_partition_field: the BigQuery field used to match partitions for a merge
-        :param updated_date_field: the BigQuery field used to determine newest entry for a merge
         :param bq_merge_days: how often partitions should be merged (every x days)
         :param catchup: whether to catchup the DAG or not.
         :param queue: the Airflow queue name.
@@ -101,7 +100,6 @@ class StreamTelescope(Telescope):
         self.dataset_id = dataset_id
         self.source_format = source_format
         self.merge_partition_field = merge_partition_field
-        self.updated_date_field = updated_date_field
         self.bq_merge_days = bq_merge_days
         self.load_bigquery_table_kwargs = load_bigquery_table_kwargs if load_bigquery_table_kwargs else dict()
         self.dataset_description = dataset_description
@@ -186,12 +184,12 @@ class StreamTelescope(Telescope):
                 if self.batch_load:
                     main_table_id, partition_table_id = self.dag_id, f'{self.dag_id}_partitions'
                     bq_delete_old(start_date, end_date, self.dataset_id, main_table_id, partition_table_id,
-                                  self.merge_partition_field, self.updated_date_field)
+                                  self.merge_partition_field)
                     return
                 else:
                     main_table_id, partition_table_id = table_ids_from_path(transform_path)
                     bq_delete_old(start_date, end_date, self.dataset_id, main_table_id, partition_table_id,
-                                  self.merge_partition_field, self.updated_date_field)
+                                  self.merge_partition_field)
         else:
             raise AirflowSkipException(f'Skipped, only delete old records every {self.bq_merge_days} days. '
                                        f'Last delete was {(end_date - start_date).days + 1} days ago on {ti.previous_start_date_success}')

--- a/observatory-platform/observatory/platform/utils/template_utils.py
+++ b/observatory-platform/observatory/platform/utils/template_utils.py
@@ -467,7 +467,6 @@ def bq_delete_old(
     main_table_id: str,
     partition_table_id: str,
     merge_partition_field: str,
-    updated_date_field: str,
 ):
     """ Will run a BigQuery query that deletes rows from the main table that are matched with rows from
     specific partitions of the partition table.
@@ -478,7 +477,6 @@ def bq_delete_old(
     :param main_table_id: Main table id.
     :param partition_table_id: Partition table id.
     :param merge_partition_field: Merge partition field.
-    :param updated_date_field: Updated date field.
     :return: None.
     """
     start_date = start_date.strftime("%Y-%m-%d")
@@ -488,7 +486,6 @@ def bq_delete_old(
     main_table = main_table_id
     partitioned_table = partition_table_id
     merge_condition_field = merge_partition_field
-    updated_date_field = updated_date_field
 
     template_path = os.path.join(workflow_sql_templates_path(), make_sql_jinja2_filename("merge_delete_matched"))
     query = render_template(
@@ -499,7 +496,6 @@ def bq_delete_old(
         merge_condition_field=merge_condition_field,
         start_date=start_date,
         end_date=end_date,
-        updated_date_field=updated_date_field,
     )
     run_bigquery_query(query)
 


### PR DESCRIPTION
Remove usage of date field to check if a matched row is older/newer when merging partitions into a table.

The original SQL
```sql
MERGE
  {{ dataset }}.{{ main_table }} M
USING
  (SELECT {{ merge_condition_field }} AS id, {{ updated_date_field }} AS date FROM {{ dataset }}.{{ partitioned_table }} WHERE _PARTITIONDATE >= '{{ start_date }}' AND _PARTITIONDATE < '{{ end_date }}') P
ON
  M.{{ merge_condition_field }} = P.id
WHEN MATCHED AND M.{{ updated_date_field }} <= P.date OR M.{{ updated_date_field }} is null THEN
  DELETE
```

After removing the date check when a row is matched:
```sql
MERGE
  `{{ dataset }}.{{ main_table }}` M
USING
  (SELECT {{ merge_condition_field }} AS id FROM `{{ dataset }}.{{ partitioned_table }}` WHERE _PARTITIONDATE > '{{ start_date }}' AND _PARTITIONDATE <= '{{ end_date }}') P
ON
  M.{{ merge_condition_field }} = P.id
WHEN MATCHED THEN
  DELETE
```

An issue came up when for a telescope (oapen metadata) the field used for the `updated_date_field` had its mode changed from REQUIRED to REPEATED, because this field can have multiple values.
The `updated_date_field` can't be a REPEATED field in the merge query and there is not really another appropriate field to use instead.

I think this check was a safety check in the first place, because the partition that is merged into the main table should always include newer data. Since this is now causing issues I suggest to just remove this safety check from the merge query completely.