### PR TITLE
Conditionally create the external IP used for VMs based on the environment

### DIFF
--- a/observatory-platform/observatory/platform/terraform/main.tf
+++ b/observatory-platform/observatory/platform/terraform/main.tf
@@ -561,7 +561,7 @@ data "google_compute_image" "observatory_image" {
 }
 
 resource "google_compute_address" "airflow_main_vm_static_external_ip" {
-  count = var.environment == "develop" ? 1 : 0
+  count = var.environment == "production" ? 1 : 0
   name = "${local.main_vm_name}-static-external-ip"
   address_type = "EXTERNAL"
   region = var.google_cloud.region

--- a/observatory-platform/observatory/platform/terraform/main.tf
+++ b/observatory-platform/observatory/platform/terraform/main.tf
@@ -555,16 +555,6 @@ data "google_compute_image" "observatory_image" {
   depends_on = [google_project_service.compute_engine]
 }
 
-resource "google_compute_address" "airflow_main_vm_static_external_ip" {
-  name = "${local.main_vm_name}-static-external-ip"
-  address_type = "EXTERNAL"
-  region = var.google_cloud.region
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
-
 module "airflow_main_vm" {
   source = "./vm"
   name = local.main_vm_name
@@ -584,21 +574,11 @@ module "airflow_main_vm" {
   service_account_email = local.compute_service_account_email
   startup_script_path = "./startup-main.tpl"
   metadata_variables = local.metadata_variables
-  static_external_ip = google_compute_address.airflow_main_vm_static_external_ip
 }
 
 ########################################################################################################################
 # Observatory Platform Worker VM
 ########################################################################################################################
-
-resource "google_compute_address" "airflow_worker_vm_static_external_ip" {
-  name = "${local.worker_vm_name}-static-external-ip"
-  address_type = "EXTERNAL"
-  region = var.google_cloud.region
-  lifecycle {
-    prevent_destroy = true
-  }
-}
 
 module "airflow_worker_vm" {
   count = var.airflow_worker_vm.create == true ? 1 : 0
@@ -615,7 +595,6 @@ module "airflow_worker_vm" {
   service_account_email = local.compute_service_account_email
   startup_script_path = "./startup-worker.tpl"
   metadata_variables = local.metadata_variables
-  static_external_ip = google_compute_address.airflow_worker_vm_static_external_ip
 }
 
 ########################################################################################################################

--- a/observatory-platform/observatory/platform/terraform/vm/main.tf
+++ b/observatory-platform/observatory/platform/terraform/vm/main.tf
@@ -1,3 +1,13 @@
+resource "google_compute_address" "vm_static_external_ip" {
+  count = var.metadata_variables["environment"] == "production" ? 1 : 0
+  name = "${var.name}-static-external-ip"
+  address_type = "EXTERNAL"
+  region = var.region
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "google_compute_address" "vm_private_ip" {
   name = "${var.name}-private-ip"
   address_type = "INTERNAL"
@@ -23,7 +33,7 @@ resource "google_compute_instance" "vm_instance" {
     network_ip = google_compute_address.vm_private_ip.address
     subnetwork = var.subnetwork.name # Subnetwork should be specified for custom subnetmode network
     access_config {
-      nat_ip = var.static_external_ip.address
+      nat_ip = try(google_compute_address.vm_static_external_ip[0].address, null)
     }
   }
 

--- a/observatory-platform/observatory/platform/terraform/vm/main.tf
+++ b/observatory-platform/observatory/platform/terraform/vm/main.tf
@@ -1,13 +1,3 @@
-resource "google_compute_address" "vm_static_external_ip" {
-  count = var.metadata_variables["environment"] == "production" ? 1 : 0
-  name = "${var.name}-static-external-ip"
-  address_type = "EXTERNAL"
-  region = var.region
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "google_compute_address" "vm_private_ip" {
   name = "${var.name}-private-ip"
   address_type = "INTERNAL"
@@ -33,7 +23,7 @@ resource "google_compute_instance" "vm_instance" {
     network_ip = google_compute_address.vm_private_ip.address
     subnetwork = var.subnetwork.name # Subnetwork should be specified for custom subnetmode network
     access_config {
-      nat_ip = try(google_compute_address.vm_static_external_ip[0].address, null)
+      nat_ip = var.static_external_ip_address
     }
   }
 

--- a/observatory-platform/observatory/platform/terraform/vm/variables.tf
+++ b/observatory-platform/observatory/platform/terraform/vm/variables.tf
@@ -26,14 +26,6 @@ variable "subnetwork" {
   description = ""
 }
 
-variable "static_external_ip" {
-  type = object({
-    id=string
-    address=string
-  })
-  description = "The static external IP address for the VM"
-}
-
 variable "region" {
   type = string
   description = ""

--- a/observatory-platform/observatory/platform/terraform/vm/variables.tf
+++ b/observatory-platform/observatory/platform/terraform/vm/variables.tf
@@ -26,6 +26,11 @@ variable "subnetwork" {
   description = ""
 }
 
+variable "static_external_ip_address" {
+  type = string
+  description = "The static external IP address for the VM"
+}
+
 variable "region" {
   type = string
   description = ""


### PR DESCRIPTION
Currently, the `google_compute_address` resource that is created for both VMs has the lifecycle attribute 'prevent_destroy' set to 'true'.

This means that any terraform destroy is prevented, which is an issue, because in a develop environment the terraform resources should be able to be destroyed and created.

The compute address resource is used to create an external ip address and the address is passed to the configuration of the airflow VMs. I believe the ip address should stay the same in the production environment, so it makes sense that this resource prevents destroy there.

I've changed it so that the compute address is only created and used in the production environment (with the prevent_destroy still set).
Additionally I moved this resource inside the VM module, because I think it fits better in there and reduces duplication of writing the code for this resource both for the worker/main VM.

I've tested that the VM is still created correctly and works in both the develop/production environment.