### PR TITLE
Bugfixes for running workflows in production

### DIFF
--- a/observatory-dags/observatory/dags/dags/elastic_import.py
+++ b/observatory-dags/observatory/dags/dags/elastic_import.py
@@ -37,10 +37,9 @@ DAG_PREFIX = "elastic_import"
 ELASTIC_MAPPINGS_PATH = make_elastic_mappings_path()
 AO_KIBANA_TIME_FIELDS = [TimeField("^.*$", "published_year")]
 OAEBU_KIBANA_TIME_FIELDS = [
-    TimeField("^oaebu-unmatched-book-metrics$", "release_date"),
-    TimeField("^oaebu-book-product-list$", "release_date"),
+    TimeField("^oaebu-.*-unmatched-book-metrics$", "release_date"),
+    TimeField("^oaebu-.*-book-product-list$", "time_field"),
     TimeField("^oaebu-.*$", "month"),
-    TimeField("^.*$", "published_year"),
 ]
 
 
@@ -113,13 +112,13 @@ configs = [
         kibana_time_fields=OAEBU_KIBANA_TIME_FIELDS,
     ),
     ElasticImportConfig(
-        dag_id=make_dag_id(DAG_PREFIX, "umich_press"),
+        dag_id=make_dag_id(DAG_PREFIX, "university_of_michigan_press"),
         project_id="oaebu-umich-press",
         dataset_id=DATASET_ID,
         bucket_name="oaebu-umich-press-transform",
         data_location=DATA_LOCATION,
         file_type=FILE_TYPE_JSONL,
-        sensor_dag_ids=[make_dag_id(DAG_ONIX_WORKFLOW_PREFIX, "umich_press")],
+        sensor_dag_ids=[make_dag_id(DAG_ONIX_WORKFLOW_PREFIX, "university_of_michigan_press")],
         elastic_mappings_path=ELASTIC_MAPPINGS_PATH,
         elastic_mappings_func=load_elastic_mappings_oaebu,
         kibana_spaces=["oaebu-umich-press", "dev-oaebu-umich-press"],

--- a/observatory-dags/observatory/dags/dags/mag.py
+++ b/observatory-dags/observatory/dags/dags/mag.py
@@ -41,8 +41,7 @@ Saved to the BigQuery tables:
     <project_id>.mag.RelatedFieldOfStudyYYYYMMDD
 """
 
-from datetime import datetime
-
+import pendulum
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.python_operator import ShortCircuitOperator
@@ -51,7 +50,7 @@ from observatory.dags.telescopes.mag import MagTelescope
 
 default_args = {
     "owner": "airflow",
-    "start_date": datetime(2020, 7, 1)
+    "start_date": pendulum.Pendulum(2020, 7, 1)
 }
 
 with DAG(dag_id=MagTelescope.DAG_ID, schedule_interval="@weekly", default_args=default_args, max_active_runs=1) as dag:

--- a/observatory-dags/observatory/dags/dags/onix_workflow.py
+++ b/observatory-dags/observatory/dags/dags/onix_workflow.py
@@ -88,27 +88,39 @@ def get_oaebu_partner_data(project_id, org_name):
     ]
 
     publisher_to_provider_mapping = {
-        "ANU Press": [OaebuPartnerName.google_analytics,
-                            OaebuPartnerName.google_books_sales,
-                            OaebuPartnerName.google_books_traffic,
-                            OaebuPartnerName.jstor_country,
-                            OaebuPartnerName.jstor_institution,
-                            OaebuPartnerName.oapen_irus_uk],
-        "UCL Press": [OaebuPartnerName.google_books_sales,
-                            OaebuPartnerName.google_books_traffic,
-                            OaebuPartnerName.jstor_country,
-                            OaebuPartnerName.jstor_institution,
-                            OaebuPartnerName.oapen_irus_uk,
-                            OaebuPartnerName.ucl_discovery],
+        "ANU Press": [
+            OaebuPartnerName.google_analytics,
+            OaebuPartnerName.google_books_sales,
+            OaebuPartnerName.google_books_traffic,
+            OaebuPartnerName.jstor_country,
+            OaebuPartnerName.jstor_institution,
+            OaebuPartnerName.oapen_irus_uk,
+        ],
+        "UCL Press": [
+            OaebuPartnerName.google_books_sales,
+            OaebuPartnerName.google_books_traffic,
+            OaebuPartnerName.jstor_country,
+            OaebuPartnerName.jstor_institution,
+            OaebuPartnerName.oapen_irus_uk,
+            OaebuPartnerName.ucl_discovery,
+        ],
         "Wits University Press": [],
-        "University of Michigan Press": [],
+        "University of Michigan Press": [
+            OaebuPartnerName.google_books_sales,
+            OaebuPartnerName.google_books_traffic,
+            OaebuPartnerName.jstor_country,
+            OaebuPartnerName.jstor_institution,
+            OaebuPartnerName.oapen_irus_uk,
+        ],
         "Springer Nature": [],
         "Oapen Press": [OaebuPartnerName.oapen_irus_uk],
-        "Curtin Press": [OaebuPartnerName.google_books_sales,
-                            OaebuPartnerName.google_books_traffic,
-                            OaebuPartnerName.jstor_country,
-                            OaebuPartnerName.jstor_institution,
-                            OaebuPartnerName.oapen_irus_uk],
+        "Curtin Press": [
+            OaebuPartnerName.google_books_sales,
+            OaebuPartnerName.google_books_traffic,
+            OaebuPartnerName.jstor_country,
+            OaebuPartnerName.jstor_institution,
+            OaebuPartnerName.oapen_irus_uk,
+        ],
     }
 
     publisher_data_partners = list()
@@ -134,10 +146,7 @@ for telescope in telescopes:
     data_partners = get_oaebu_partner_data(gcp_project_id, org_name)
 
     onix_workflow = OnixWorkflow(
-        org_name=org_name,
-        gcp_project_id=gcp_project_id,
-        gcp_bucket_name=gcp_bucket_name,
-        data_partners=data_partners,
+        org_name=org_name, gcp_project_id=gcp_project_id, gcp_bucket_name=gcp_bucket_name, data_partners=data_partners,
     )
 
     globals()[onix_workflow.dag_id] = onix_workflow.make_dag()

--- a/observatory-dags/observatory/dags/dags/open_citations.py
+++ b/observatory-dags/observatory/dags/dags/open_citations.py
@@ -20,8 +20,7 @@ A DAG that harvests the OpenCitations Indexes: http://opencitations.net/
 Saved to the BigQuery table: <project_id>.open_citations.open_citationsYYYYMMDD
 """
 
-from datetime import datetime
-
+import pendulum
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.python_operator import ShortCircuitOperator
@@ -30,7 +29,7 @@ from observatory.dags.telescopes.open_citations import OpenCitationsTelescope
 
 default_args = {
     "owner": "airflow",
-    "start_date": datetime(2018, 7, 1)
+    "start_date": pendulum.Pendulum(2018, 7, 1)
 }
 
 with DAG(dag_id=OpenCitationsTelescope.DAG_ID, schedule_interval="@weekly", default_args=default_args) as dag:

--- a/observatory-dags/observatory/dags/dags/scopus.py
+++ b/observatory-dags/observatory/dags/dags/scopus.py
@@ -16,16 +16,17 @@
 
 
 import logging
-from datetime import datetime
 
+import pendulum
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.subdag_operator import SubDagOperator
+
 from observatory.dags.telescopes.scopus import ScopusTelescope
 from observatory.platform.utils.airflow_utils import list_connections
 
 default_args = {'owner': 'airflow',
-                'start_date': datetime(2018, 1, 1),
+                'start_date': pendulum.Pendulum(2018, 1, 1),
                 }
 
 

--- a/observatory-dags/observatory/dags/dags/unpaywall.py
+++ b/observatory-dags/observatory/dags/dags/unpaywall.py
@@ -26,8 +26,7 @@ Does not work with the following releases:
 * 2018-03-29, 2018-04-28, 2018-06-21, 2018-09-02, 2018-09-06
 """
 
-from datetime import datetime
-
+import pendulum
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.python_operator import ShortCircuitOperator
@@ -36,7 +35,7 @@ from observatory.dags.telescopes.unpaywall import UnpaywallTelescope
 
 default_args = {
     "owner": "airflow",
-    "start_date": datetime(2018, 9, 7)
+    "start_date": pendulum.Pendulum(2018, 9, 7)
 }
 
 with DAG(dag_id="unpaywall", schedule_interval="@weekly", default_args=default_args) as dag:

--- a/observatory-dags/observatory/dags/dags/wos.py
+++ b/observatory-dags/observatory/dags/dags/wos.py
@@ -16,16 +16,17 @@
 
 
 import logging
-from datetime import datetime
 
+import pendulum
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.subdag_operator import SubDagOperator
+
 from observatory.dags.telescopes.wos import WosTelescope
 from observatory.platform.utils.airflow_utils import list_connections
 
 default_args = {'owner': 'airflow',
-                'start_date': datetime(2018, 1, 1),
+                'start_date': pendulum.Pendulum(2018, 1, 1),
                 }
 
 

--- a/observatory-dags/observatory/dags/telescopes/crossref_events.py
+++ b/observatory-dags/observatory/dags/telescopes/crossref_events.py
@@ -20,7 +20,6 @@ import logging
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
 from typing import List, Tuple, Union
 
 import jsonlines
@@ -28,11 +27,12 @@ import pendulum
 import requests
 from airflow.exceptions import AirflowSkipException
 from airflow.models.taskinstance import TaskInstance
+from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed, RetryError
+
 from observatory.platform.telescopes.stream_telescope import (StreamRelease, StreamTelescope)
 from observatory.platform.utils.airflow_utils import AirflowVars
-from observatory.platform.utils.url_utils import get_ao_user_agent
 from observatory.platform.utils.template_utils import upload_files_from_list
-from tenacity import retry, stop_after_attempt, wait_exponential, wait_fixed, RetryError
+from observatory.platform.utils.url_utils import get_ao_user_agent
 
 
 class CrossrefEventsRelease(StreamRelease):
@@ -179,7 +179,7 @@ class CrossrefEventsTelescope(StreamTelescope):
 
     DAG_ID = 'crossref_events'
 
-    def __init__(self, dag_id: str = DAG_ID, start_date: datetime = datetime(2018, 5, 14),
+    def __init__(self, dag_id: str = DAG_ID, start_date: pendulum.Pendulum = pendulum.Pendulum(2018, 5, 14),
                  schedule_interval: str = '@weekly', dataset_id: str = 'crossref',
                  dataset_description: str = 'The Crossref Events dataset: https://www.eventdata.crossref.org/guide/',
                  merge_partition_field: str = 'id', bq_merge_days: int = 7, batch_load: bool = True,

--- a/observatory-dags/observatory/dags/telescopes/crossref_fundref.py
+++ b/observatory-dags/observatory/dags/telescopes/crossref_fundref.py
@@ -25,7 +25,6 @@ import random
 import shutil
 import subprocess
 import xml.etree.ElementTree as ET
-from datetime import datetime
 from typing import Dict, List, Tuple
 
 import jsonlines
@@ -34,13 +33,14 @@ import requests
 from airflow.api.common.experimental.pool import create_pool
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
+from pendulum import Pendulum
+
 from observatory.platform.telescopes.snapshot_telescope import SnapshotRelease, SnapshotTelescope
 from observatory.platform.utils.airflow_utils import AirflowVariable as Variable, AirflowVars
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id, bigquery_table_exists
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.template_utils import upload_files_from_list
 from observatory.platform.utils.url_utils import retry_session
-from pendulum import Pendulum
 
 
 class CrossrefFundrefRelease(SnapshotRelease):
@@ -175,7 +175,7 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
     def __init__(
         self,
         dag_id: str = DAG_ID,
-        start_date: datetime = datetime(2014, 3, 1),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2014, 3, 1),
         schedule_interval: str = "@weekly",
         dataset_id: str = DATASET_ID,
         table_descriptions: Dict = None,

--- a/observatory-dags/observatory/dags/telescopes/crossref_metadata.py
+++ b/observatory-dags/observatory/dags/telescopes/crossref_metadata.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations, annotations
 
-import datetime
 import functools
 import logging
 import os
@@ -25,7 +24,6 @@ import shutil
 import subprocess
 import xml.etree.ElementTree as ET
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
 from subprocess import Popen
 from typing import Dict, List
 
@@ -163,7 +161,7 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
     def __init__(
         self,
         dag_id: str = DAG_ID,
-        start_date: datetime = datetime(2020, 6, 7),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2020, 6, 7),
         schedule_interval: str = SCHEDULE_INTERVAL,
         dataset_id: str = "crossref",
         queue: str = 'remote_queue',

--- a/observatory-dags/observatory/dags/telescopes/doab.py
+++ b/observatory-dags/observatory/dags/telescopes/doab.py
@@ -18,7 +18,6 @@
 import csv
 import logging
 import os
-from datetime import datetime
 from typing import Tuple
 
 import pendulum
@@ -160,7 +159,7 @@ class DoabTelescope(StreamTelescope):
     def __init__(
         self,
         dag_id: str = "doab",
-        start_date: datetime = datetime(2018, 5, 14),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2018, 5, 14),
         schedule_interval: str = "@monthly",
         dataset_id: str = "doab",
         merge_partition_field: str = "id",

--- a/observatory-dags/observatory/dags/telescopes/geonames.py
+++ b/observatory-dags/observatory/dags/telescopes/geonames.py
@@ -144,7 +144,7 @@ class GeonamesTelescope(SnapshotTelescope):
 
     DAG_ID = 'geonames'
 
-    def __init__(self, dag_id: str = DAG_ID, start_date: datetime = datetime(2020, 9, 1),
+    def __init__(self, dag_id: str = DAG_ID, start_date: pendulum.Pendulum = pendulum.Pendulum(2020, 9, 1),
                  schedule_interval: str = '@weekly', dataset_id: str = 'geonames',
                  source_format: str = SourceFormat.CSV,
                  dataset_description: str = 'The GeoNames geographical database: https://www.geonames.org/',

--- a/observatory-dags/observatory/dags/telescopes/google_analytics.py
+++ b/observatory-dags/observatory/dags/telescopes/google_analytics.py
@@ -16,10 +16,9 @@
 
 from __future__ import annotations
 
-import datetime
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Dict, List, Optional, Tuple
 
 import pendulum
@@ -110,7 +109,7 @@ class GoogleAnalyticsTelescope(SnapshotTelescope):
         view_id: str,
         pagepath_regex: str,
         dag_id: Optional[str] = None,
-        start_date: datetime = datetime(2018, 1, 1),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2018, 1, 1),
         schedule_interval: str = "@monthly",
         dataset_id: str = "google",
         catchup: bool = True,

--- a/observatory-dags/observatory/dags/telescopes/google_books.py
+++ b/observatory-dags/observatory/dags/telescopes/google_books.py
@@ -161,7 +161,7 @@ class GoogleBooksTelescope(SnapshotTelescope):
         self,
         organisation: Organisation,
         dag_id: Optional[str] = None,
-        start_date: datetime = datetime(2018, 1, 1),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2018, 1, 1),
         schedule_interval: str = "@monthly",
         dataset_id: str = "google",
         catchup: bool = False,

--- a/observatory-dags/observatory/dags/telescopes/grid.py
+++ b/observatory-dags/observatory/dags/telescopes/grid.py
@@ -16,12 +16,10 @@
 
 from __future__ import annotations
 
-import datetime
 import json
 import logging
 import os
 import re
-from datetime import datetime
 from shutil import copyfile
 from typing import List
 from zipfile import BadZipFile, ZipFile
@@ -209,7 +207,7 @@ class GridTelescope(SnapshotTelescope):
     def __init__(
         self,
         dag_id: str = DAG_ID,
-        start_date: datetime = datetime(2015, 9, 1),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2015, 9, 1),
         schedule_interval: str = "@weekly",
         dataset_id: str = DATASET_ID,
         source_format: str = SourceFormat.NEWLINE_DELIMITED_JSON,

--- a/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
@@ -19,7 +19,6 @@ import json
 import logging
 import os
 import time
-from datetime import datetime
 from typing import List, Optional, Tuple, Dict
 from urllib.parse import quote
 
@@ -166,7 +165,7 @@ class OapenIrusUkRelease(SnapshotRelease):
         function_url = f"https://{function_region}-{oapen_project_id}.cloudfunctions.net/{function_name}"
         geoip_license_key = BaseHook.get_connection(AirflowConns.GEOIP_LICENSE_KEY).password
 
-        if self.release_date >= datetime(2020, 4, 1):
+        if self.release_date >= pendulum.Pendulum(2020, 4, 1):
             publisher_uuid = get_publisher_uuid(publisher_id)
             airflow_conn = AirflowConns.OAPEN_IRUS_UK_API
         else:
@@ -239,7 +238,7 @@ class OapenIrusUkTelescope(SnapshotTelescope):
         organisation: Organisation,
         publisher_id: str,
         dag_id: Optional[str] = None,
-        start_date: datetime = datetime(2018, 1, 1),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2018, 1, 1),
         schedule_interval: str = "0 0 14 * *",
         dataset_id: str = "oapen",
         dataset_description: str = "OAPEN dataset",

--- a/observatory-dags/observatory/dags/telescopes/oapen_metadata.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_metadata.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import csv
 import logging
 import os
-from datetime import datetime
 from typing import Tuple, List
 
 import pendulum
@@ -136,7 +135,7 @@ class OapenMetadataTelescope(StreamTelescope):
     def __init__(
         self,
         dag_id: str = "oapen_metadata",
-        start_date: datetime = datetime(2018, 5, 14),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2018, 5, 14),
         schedule_interval: str = "@weekly",
         dataset_id: str = "oapen",
         merge_partition_field: str = "id",

--- a/observatory-dags/observatory/dags/telescopes/onix.py
+++ b/observatory-dags/observatory/dags/telescopes/onix.py
@@ -206,7 +206,7 @@ class OnixTelescope(SnapshotTelescope):
         date_regex: str,
         date_format: str,
         dag_id: Optional[str] = None,
-        start_date: datetime = datetime(2021, 3, 28),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2021, 3, 28),
         schedule_interval: str = "@weekly",
         dataset_id: str = "onix",
         source_format: str = SourceFormat.NEWLINE_DELIMITED_JSON,

--- a/observatory-dags/observatory/dags/telescopes/ucl_discovery.py
+++ b/observatory-dags/observatory/dags/telescopes/ucl_discovery.py
@@ -231,7 +231,7 @@ class UclDiscoveryTelescope(SnapshotTelescope):
         self,
         organisation: Organisation,
         dag_id: Optional[str] = None,
-        start_date: datetime = datetime(2008, 1, 1),
+        start_date: pendulum.Pendulum = pendulum.Pendulum(2008, 1, 1),
         schedule_interval: str = "@monthly",
         dataset_id: str = "ucl",
         airflow_vars: list = None,

--- a/observatory-dags/observatory/dags/workflows/doi_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/doi_workflow.py
@@ -20,9 +20,9 @@ import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from datetime import datetime
 from typing import List, Dict, Optional, Tuple
 
+import pendulum
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
 from airflow.sensors.external_task_sensor import ExternalTaskSensor
@@ -345,7 +345,7 @@ class DoiWorkflow(Telescope):
         elastic_dataset_id: str = ELASTIC_DATASET_ID,
         transforms: Tuple = None,
         dag_id: Optional[str] = "doi",
-        start_date: Optional[Pendulum] = datetime(2020, 8, 30),
+        start_date: Optional[Pendulum] = pendulum.Pendulum(2020, 8, 30),
         schedule_interval: Optional[str] = "@weekly",
         catchup: Optional[bool] = False,
         airflow_vars: List = None,

--- a/observatory-dags/observatory/dags/workflows/doi_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/doi_workflow.py
@@ -265,8 +265,17 @@ class DoiWorkflow(Telescope):
     EXPORT_OUTPUT_TYPES_FILENAME = make_sql_jinja2_filename("export_output_types")
     EXPORT_RELATIONS_FILENAME = make_sql_jinja2_filename("export_relations")
 
-    SENSOR_DAG_IDS = ["crossref_metadata", "crossref_fundref", "geonames", "grid", "mag", "open_citations",
-                      "unpaywall", "orcid"]
+    SENSOR_DAG_IDS = [
+        "crossref_metadata",
+        "crossref_fundref",
+        "geonames",
+        "grid",
+        "mag",
+        "open_citations",
+        "unpaywall",
+        "orcid",
+        "crossref_events",
+    ]
 
     AGGREGATIONS = [
         Aggregation(

--- a/observatory-platform/observatory/platform/dags/dummy_telescope.py
+++ b/observatory-platform/observatory/platform/dags/dummy_telescope.py
@@ -14,14 +14,13 @@
 
 # Author: Aniek Roelofs
 
-from datetime import datetime
-
+import pendulum
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 
 default_args = {
     "owner": "airflow",
-    "start_date": datetime(2020, 8, 10)
+    "start_date": pendulum.Pendulum(2020, 8, 10)
 }
 
 with DAG(dag_id="dummy_telescope", schedule_interval="@daily", default_args=default_args, catchup=True) as dag:

--- a/observatory-platform/observatory/platform/dags/vm_create.py
+++ b/observatory-platform/observatory/platform/dags/vm_create.py
@@ -14,8 +14,7 @@
 
 # Author: Aniek Roelofs
 
-from datetime import datetime
-
+import pendulum
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.python_operator import ShortCircuitOperator
@@ -24,7 +23,7 @@ from observatory.platform.tasks.terraform import TerraformTasks
 
 default_args = {
     "owner": "airflow",
-    "start_date": datetime(2020, 7, 1)
+    "start_date": pendulum.Pendulum(2020, 7, 1)
 }
 
 with DAG(dag_id=TerraformTasks.DAG_ID_CREATE_VM, schedule_interval="@weekly", default_args=default_args,

--- a/observatory-platform/observatory/platform/dags/vm_destroy.py
+++ b/observatory-platform/observatory/platform/dags/vm_destroy.py
@@ -14,8 +14,7 @@
 
 # Author: Aniek Roelofs
 
-from datetime import datetime
-
+import pendulum
 from airflow import DAG
 from airflow.operators.python_operator import BranchPythonOperator
 from airflow.operators.python_operator import PythonOperator
@@ -25,7 +24,7 @@ from observatory.platform.tasks.terraform import TerraformTasks
 
 default_args = {
     "owner": "airflow",
-    "start_date": datetime(2020, 1, 1)
+    "start_date": pendulum.Pendulum(2020, 1, 1)
 }
 
 with DAG(dag_id=TerraformTasks.DAG_ID_DESTROY_VM, schedule_interval="*/10 * * * *", default_args=default_args,

--- a/observatory-platform/observatory/platform/telescopes/snapshot_telescope.py
+++ b/observatory-platform/observatory/platform/telescopes/snapshot_telescope.py
@@ -14,7 +14,6 @@
 
 # Author: Aniek Roelofs, James Diprose, Tuan Chien
 
-import datetime
 from typing import List, Dict
 
 import pendulum
@@ -43,7 +42,7 @@ class SnapshotRelease(Release):
 
 
 class SnapshotTelescope(Telescope):
-    def __init__(self, dag_id: str, start_date: datetime, schedule_interval: str, dataset_id: str, catchup: bool = True,
+    def __init__(self, dag_id: str, start_date: pendulum.Pendulum, schedule_interval: str, dataset_id: str, catchup: bool = True,
                  queue: str = 'default', max_retries: int = 3, max_active_runs: int = 1,
                  source_format: SourceFormat = SourceFormat.NEWLINE_DELIMITED_JSON, schema_prefix: str = '',
                  schema_version: str = None, load_bigquery_table_kwargs: Dict = None,

--- a/observatory-platform/observatory/platform/telescopes/telescope.py
+++ b/observatory-platform/observatory/platform/telescopes/telescope.py
@@ -17,13 +17,13 @@
 import contextlib
 import copy
 import dataclasses
-import datetime
 import logging
 import shutil
 from abc import ABC, abstractmethod
 from functools import partial
 from typing import Any, Callable, List, Union, Dict
 
+import pendulum
 from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
@@ -210,7 +210,7 @@ class Telescope(AbstractTelescope):
     def __init__(
         self,
         dag_id: str,
-        start_date: datetime,
+        start_date: pendulum.Pendulum,
         schedule_interval: str,
         catchup: bool = False,
         queue: str = "default",

--- a/observatory-platform/observatory/platform/utils/telescope_utils.py
+++ b/observatory-platform/observatory/platform/utils/telescope_utils.py
@@ -538,7 +538,7 @@ def make_telescope_sensor(telescope_name: str, dag_prefix: str) -> ExternalTaskS
     dag_id = make_dag_id(dag_prefix, telescope_name)
 
     return ExternalTaskSensor(
-        task_id=f"{dag_id}_sensor", external_dag_id=dag_id, mode="reschedule", start_date=datetime(2021, 3, 28)
+        task_id=f"{dag_id}_sensor", external_dag_id=dag_id, mode="reschedule", start_date=pendulum.Pendulum(2021, 3, 28)
     )
 
 

--- a/tests/observatory/dags/workflows/test_doi.py
+++ b/tests/observatory/dags/workflows/test_doi.py
@@ -141,6 +141,7 @@ class TestDoiWorkflow(ObservatoryTestCase):
                 "open_citations_sensor": ["check_dependencies"],
                 "unpaywall_sensor": ["check_dependencies"],
                 "orcid_sensor": ["check_dependencies"],
+                "crossref_events_sensor": ["check_dependencies"],
                 "check_dependencies": ["create_datasets"],
                 "create_datasets": [
                     "create_crossref_events",

--- a/tests/observatory/dags/workflows/test_elastic_import_workflow.py
+++ b/tests/observatory/dags/workflows/test_elastic_import_workflow.py
@@ -366,7 +366,7 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
         with env.create():
             expected_dag_ids = [
                 make_dag_id("elastic_import", suffix)
-                for suffix in ["observatory", "anu_press", "ucl_press", "wits_press", "umich_press"]
+                for suffix in ["observatory", "anu_press", "ucl_press", "wits_press", "university_of_michigan_press"]
             ]
 
             dag_file = os.path.join(module_file_path("observatory.dags.dags"), "elastic_import.py")


### PR DESCRIPTION
This PR fixes a number of issues that were found when running the workflows in production:
* JSTOR telescope: log a warning instead failing when encountering unknown file types.
* Change datetime.datetime types to pendulum.Pendulum: encountered errors in the scheduler because we were using a mix of datetime.datetime and pendulum.Pendulum (timezone aware) types and the scheduler was throwing errors because it can't compare naive datetimes to timezone aware datetimes.
* Add Umich to onix workflow data partners.
* Fix up Kibana index pattern time fields in elastic import.
* Add crossref_events sensor to DOI DAG.