### PR TITLE
Update ONIX workflow so it always uses latest ONIX release

### DIFF
--- a/observatory-dags/observatory/dags/dags/onix_workflow.py
+++ b/observatory-dags/observatory/dags/dags/onix_workflow.py
@@ -30,7 +30,17 @@ def get_oaebu_partner_data(project_id, org_name):
 
     oaebu_data = [
         OaebuPartners(
+            name=OaebuPartnerName.onix,
+            dag_id_prefix="onix",
+            gcp_project_id=project_id,
+            gcp_dataset_id="onix",
+            gcp_table_id="onix",
+            isbn_field_name="ISBN13",
+            sharded=True,
+        ),
+        OaebuPartners(
             name=OaebuPartnerName.google_analytics,
+            dag_id_prefix="google_analytics",
             gcp_project_id=project_id,
             gcp_dataset_id="google",
             gcp_table_id="google_analytics",
@@ -39,6 +49,7 @@ def get_oaebu_partner_data(project_id, org_name):
         ),
         OaebuPartners(
             name=OaebuPartnerName.google_books_sales,
+            dag_id_prefix="google_books",
             gcp_project_id=project_id,
             gcp_dataset_id="google",
             gcp_table_id="google_books_sales",
@@ -47,6 +58,7 @@ def get_oaebu_partner_data(project_id, org_name):
         ),
         OaebuPartners(
             name=OaebuPartnerName.google_books_traffic,
+            dag_id_prefix="google_books",
             gcp_project_id=project_id,
             gcp_dataset_id="google",
             gcp_table_id="google_books_traffic",
@@ -55,6 +67,7 @@ def get_oaebu_partner_data(project_id, org_name):
         ),
         OaebuPartners(
             name=OaebuPartnerName.jstor_country,
+            dag_id_prefix="jstor",
             gcp_project_id=project_id,
             gcp_dataset_id="jstor",
             gcp_table_id="jstor_country",
@@ -63,6 +76,7 @@ def get_oaebu_partner_data(project_id, org_name):
         ),
         OaebuPartners(
             name=OaebuPartnerName.jstor_institution,
+            dag_id_prefix="jstor",
             gcp_project_id=project_id,
             gcp_dataset_id="jstor",
             gcp_table_id="jstor_institution",
@@ -71,6 +85,7 @@ def get_oaebu_partner_data(project_id, org_name):
         ),
         OaebuPartners(
             name=OaebuPartnerName.oapen_irus_uk,
+            dag_id_prefix="oapen_irus_uk",
             gcp_project_id=project_id,
             gcp_dataset_id="oapen",
             gcp_table_id="oapen_irus_uk",
@@ -79,6 +94,7 @@ def get_oaebu_partner_data(project_id, org_name):
         ),
         OaebuPartners(
             name=OaebuPartnerName.ucl_discovery,
+            dag_id_prefix="ucl_discovery",
             gcp_project_id=project_id,
             gcp_dataset_id="ucl",
             gcp_table_id="ucl_discovery",
@@ -104,17 +120,7 @@ def get_oaebu_partner_data(project_id, org_name):
             OaebuPartnerName.oapen_irus_uk,
             OaebuPartnerName.ucl_discovery,
         ],
-        "Wits University Press": [],
         "University of Michigan Press": [
-            OaebuPartnerName.google_books_sales,
-            OaebuPartnerName.google_books_traffic,
-            OaebuPartnerName.jstor_country,
-            OaebuPartnerName.jstor_institution,
-            OaebuPartnerName.oapen_irus_uk,
-        ],
-        "Springer Nature": [],
-        "Oapen Press": [OaebuPartnerName.oapen_irus_uk],
-        "Curtin Press": [
             OaebuPartnerName.google_books_sales,
             OaebuPartnerName.google_books_traffic,
             OaebuPartnerName.jstor_country,

--- a/observatory-dags/observatory/dags/dags/onix_workflow.py
+++ b/observatory-dags/observatory/dags/dags/onix_workflow.py
@@ -30,15 +30,6 @@ def get_oaebu_partner_data(project_id, org_name):
 
     oaebu_data = [
         OaebuPartners(
-            name=OaebuPartnerName.onix,
-            dag_id_prefix="onix",
-            gcp_project_id=project_id,
-            gcp_dataset_id="onix",
-            gcp_table_id="onix",
-            isbn_field_name="ISBN13",
-            sharded=True,
-        ),
-        OaebuPartners(
             name=OaebuPartnerName.google_analytics,
             dag_id_prefix="google_analytics",
             gcp_project_id=project_id,

--- a/observatory-dags/observatory/dags/database/sql/create_book_products.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/create_book_products.sql.jinja2
@@ -145,7 +145,7 @@ onix_ebook_titles as (
                 )
             ) as authors
         ) as onix
-    FROM `{{ project_id }}.{{ onix_dataset_id }}.onix{{ release.strftime('%Y%m%d') }}` as onix
+    FROM `{{ project_id }}.{{ onix_dataset_id }}.onix{{ onix_release_date.strftime('%Y%m%d') }}` as onix
     WHERE ProductForm = "Digital download and online" OR ProductForm = "Digital (delivered electronically)"
 ),
 
@@ -153,7 +153,7 @@ onix_ebook_titles as (
 google_analytics_metrics as (
     SELECT
         publication_id as ISBN13, release_date, STRUCT(STRUCT(AVG(average_time) as average_time, ARRAY_CONCAT_AGG(unique_views.country) as country, ARRAY_CONCAT_AGG(unique_views.referrer) as referrer, ARRAY_CONCAT_AGG(unique_views.social_network) as social_network) as unique_views) as metrics
-    FROM {% if google_analytics %} `{{ project_id }}.{{ dataset_id }}.{{ google_analytics_dataset }}_google_analytics_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_google_analytics {% endif %}
+    FROM {% if google_analytics %} `{{ project_id }}.{{ dataset_id }}.{{ google_analytics_dataset }}_google_analytics_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_analytics {% endif %}
     WHERE publication_whole_or_part = '(citation)' and publication_type = "book"
     GROUP BY publication_id, release_date
 ),
@@ -162,27 +162,27 @@ google_analytics_metrics as (
 google_books_sales_metrics as (
     SELECT
         Primary_ISBN as ISBN13, release_date, STRUCT(SUM(qty) as qty) as metrics
-    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_sales_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_google_books_sales {% endif %} as google_books
+    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_sales_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_sales {% endif %} as google_books
     GROUP BY Primary_ISBN, release_date
 ),
 
 google_books_sales_metadata as (
     SELECT
         Primary_ISBN as ISBN13, MAX(Imprint_Name) as Imprint_Name, MAX(Title) as Title, MAX(Author) as Author
-    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_sales_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_google_books_sales {% endif %} as google_books
+    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_sales_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_sales {% endif %} as google_books
     GROUP BY Primary_ISBN
 ),
 
 google_books_traffic_metrics as (
     SELECT
         Primary_ISBN  as ISBN13, release_date, STRUCT(Book_Visits_BV_, BV_with_Pages_Viewed, Non_Unique_Buy_Clicks, BV_with_Buy_Clicks, Buy_Link_CTR, Pages_Viewed) as metrics
-    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_traffic_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_google_books_traffic {% endif %} as google_books
+    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_traffic_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_traffic {% endif %} as google_books
 ),
 
 google_books_traffic_metadata as (
     SELECT
         Primary_ISBN  as ISBN13, MAX(title) as Title
-    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_traffic_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_google_books_traffic {% endif %} as google_books
+    FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_traffic_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_traffic {% endif %} as google_books
     GROUP BY Primary_ISBN
 ),
 
@@ -190,28 +190,28 @@ google_books_traffic_metadata as (
 jstor_country_metrics as (
     SELECT
         eISBN as ISBN13, release_date, ARRAY_AGG(STRUCT(Country_name, Total_Item_Requests)) as metrics
-    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_country_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_jstor_country {% endif %} as jstor_country
+    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_country_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_country {% endif %} as jstor_country
     GROUP BY eISBN, release_date
 ),
 
 jstor_country_metadata as (
     SELECT
         eISBN as ISBN13, MAX(Book_Title) as Book_Title, MAX(Book_ID) as Book_ID, MAX(Authors) as Authors, MAX(ISBN) as ISBN, eISBN, MAX(Copyright_Year) as Copyright_Year, MAX(Disciplines) as Disciplines, MAX(Usage_Type) as Usage_Type
-    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_country_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_jstor_country {% endif %} as jstor_country
+    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_country_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_country {% endif %} as jstor_country
     GROUP BY eISBN
 ),
 
 jstor_institution_metrics as (
     SELECT
         eISBN as ISBN13, release_date, ARRAY_AGG(STRUCT(Institution, Total_Item_Requests)) as metrics
-    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_institution_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_jstor_institution {% endif %} as jstor_institution
+    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_institution_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_institution {% endif %} as jstor_institution
     GROUP BY eISBN, release_date
 ),
 
 jstor_institution_metadata as (
     SELECT
         eISBN as ISBN13, MAX(Book_Title) as Book_Title, MAX(Book_ID) as Book_ID, MAX(Authors) as Authors, MAX(ISBN) as ISBN, eISBN, MAX(Copyright_Year) as Copyright_Year, MAX(Disciplines) as Disciplines, MAX(Usage_Type) as Usage_Type
-    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_institution_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_jstor_institution {% endif %} as jstor_institution
+    FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_institution_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_institution {% endif %} as jstor_institution
     GROUP BY eISBN
 ),
 
@@ -219,13 +219,13 @@ jstor_institution_metadata as (
 oapen_irus_uk_metrics as (
     SELECT
         ISBN as ISBN13, release_date, STRUCT(version, title_requests, total_item_investigations, total_item_requests, unique_item_investigations, unique_item_requests, country, locations) as metrics
-    FROM {% if oapen %} `{{ project_id }}.{{ dataset_id }}.{{ oapen_dataset }}_oapen_irus_uk_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_oapen {% endif %} as oapen_irus_uk
+    FROM {% if oapen %} `{{ project_id }}.{{ dataset_id }}.{{ oapen_dataset }}_oapen_irus_uk_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_oapen {% endif %} as oapen_irus_uk
 ),
 
 oapen_irus_uk_metadata as (
     SELECT
         ISBN as ISBN13, MAX(book_title) as book_title, MAX(publisher) as publisher
-    FROM {% if oapen %} `{{ project_id }}.{{ dataset_id }}.{{ oapen_dataset }}_oapen_irus_uk_matched{{ release.strftime('%Y%m%d') }}` {% else %} empty_oapen {% endif %} as oapen_irus_uk
+    FROM {% if oapen %} `{{ project_id }}.{{ dataset_id }}.{{ oapen_dataset }}_oapen_irus_uk_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_oapen {% endif %} as oapen_irus_uk
     GROUP BY ISBN
 ),
 

--- a/observatory-dags/observatory/dags/workflows/oaebu_partners.py
+++ b/observatory-dags/observatory/dags/workflows/oaebu_partners.py
@@ -36,6 +36,7 @@ class OaebuPartners:
     """Temporary class for storing information about data sources we are using to produce oaebu intermediate tables for.  Change or remove this later when Observatory API is more mature.
 
     :param name: Name of the data partner.
+    :param dag_id_prefix: The prefix of the DAG id that the data originates from.
     :param gcp_project_id: GCP Project ID.
     :param gcp_dataset_id: GCP Dataset ID.
     :param gcp_table_id: Table name without the date suffix.
@@ -44,6 +45,7 @@ class OaebuPartners:
     """
 
     name: str
+    dag_id_prefix: str
     gcp_project_id: str
     gcp_dataset_id: str
     gcp_table_id: str

--- a/observatory-dags/observatory/dags/workflows/onix_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/onix_workflow.py
@@ -384,6 +384,7 @@ class OnixWorkflow(Telescope):
 
         # Aggregate work families
         agg = BookWorkFamilyAggregator(works)
+        works_families = agg.aggregate()
         lookup_table = agg.get_works_family_lookup_table()
         list_to_jsonl_gz(release.worksfamilylookup_filename, lookup_table)
 
@@ -610,7 +611,8 @@ class OnixWorkflow(Telescope):
             project_id=release.project_id,
             onix_dataset_id=release.onix_dataset_id,
             dataset_id=release.oaebu_intermediate_dataset,
-            release=release_date,
+            onix_release_date=release.onix_release_date,
+            release_date=release_date,
             google_analytics=include_google_analytics,
             google_books=include_google_books,
             jstor=include_jstor,

--- a/observatory-dags/observatory/dags/workflows/onix_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/onix_workflow.py
@@ -329,13 +329,17 @@ class OnixWorkflow(Telescope):
         release_date = kwargs["next_execution_date"].subtract(microseconds=1).date()
 
         # Get ONIX release date
-        onix_release_date = select_table_shard_dates(
+        onix_release_dates = select_table_shard_dates(
             project_id=self.gcp_project_id,
             dataset_id=self.onix_dataset_id,
             table_id=self.onix_table_id,
             end_date=release_date,
-        )[0]
+        )
 
+        if not len(onix_release_dates):
+            raise AirflowException("OnixWorkflow.make_release: no ONIX releases found")
+
+        onix_release_date = onix_release_dates[0]
         return OnixWorkflowRelease(
             dag_id=self.dag_id,
             release_date=release_date,

--- a/tests/observatory/dags/workflows/test_doi_workflow.py
+++ b/tests/observatory/dags/workflows/test_doi_workflow.py
@@ -17,13 +17,10 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime
 from typing import Dict, List
 
 import pendulum
-from airflow import DAG
 from airflow.exceptions import AirflowException
-from airflow.operators.dummy_operator import DummyOperator
 
 from observatory.dags.model import (
     bq_load_observatory_dataset,
@@ -40,26 +37,8 @@ from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
+    make_dummy_dag,
 )
-
-
-def make_dummy_dag(dag_id: str, execution_date: datetime) -> DAG:
-    """ A Dummy DAG for testing purposes.
-
-    :param dag_id: the DAG id.
-    :param execution_date: the DAGs execution date.
-    :return: the DAG.
-    """
-
-    with DAG(
-        dag_id=dag_id,
-        schedule_interval="@weekly",
-        default_args={"owner": "airflow", "start_date": execution_date},
-        catchup=False,
-    ) as dag:
-        task1 = DummyOperator(task_id="dummy_task")
-
-    return dag
 
 
 class TestDoiWorkflow(ObservatoryTestCase):


### PR DESCRIPTION
This PR updates the ONIX Workflow so that it:
* Waits for the ONIX telescope and all data partners to finish via sensors.
* Always uses the latest ONIX release available for an organisation.

The workflow was previously synced with the ONIX telescope and would only generate new data for a release if an ONIX file was processed by the ONIX telescope. This would mean that the ONIX Workflow would not run if there was no new ONIX data, but the data partners had fresh data.