### PR TITLE
OAPEN as organisation for OAPEN telescope

### DIFF
--- a/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
@@ -38,14 +38,14 @@ from observatory.api.client.model.organisation import Organisation
 from observatory.platform.telescopes.snapshot_telescope import SnapshotRelease, SnapshotTelescope
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.data_utils import get_file
-from observatory.platform.utils.file_utils import _hash_file
+from observatory.platform.utils.file_utils import _hash_file, list_to_jsonl_gz
 from observatory.platform.utils.gc_utils import (
     copy_blob_from_cloud_storage,
     create_cloud_storage_bucket,
     download_blob_from_cloud_storage,
     upload_file_to_cloud_storage,
 )
-from observatory.platform.utils.telescope_utils import make_dag_id, make_org_id, add_partition_date, list_to_jsonl_gz
+from observatory.platform.utils.telescope_utils import make_dag_id, make_org_id, add_partition_date
 from observatory.platform.utils.template_utils import (
     SubFolder,
     blob_name,

--- a/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
+++ b/observatory-dags/observatory/dags/telescopes/oapen_irus_uk.py
@@ -603,7 +603,7 @@ def call_cloud_function(
             remaining_publishers = 0
 
         entries = response_json["entries"]
-        if entries == 0:
+        if entries == 0 and remaining_publishers == 0:
             raise AirflowSkipException("No access stats entries for publisher(s) in month.")
 
         logging.info(f"Processed {entries} entries in total. {remaining_publishers} publishers " f"left to process")

--- a/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
+++ b/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
@@ -345,7 +345,7 @@ class TestOapenIrusUk(ObservatoryTestCase):
         connections = {AirflowConns.GEOIP_LICENSE_KEY: Connection(AirflowConns.GEOIP_LICENSE_KEY,
                                                                   uri='http://user_id:key@'),
                        AirflowConns.OAPEN_IRUS_UK_API: Connection(AirflowConns.OAPEN_IRUS_UK_API,
-                                                                  uri='mysql://requestor_id:api_key@'),
+                                                                  uri='http://requestor_id:api_key@'),
                        AirflowConns.OAPEN_IRUS_UK_LOGIN: Connection(AirflowConns.OAPEN_IRUS_UK_LOGIN,
                                                                     uri='mysql://email:password@')}
         mock_conn_get.side_effect = lambda x: connections[x]

--- a/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
+++ b/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
@@ -16,12 +16,12 @@
 
 import json
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 from urllib.parse import quote
 
 import httpretty
 import pendulum
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.connection import Connection
 from click.testing import CliRunner
 from googleapiclient.discovery import build
@@ -34,6 +34,7 @@ from observatory.api.server import orm
 from observatory.dags.telescopes.oapen_irus_uk import (
     OapenIrusUkRelease,
     OapenIrusUkTelescope,
+    call_cloud_function,
     cloud_function_exists,
     create_cloud_function,
     upload_source_code_to_bucket,
@@ -252,6 +253,144 @@ class TestOapenIrusUk(ObservatoryTestCase):
             # Delete oapen bucket
             env._delete_bucket(OapenIrusUkTelescope.OAPEN_BUCKET)
 
+    @patch('observatory.platform.utils.template_utils.AirflowVariable.get')
+    @patch('observatory.dags.telescopes.oapen_irus_uk.upload_source_code_to_bucket')
+    @patch('observatory.dags.telescopes.oapen_irus_uk.cloud_function_exists')
+    @patch('observatory.dags.telescopes.oapen_irus_uk.create_cloud_function')
+    def test_release_create_cloud_function(self, mock_create_function, mock_function_exists, mock_upload,
+                                           mock_variable_get):
+        """ Test the create_cloud_function method of the OapenIrusUkRelease
+
+        :param mock_variable_get: Mock Airflow Variable 'data'
+        :return: None.
+        """
+        def reset_mocks():
+            mock_upload.reset_mock()
+            mock_function_exists.reset_mock()
+            mock_create_function.reset_mock()
+
+        def assert_mocks(create: bool, update: bool):
+            mock_upload.assert_called_once_with(telescope.FUNCTION_SOURCE_URL, telescope.OAPEN_PROJECT_ID,
+                                                telescope.OAPEN_BUCKET, telescope.FUNCTION_BLOB_NAME)
+            mock_function_exists.assert_called_once_with(ANY, location, full_name)
+            if create or update:
+                mock_create_function.assert_called_once_with(ANY, location, full_name, telescope.OAPEN_BUCKET,
+                                                             telescope.FUNCTION_BLOB_NAME, telescope.max_active_runs,
+                                                             update)
+            else:
+                mock_create_function.assert_not_called()
+
+        with CliRunner().isolated_filesystem():
+            mock_variable_get.return_value = os.path.join(os.getcwd(), 'data')
+            # Create release instance
+            org = Organisation(
+                name=self.organisation_name,
+                gcp_project_id=self.project_id,
+                gcp_download_bucket='download_bucket',
+                gcp_transform_bucket='transform_bucket'
+            )
+            telescope = OapenIrusUkTelescope(org, publisher_id='publisher', dataset_id='dataset_id')
+            release = OapenIrusUkRelease(telescope.dag_id, pendulum.parse('2020-02-01'), org)
+
+            location = f"projects/{telescope.OAPEN_PROJECT_ID}/locations/{telescope.FUNCTION_REGION}"
+            full_name = f"{location}/functions/{telescope.FUNCTION_NAME}"
+
+            # Test when source code upload was unsuccessful
+            mock_upload.return_value = False, False
+            with self.assertRaises(AirflowException):
+                release.create_cloud_function(telescope.max_active_runs)
+
+            # Test when cloud function does not exist
+            reset_mocks()
+            mock_upload.return_value = True, True
+            mock_function_exists.return_value = False
+            mock_create_function.return_value = True, "response"
+            release.create_cloud_function(telescope.max_active_runs)
+            assert_mocks(create=True, update=False)
+
+            # Test when cloud function exists, but source code has changed
+            reset_mocks()
+            mock_upload.return_value = True, True
+            mock_function_exists.return_value = True
+            mock_create_function.return_value = True, "response"
+            release.create_cloud_function(telescope.max_active_runs)
+            assert_mocks(create=False, update=True)
+
+            # Test when cloud function exists and source code has not changed
+            reset_mocks()
+            mock_upload.return_value = True, False
+            mock_function_exists.return_value = True
+            release.create_cloud_function(telescope.max_active_runs)
+            assert_mocks(create=False, update=False)
+
+            # Test when create cloud function was unsuccessful
+            reset_mocks()
+            mock_upload.return_value = True, True
+            mock_function_exists.return_value = True
+            mock_create_function.return_value = False, "response"
+            with self.assertRaises(AirflowException):
+                release.create_cloud_function(telescope.max_active_runs)
+
+    @patch('observatory.platform.utils.template_utils.AirflowVariable.get')
+    @patch('observatory.dags.telescopes.oapen_irus_uk.BaseHook.get_connection')
+    @patch('observatory.dags.telescopes.oapen_irus_uk.get_publisher_uuid')
+    @patch('observatory.dags.telescopes.oapen_irus_uk.call_cloud_function')
+    def test_release_call_cloud_function(self, mock_call_function, mock_get_publisher, mock_conn_get,
+                                         mock_variable_get):
+        """ Test the call_cloud_function method of the OapenIrusUkRelease
+
+        :param mock_variable_get: Mock Airflow Variable 'data'
+        :return: None.
+        """
+        connections = {AirflowConns.GEOIP_LICENSE_KEY: Connection(AirflowConns.GEOIP_LICENSE_KEY,
+                                                                  uri='mysql://user_id:key@'),
+                       AirflowConns.OAPEN_IRUS_UK_API: Connection(AirflowConns.OAPEN_IRUS_UK_API,
+                                                                  uri='mysql://requestor_id:api_key@'),
+                       AirflowConns.OAPEN_IRUS_UK_LOGIN: Connection(AirflowConns.OAPEN_IRUS_UK_LOGIN,
+                                                                    uri='mysql://email:password@')}
+        mock_conn_get.side_effect = lambda x: connections[x]
+        mock_get_publisher.return_value = 'publisher_uuid'
+
+        with CliRunner().isolated_filesystem():
+            mock_variable_get.return_value = os.path.join(os.getcwd(), 'data')
+            org = Organisation(
+                name=self.organisation_name,
+                gcp_project_id=self.project_id,
+                gcp_download_bucket='download_bucket',
+                gcp_transform_bucket='transform_bucket'
+            )
+
+            # Test new platform and old platform
+            for date in ['2020-03', '2020-04']:
+                # Test for a given publisher name and the 'oapen' publisher
+                for publisher_id in ['publisher', 'oapen']:
+                    mock_call_function.reset_mock()
+
+                    telescope = OapenIrusUkTelescope(org, publisher_id=publisher_id, dataset_id='dataset_id')
+                    release = OapenIrusUkRelease(telescope.dag_id, pendulum.parse(date + '-01'), org)
+                    function_url = f"https://{telescope.FUNCTION_REGION}-{telescope.OAPEN_PROJECT_ID}" \
+                                   f".cloudfunctions.net/{telescope.FUNCTION_NAME}"
+
+                    release.call_cloud_function(telescope.publisher_id)
+
+                    # Test that the call function is called with the correct args
+                    if date == '2020-04':
+                        username = 'requestor_id'
+                        password = 'api_key'
+                        if publisher_id == "oapen":
+                            publisher_uuid = ""
+                        else:
+                            publisher_uuid = 'publisher_uuid'
+                    else:
+                        username = 'email'
+                        password = 'password'
+                        publisher_uuid = "NA"
+                        if publisher_id == "oapen":
+                            publisher_id = ""
+                    mock_call_function.assert_called_once_with(function_url, date, username, password,
+                                                               'key', publisher_id, publisher_uuid,
+                                                               telescope.OAPEN_BUCKET, release.blob_name)
+
     @patch("observatory.dags.telescopes.oapen_irus_uk.upload_file_to_cloud_storage")
     @patch("observatory.dags.telescopes.oapen_irus_uk.create_cloud_storage_bucket")
     @patch("observatory.platform.utils.template_utils.AirflowVariable.get")
@@ -315,6 +454,9 @@ class TestOapenIrusUk(ObservatoryTestCase):
         self.assertTrue(exists)
 
     def test_create_cloud_function(self):
+        """ Test the function that creates the cloud function
+        :return: None.
+        """
         location = "projects/project-id/locations/us-central1"
         full_name = "projects/project-id/locations/us-central1/functions/function-2"
         source_bucket = "oapen_bucket"
@@ -409,3 +551,45 @@ class TestOapenIrusUk(ObservatoryTestCase):
         )
         self.assertFalse(success)
         self.assertDictEqual({"message": "error"}, msg)
+
+    @patch("observatory.dags.telescopes.oapen_irus_uk.AuthorizedSession.post")
+    def test_call_cloud_function(self, mock_authorized_session):
+        """ Test the function that calls the cloud function
+        :return: None.
+        """
+
+        function_url = "function_url"
+        release_date = "2020-01-01"
+        username = "username"
+        password = "password"
+        geoip_license_key = "key"
+        publisher_name = "publisher_name"
+        publisher_uuid = "publisher_uuid"
+        bucket_name = "bucket"
+        blob_name = "blob"
+
+        # Set responses for consequential calls
+        mock_authorized_session.side_effect = [MagicMock(spec=Response, status_code=200, reason="unit test",
+                                                         json=lambda: {'entries': 100,
+                                                                       'unprocessed_publishers': ['publisher1',
+                                                                                                  'publisher2']}),
+                                               MagicMock(spec=Response, status_code=200, reason="unit test",
+                                                         json=lambda: {'entries': 200, 'unprocessed_publishers': None}),
+                                               MagicMock(spec=Response, status_code=200, reason="unit test",
+                                                         json=lambda: {'entries': 0, 'unprocessed_publishers': None}),
+                                               MagicMock(spec=Response, status_code=400, reason="unit test")
+                                               ]
+        # Test when there are unprocessed publishers (first 2 responses from side effect)
+        call_cloud_function(function_url, release_date, username, password, geoip_license_key, publisher_name,
+                            publisher_uuid, bucket_name, blob_name)
+        self.assertEqual(2, mock_authorized_session.call_count)
+
+        # Test when entries is 0 (3rd response from side effect)
+        with self.assertRaises(AirflowSkipException):
+            call_cloud_function(function_url, release_date, username, password, geoip_license_key, publisher_name,
+                                publisher_uuid, bucket_name, blob_name)
+
+        # Test when response status code is not 200 (last response from side effect)
+        with self.assertRaises(AirflowException):
+            call_cloud_function(function_url, release_date, username, password, geoip_license_key, publisher_name,
+                                publisher_uuid, bucket_name, blob_name)

--- a/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
+++ b/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
@@ -343,7 +343,7 @@ class TestOapenIrusUk(ObservatoryTestCase):
         :return: None.
         """
         connections = {AirflowConns.GEOIP_LICENSE_KEY: Connection(AirflowConns.GEOIP_LICENSE_KEY,
-                                                                  uri='mysql://user_id:key@'),
+                                                                  uri='http://user_id:key@'),
                        AirflowConns.OAPEN_IRUS_UK_API: Connection(AirflowConns.OAPEN_IRUS_UK_API,
                                                                   uri='mysql://requestor_id:api_key@'),
                        AirflowConns.OAPEN_IRUS_UK_LOGIN: Connection(AirflowConns.OAPEN_IRUS_UK_LOGIN,

--- a/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
+++ b/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
@@ -188,7 +188,7 @@ class TestOapenIrusUk(ObservatoryTestCase):
         # Create the Observatory environment and run tests
         with env.create(task_logging=True):
             # Add airflow connections
-            conn = Connection(conn_id=AirflowConns.GEOIP_LICENSE_KEY, uri="mysql://email_address:password@")
+            conn = Connection(conn_id=AirflowConns.GEOIP_LICENSE_KEY, uri="http://email_address:password@")
             env.add_connection(conn)
             conn = Connection(conn_id=AirflowConns.OAPEN_IRUS_UK_API, uri="mysql://requestor_id:api_key@")
             env.add_connection(conn)

--- a/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
+++ b/tests/observatory/dags/telescopes/test_oapen_irus_uk.py
@@ -347,7 +347,7 @@ class TestOapenIrusUk(ObservatoryTestCase):
                        AirflowConns.OAPEN_IRUS_UK_API: Connection(AirflowConns.OAPEN_IRUS_UK_API,
                                                                   uri='http://requestor_id:api_key@'),
                        AirflowConns.OAPEN_IRUS_UK_LOGIN: Connection(AirflowConns.OAPEN_IRUS_UK_LOGIN,
-                                                                    uri='mysql://email:password@')}
+                                                                    uri='http://email:password@')}
         mock_conn_get.side_effect = lambda x: connections[x]
         mock_get_publisher.return_value = 'publisher_uuid'
 


### PR DESCRIPTION
The oapen telescope is updated to use the latest cloud function v1.1.4 release (see https://github.com/The-Academic-Observatory/oapen-irus-uk-cloud-function/pull/8) for the relevant cloud function PR.

This release:
- Adds functionality to download reports for all publishers when no publisher name is given for the old platform (before 2020-04).
- Updates code to work with the recently released API v2.1 of the new platform (since 2020-04).