### PR TITLE
Add variable subtype to crossref_metadata_2021-01-01.json

### DIFF
--- a/observatory-dags/observatory/dags/database/schema/crossref_metadata_2021-01-01.json
+++ b/observatory-dags/observatory/dags/database/schema/crossref_metadata_2021-01-01.json
@@ -79,6 +79,12 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "subtype",
+    "type": "STRING",
+    "description": "Enumeration, one of the type ids from https://data.crossref.org/reports/help/schema_doc/4.4.2/schema_4_4_2.html#posted_content."
+  },
+  {
+    "mode": "NULLABLE",
     "name": "type",
     "type": "STRING",
     "description": "Enumeration, one of the type ids from https://api.crossref.org/v1/types."


### PR DESCRIPTION
This (hopefully) includes the variable subtype from Crossref metadata 

resolve #455 (for more details see issue) 