### PR TITLE
small date parsing fix to handle years between 1AD and 999AD

### DIFF
--- a/observatory-dags/observatory/dags/database/sql/create_crossref_events.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/create_crossref_events.sql.jinja2
@@ -18,7 +18,7 @@ SELECT
   doi,
   ARRAY(SELECT as STRUCT source, SUM(count) as count FROM UNNEST(months) GROUP BY source) as events,
   months,
-  ARRAY(SELECT as STRUCT CAST(LEFT(month, 4) as int64) as year, source, SUM(count) as count FROM UNNEST(months) GROUP BY year, source) as years
+  ARRAY(SELECT as STRUCT CAST(SPLIT(month, "-")[SAFE_OFFSET(0)] as int64) as year, source, SUM(count) as count FROM UNNEST(months) GROUP BY year, source) as years
 FROM (
 SELECT
   doi,


### PR DESCRIPTION
crossref events failed to process because a record had the year set to '1'. The script was only expecting years with 4 digits. The change should now be able to handle any number of digits.