### PR TITLE
Move settings out of cli and into config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,3 +18,4 @@ omit =
     observatory-api/observatory/api/client/exceptions.py
     observatory-api/observatory/api/client/model_utils.py
     observatory-api/observatory/api/client/rest.py
+    observatory-platform/observatory/platform/airflow/*

--- a/observatory-platform/observatory/platform/airflow/credentials_provider.py
+++ b/observatory-platform/observatory/platform/airflow/credentials_provider.py
@@ -1,0 +1,359 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This module contains a mechanism for providing temporary
+Google Cloud authentication.
+"""
+import json
+import logging
+import tempfile
+from contextlib import ExitStack, contextmanager
+from typing import Collection, Dict, Generator, Optional, Sequence, Tuple, Union
+from urllib.parse import urlencode
+
+import google.auth
+import google.auth.credentials
+import google.oauth2.service_account
+from google.auth import impersonated_credentials
+from google.auth.environment_vars import CREDENTIALS, LEGACY_PROJECT, PROJECT
+
+from airflow.exceptions import AirflowException
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.process_utils import patch_environ
+
+log = logging.getLogger(__name__)
+
+AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT = "AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT"
+_DEFAULT_SCOPES: Sequence[str] = ('https://www.googleapis.com/auth/cloud-platform',)
+
+
+def build_gcp_conn(
+    key_file_path: Optional[str] = None,
+    scopes: Optional[Sequence[str]] = None,
+    project_id: Optional[str] = None,
+) -> str:
+    """
+    Builds a uri that can be used as :envvar:`AIRFLOW_CONN_{CONN_ID}` with provided service key,
+    scopes and project id.
+
+    :param key_file_path: Path to service key.
+    :type key_file_path: Optional[str]
+    :param scopes: Required OAuth scopes.
+    :type scopes: Optional[List[str]]
+    :param project_id: The Google Cloud project id to be used for the connection.
+    :type project_id: Optional[str]
+    :return: String representing Airflow connection.
+    """
+    conn = "google-cloud-platform://?{}"
+    extras = "extra__google_cloud_platform"
+
+    query_params = {}
+    if key_file_path:
+        query_params[f"{extras}__key_path"] = key_file_path
+    if scopes:
+        scopes_string = ",".join(scopes)
+        query_params[f"{extras}__scope"] = scopes_string
+    if project_id:
+        query_params[f"{extras}__projects"] = project_id
+
+    query = urlencode(query_params)
+    return conn.format(query)
+
+
+@contextmanager
+def provide_gcp_credentials(key_file_path: Optional[str] = None, key_file_dict: Optional[Dict] = None):
+    """
+    Context manager that provides a Google Cloud credentials for application supporting `Application
+    Default Credentials (ADC) strategy <https://cloud.google.com/docs/authentication/production>`__.
+
+    It can be used to provide credentials for external programs (e.g. gcloud) that expect authorization
+    file in ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable.
+
+    :param key_file_path: Path to file with Google Cloud Service Account .json file.
+    :type key_file_path: str
+    :param key_file_dict: Dictionary with credentials.
+    :type key_file_dict: Dict
+    """
+    if not key_file_path and not key_file_dict:
+        raise ValueError("Please provide `key_file_path` or `key_file_dict`.")
+
+    if key_file_path and key_file_path.endswith(".p12"):
+        raise AirflowException("Legacy P12 key file are not supported, use a JSON key file.")
+
+    with tempfile.NamedTemporaryFile(mode="w+t") as conf_file:
+        if not key_file_path and key_file_dict:
+            conf_file.write(json.dumps(key_file_dict))
+            conf_file.flush()
+            key_file_path = conf_file.name
+        if key_file_path:
+            with patch_environ({CREDENTIALS: key_file_path}):
+                yield
+        else:
+            # We will use the default service account credentials.
+            yield
+
+
+@contextmanager
+def provide_gcp_connection(
+    key_file_path: Optional[str] = None,
+    scopes: Optional[Sequence] = None,
+    project_id: Optional[str] = None,
+) -> Generator:
+    """
+    Context manager that provides a temporary value of :envvar:`AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT`
+    connection. It build a new connection that includes path to provided service json,
+    required scopes and project id.
+
+    :param key_file_path: Path to file with Google Cloud Service Account .json file.
+    :type key_file_path: str
+    :param scopes: OAuth scopes for the connection
+    :type scopes: Sequence
+    :param project_id: The id of Google Cloud project for the connection.
+    :type project_id: str
+    """
+    if key_file_path and key_file_path.endswith(".p12"):
+        raise AirflowException("Legacy P12 key file are not supported, use a JSON key file.")
+
+    conn = build_gcp_conn(scopes=scopes, key_file_path=key_file_path, project_id=project_id)
+
+    with patch_environ({AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT: conn}):
+        yield
+
+
+@contextmanager
+def provide_gcp_conn_and_credentials(
+    key_file_path: Optional[str] = None,
+    scopes: Optional[Sequence] = None,
+    project_id: Optional[str] = None,
+) -> Generator:
+    """
+    Context manager that provides both:
+
+    - Google Cloud credentials for application supporting `Application Default Credentials (ADC)
+      strategy <https://cloud.google.com/docs/authentication/production>`__.
+    - temporary value of :envvar:`AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT` connection
+
+    :param key_file_path: Path to file with Google Cloud Service Account .json file.
+    :type key_file_path: str
+    :param scopes: OAuth scopes for the connection
+    :type scopes: Sequence
+    :param project_id: The id of Google Cloud project for the connection.
+    :type project_id: str
+    """
+    with ExitStack() as stack:
+        if key_file_path:
+            stack.enter_context(provide_gcp_credentials(key_file_path))  # type; ignore
+        if project_id:
+            stack.enter_context(  # type; ignore
+                patch_environ({PROJECT: project_id, LEGACY_PROJECT: project_id})
+            )
+
+        stack.enter_context(provide_gcp_connection(key_file_path, scopes, project_id))  # type; ignore
+        yield
+
+
+class _CredentialProvider(LoggingMixin):
+    """
+    Prepare the Credentials object for Google API and the associated project_id
+
+    Only either `key_path` or `keyfile_dict` should be provided, or an exception will
+    occur. If neither of them are provided, return default credentials for the current environment
+
+    :param key_path: Path to Google Cloud Service Account key file (JSON).
+    :type key_path: str
+    :param keyfile_dict: A dict representing Cloud Service Account as in the Credential JSON file
+    :type keyfile_dict: Dict[str, str]
+    :param scopes:  OAuth scopes for the connection
+    :type scopes: Collection[str]
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param disable_logging: If true, disable all log messages, which allows you to use this
+        class to configure Logger.
+    :param target_principal: The service account to directly impersonate using short-term
+        credentials, if any. For this to work, the target_principal account must grant
+        the originating account the Service Account Token Creator IAM role.
+    :type target_principal: str
+    :param delegates: optional chained list of accounts required to get the access_token of
+        target_principal. If set, the sequence of identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account and target_principal
+        granting the role to the last account from the list.
+    :type delegates: Sequence[str]
+    """
+
+    def __init__(
+        self,
+        key_path: Optional[str] = None,
+        keyfile_dict: Optional[Dict[str, str]] = None,
+        scopes: Optional[Collection[str]] = None,
+        delegate_to: Optional[str] = None,
+        disable_logging: bool = False,
+        target_principal: Optional[str] = None,
+        delegates: Optional[Sequence[str]] = None,
+    ) -> None:
+        super().__init__()
+        if key_path and keyfile_dict:
+            raise AirflowException(
+                "The `keyfile_dict` and `key_path` fields are mutually exclusive. "
+                "Please provide only one value."
+            )
+        self.key_path = key_path
+        self.keyfile_dict = keyfile_dict
+        self.scopes = scopes
+        self.delegate_to = delegate_to
+        self.disable_logging = disable_logging
+        self.target_principal = target_principal
+        self.delegates = delegates
+
+    def get_credentials_and_project(self) -> Tuple[google.auth.credentials.Credentials, str]:
+        """
+        Get current credentials and project ID.
+
+        :return: Google Auth Credentials
+        :type: Tuple[google.auth.credentials.Credentials, str]
+        """
+        if self.key_path:
+            credentials, project_id = self._get_credentials_using_key_path()
+        elif self.keyfile_dict:
+            credentials, project_id = self._get_credentials_using_keyfile_dict()
+        else:
+            credentials, project_id = self._get_credentials_using_adc()
+
+        if self.delegate_to:
+            if hasattr(credentials, 'with_subject'):
+                credentials = credentials.with_subject(self.delegate_to)
+            else:
+                raise AirflowException(
+                    "The `delegate_to` parameter cannot be used here as the current "
+                    "authentication method does not support account impersonate. "
+                    "Please use service-account for authorization."
+                )
+
+        if self.target_principal:
+            credentials = impersonated_credentials.Credentials(
+                source_credentials=credentials,
+                target_principal=self.target_principal,
+                delegates=self.delegates,
+                target_scopes=self.scopes,
+            )
+
+            project_id = _get_project_id_from_service_account_email(self.target_principal)
+
+        return credentials, project_id
+
+    def _get_credentials_using_keyfile_dict(self):
+        self._log_debug('Getting connection using JSON Dict')
+        # Depending on how the JSON was formatted, it may contain
+        # escaped newlines. Convert those to actual newlines.
+        self.keyfile_dict['private_key'] = self.keyfile_dict['private_key'].replace('\\n', '\n')
+        credentials = google.oauth2.service_account.Credentials.from_service_account_info(
+            self.keyfile_dict, scopes=self.scopes
+        )
+        project_id = credentials.project_id
+        return credentials, project_id
+
+    def _get_credentials_using_key_path(self):
+        if self.key_path.endswith('.p12'):
+            raise AirflowException('Legacy P12 key file are not supported, use a JSON key file.')
+
+        if not self.key_path.endswith('.json'):
+            raise AirflowException('Unrecognised extension for key file.')
+
+        self._log_debug('Getting connection using JSON key file %s', self.key_path)
+        credentials = google.oauth2.service_account.Credentials.from_service_account_file(
+            self.key_path, scopes=self.scopes
+        )
+        project_id = credentials.project_id
+        return credentials, project_id
+
+    def _get_credentials_using_adc(self):
+        self._log_info(
+            'Getting connection using `google.auth.default()` since no key file is defined for hook.'
+        )
+        credentials, project_id = google.auth.default(scopes=self.scopes)
+        return credentials, project_id
+
+    def _log_info(self, *args, **kwargs) -> None:
+        if not self.disable_logging:
+            self.log.info(*args, **kwargs)
+
+    def _log_debug(self, *args, **kwargs) -> None:
+        if not self.disable_logging:
+            self.log.debug(*args, **kwargs)
+
+
+def get_credentials_and_project_id(*args, **kwargs) -> Tuple[google.auth.credentials.Credentials, str]:
+    """Returns the Credentials object for Google API and the associated project_id."""
+    return _CredentialProvider(*args, **kwargs).get_credentials_and_project()
+
+
+def _get_scopes(scopes: Optional[str] = None) -> Sequence[str]:
+    """
+    Parse a comma-separated string containing OAuth2 scopes if `scopes` is provided.
+    Otherwise, default scope will be returned.
+
+    :param scopes: A comma-separated string containing OAuth2 scopes
+    :type scopes: Optional[str]
+    :return: Returns the scope defined in the connection configuration, or the default scope
+    :rtype: Sequence[str]
+    """
+    return [s.strip() for s in scopes.split(',')] if scopes else _DEFAULT_SCOPES
+
+
+def _get_target_principal_and_delegates(
+    impersonation_chain: Optional[Union[str, Sequence[str]]] = None
+) -> Tuple[Optional[str], Optional[Sequence[str]]]:
+    """
+    Analyze contents of impersonation_chain and return target_principal (the service account
+    to directly impersonate using short-term credentials, if any) and optional list of delegates
+    required to get the access_token of target_principal.
+
+    :param impersonation_chain: the service account to impersonate or a chained list leading to this
+        account
+    :type impersonation_chain: Optional[Union[str, Sequence[str]]]
+
+    :return: Returns the tuple of target_principal and delegates
+    :rtype: Tuple[Optional[str], Optional[Sequence[str]]]
+    """
+    if not impersonation_chain:
+        return None, None
+
+    if isinstance(impersonation_chain, str):
+        return impersonation_chain, None
+
+    return impersonation_chain[-1], impersonation_chain[:-1]
+
+
+def _get_project_id_from_service_account_email(service_account_email: str) -> str:
+    """
+    Extracts project_id from service account's email address.
+
+    :param service_account_email: email of the service account.
+    :type service_account_email: str
+
+    :return: Returns the project_id of the provided service account.
+    :rtype: str
+    """
+    try:
+        return service_account_email.split('@')[1].split('.')[0]
+    except IndexError:
+        raise AirflowException(
+            f"Could not extract project_id from service account's email: " f"{service_account_email}."
+        )

--- a/observatory-platform/observatory/platform/airflow/secret_manager.py
+++ b/observatory-platform/observatory/platform/airflow/secret_manager.py
@@ -1,0 +1,170 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Objects relating to sourcing connections from Google Cloud Secrets Manager"""
+from typing import Optional
+
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
+
+from airflow.exceptions import AirflowException
+from observatory.platform.airflow.secret_manager_client import _SecretManagerClient
+from observatory.platform.airflow.credentials_provider import get_credentials_and_project_id
+from airflow.secrets import BaseSecretsBackend
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
+
+
+class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
+    """
+    Retrieves Connection object from Google Cloud Secrets Manager
+
+    Configurable via ``airflow.cfg`` as follows:
+
+    .. code-block:: ini
+
+        [secrets]
+        backend = airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
+        backend_kwargs = {"connections_prefix": "airflow-connections", "sep": "-"}
+
+    For example, if the Secrets Manager secret id is ``airflow-connections-smtp_default``, this would be
+    accessible if you provide ``{"connections_prefix": "airflow-connections", "sep": "-"}`` and request
+    conn_id ``smtp_default``.
+
+    If the Secrets Manager secret id is ``airflow-variables-hello``, this would be
+    accessible if you provide ``{"variables_prefix": "airflow-variables", "sep": "-"}`` and request
+    Variable Key ``hello``.
+
+    The full secret id should follow the pattern "[a-zA-Z0-9-_]".
+
+    :param connections_prefix: Specifies the prefix of the secret to read to get Connections.
+        If set to None (null), requests for connections will not be sent to GCP Secrets Manager
+    :type connections_prefix: str
+    :param variables_prefix: Specifies the prefix of the secret to read to get Variables.
+        If set to None (null), requests for variables will not be sent to GCP Secrets Manager
+    :type variables_prefix: str
+    :param config_prefix: Specifies the prefix of the secret to read to get Airflow Configurations
+        containing secrets.
+        If set to None (null), requests for configurations will not be sent to GCP Secrets Manager
+    :type config_prefix: str
+    :param gcp_key_path: Path to Google Cloud Service Account key file (JSON). Mutually exclusive with
+        gcp_keyfile_dict. use default credentials in the current environment if not provided.
+    :type gcp_key_path: str
+    :param gcp_keyfile_dict: Dictionary of keyfile parameters. Mutually exclusive with gcp_key_path.
+    :type gcp_keyfile_dict: dict
+    :param gcp_scopes: Comma-separated string containing OAuth2 scopes
+    :type gcp_scopes: str
+    :param project_id: Project ID to read the secrets from. If not passed, the project ID from credentials
+        will be used.
+    :type project_id: str
+    :param sep: Separator used to concatenate connections_prefix and conn_id. Default: "-"
+    :type sep: str
+    """
+
+    def __init__(
+        self,
+        connections_prefix: str = "airflow-connections",
+        variables_prefix: str = "airflow-variables",
+        config_prefix: str = "airflow-config",
+        gcp_keyfile_dict: Optional[dict] = None,
+        gcp_key_path: Optional[str] = None,
+        gcp_scopes: Optional[str] = None,
+        project_id: Optional[str] = None,
+        sep: str = "-",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.connections_prefix = connections_prefix
+        self.variables_prefix = variables_prefix
+        self.config_prefix = config_prefix
+        self.sep = sep
+        if connections_prefix is not None:
+            if not self._is_valid_prefix_and_sep():
+                raise AirflowException(
+                    "`connections_prefix`, `variables_prefix` and `sep` should "
+                    f"follows that pattern {SECRET_ID_PATTERN}"
+                )
+        self.credentials, self.project_id = get_credentials_and_project_id(
+            keyfile_dict=gcp_keyfile_dict, key_path=gcp_key_path, scopes=gcp_scopes
+        )
+        # In case project id provided
+        if project_id:
+            self.project_id = project_id
+
+    @cached_property
+    def client(self) -> _SecretManagerClient:
+        """
+        Cached property returning secret client.
+
+        :return: Secrets client
+        """
+        return _SecretManagerClient(credentials=self.credentials)
+
+    def _is_valid_prefix_and_sep(self) -> bool:
+        prefix = self.connections_prefix + self.sep
+        return _SecretManagerClient.is_valid_secret_name(prefix)
+
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+        """
+        Get secret value from the SecretManager.
+
+        :param conn_id: connection id
+        :type conn_id: str
+        """
+        if self.connections_prefix is None:
+            return None
+
+        return self._get_secret(self.connections_prefix, conn_id)
+
+    def get_variable(self, key: str) -> Optional[str]:
+        """
+        Get Airflow Variable from Environment Variable
+
+        :param key: Variable Key
+        :return: Variable Value
+        """
+        if self.variables_prefix is None:
+            return None
+
+        return self._get_secret(self.variables_prefix, key)
+
+    def get_config(self, key: str) -> Optional[str]:
+        """
+        Get Airflow Configuration
+
+        :param key: Configuration Option Key
+        :return: Configuration Option Value
+        """
+        if self.config_prefix is None:
+            return None
+
+        return self._get_secret(self.config_prefix, key)
+
+    def _get_secret(self, path_prefix: str, secret_id: str) -> Optional[str]:
+        """
+        Get secret value from the SecretManager based on prefix.
+
+        :param path_prefix: Prefix for the Path to get Secret
+        :type path_prefix: str
+        :param secret_id: Secret Key
+        :type secret_id: str
+        """
+        secret_id = self.build_path(path_prefix, secret_id, self.sep)
+        return self.client.get_secret(secret_id=secret_id, project_id=self.project_id)

--- a/observatory-platform/observatory/platform/airflow/secret_manager_client.py
+++ b/observatory-platform/observatory/platform/airflow/secret_manager_client.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import re
+from typing import Optional
+
+import google
+
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
+from google.api_core.exceptions import NotFound, PermissionDenied
+from google.api_core.gapic_v1.client_info import ClientInfo
+from google.cloud.secretmanager_v1 import SecretManagerServiceClient
+
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.version import version
+
+SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
+
+
+class _SecretManagerClient(LoggingMixin):
+    """
+    Retrieves Secrets object from Google Cloud Secrets Manager. This is a common class reused between
+    SecretsManager and Secrets Hook that provides the shared authentication and verification mechanisms.
+    This class should not be used directly, use SecretsManager or SecretsHook instead
+
+
+    :param credentials: Credentials used to authenticate to GCP
+    :type credentials: google.auth.credentials.Credentials
+    """
+
+    def __init__(
+        self,
+        credentials: google.auth.credentials.Credentials,
+    ) -> None:
+        super().__init__()
+        self.credentials = credentials
+
+    @staticmethod
+    def is_valid_secret_name(secret_name: str) -> bool:
+        """
+        Returns true if the secret name is valid.
+        :param secret_name: name of the secret
+        :type secret_name: str
+        :return:
+        """
+        return bool(re.match(SECRET_ID_PATTERN, secret_name))
+
+    @cached_property
+    def client(self) -> SecretManagerServiceClient:
+        """Create an authenticated KMS client"""
+        _client = SecretManagerServiceClient(
+            credentials=self.credentials, client_info=ClientInfo(client_library_version='airflow_v' + version)
+        )
+        return _client
+
+    def get_secret(self, secret_id: str, project_id: str, secret_version: str = 'latest') -> Optional[str]:
+        """
+        Get secret value from the Secret Manager.
+
+        :param secret_id: Secret Key
+        :type secret_id: str
+        :param project_id: Project id to use
+        :type project_id: str
+        :param secret_version: version of the secret (default is 'latest')
+        :type secret_version: str
+        """
+        name = self.client.secret_version_path(project_id, secret_id, secret_version)
+        try:
+            response = self.client.access_secret_version(name)
+            value = response.payload.data.decode('UTF-8')
+            return value
+        except NotFound:
+            self.log.error("Google Cloud API Call Error (NotFound): Secret ID %s not found.", secret_id)
+            return None
+        except PermissionDenied:
+            self.log.error(
+                """Google Cloud API Call Error (PermissionDenied): No access for Secret ID %s.
+                Did you add 'secretmanager.versions.access' permission?""",
+                secret_id,
+            )
+            return None

--- a/observatory-platform/observatory/platform/cli/cli.py
+++ b/observatory-platform/observatory/platform/cli/cli.py
@@ -81,8 +81,8 @@ def platform(
     """
 
     min_line_chars = 80
-    try:
-        print(f"{PLATFORM_NAME}: checking dependencies...".ljust(min_line_chars), end="\r")
+    print(f"{PLATFORM_NAME}: checking dependencies...".ljust(min_line_chars), end="\r")
+    if os.path.isfile(config_path):
         # Make the platform command, which encapsulates functionality for running the observatory
         platform_cmd = PlatformCommand(config_path, host_uid=host_uid, host_gid=host_gid, debug=debug,)
 
@@ -96,7 +96,7 @@ def platform(
             platform_stop(platform_cmd)
 
         exit(os.EX_OK)
-    except FileExistsError:
+    else:
         print(indent("config.yaml:", INDENT1))
         print(indent(f"- file not found, generating a default file on path: {config_path}", INDENT2))
         generate_cmd = GenerateCommand()
@@ -128,11 +128,6 @@ def platform_check_dependencies(platform_cmd: PlatformCommand, min_line_chars: i
     else:
         print(indent("- not installed, please install https://docs.docker.com/get-docker/", INDENT2))
 
-    print(indent("Host machine settings:", INDENT1))
-    print(indent(f"- observatory home: {observatory_home()}", INDENT2))
-    print(indent(f"- dags-path: {platform_cmd.dags_path}", INDENT2))
-    print(indent(f"- host-uid: {platform_cmd.host_uid}", INDENT2))
-
     print(indent("Docker Compose:", INDENT1))
     if platform_cmd.docker_compose_path is not None:
         print(indent(f"- path: {platform_cmd.docker_compose_path}", INDENT2))
@@ -150,6 +145,11 @@ def platform_check_dependencies(platform_cmd: PlatformCommand, min_line_chars: i
 
     if not platform_cmd.is_environment_valid:
         exit(os.EX_CONFIG)
+
+    print(indent("Host machine settings:", INDENT1))
+    print(indent(f"- observatory home: {platform_cmd.config.observatory.observatory_home}", INDENT2))
+    print(indent(f"- dags-path: {platform_cmd.dags_path}", INDENT2))
+    print(indent(f"- host-uid: {platform_cmd.host_uid}", INDENT2))
 
 
 def platform_start(platform_cmd: PlatformCommand, min_line_chars: int = 80):

--- a/observatory-platform/observatory/platform/cli/cli.py
+++ b/observatory-platform/observatory/platform/cli/cli.py
@@ -15,34 +15,16 @@
 # Author: James Diprose, Aniek Roelofs, Tuan Chien
 
 import os
-from typing import Union
 
 import click
+
 from observatory.platform.cli.click_utils import INDENT1, INDENT2, INDENT3, indent
 from observatory.platform.cli.generate_command import GenerateCommand
 from observatory.platform.cli.platform_command import PlatformCommand
 from observatory.platform.cli.terraform_command import TerraformCommand
-from observatory.platform.platform_builder import (
-    AIRFLOW_UI_PORT,
-    BUILD_PATH,
-    DAGS_MODULE,
-    DATA_PATH,
-    DEBUG,
-    DOCKER_COMPOSE_PROJECT_NAME,
-    DOCKER_NETWORK_NAME,
-    ELASTIC_PORT,
-    FLOWER_UI_PORT,
-    HOST_GID,
-    HOST_UID,
-    KIBANA_PORT,
-    LOGS_PATH,
-    POSTGRES_PATH,
-    REDIS_PORT,
-)
+from observatory.platform.platform_builder import DEBUG, HOST_GID, HOST_UID
 from observatory.platform.utils.config_utils import observatory_home
-from observatory.platform.utils.config_utils import (
-    terraform_credentials_path as default_terraform_credentials_path,
-)
+from observatory.platform.utils.config_utils import terraform_credentials_path as default_terraform_credentials_path
 
 PLATFORM_NAME = "Observatory Platform"
 TERRAFORM_NAME = "Observatory Terraform"
@@ -74,41 +56,6 @@ def cli():
     show_default=True,
 )
 @click.option(
-    "--build-path",
-    type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    default=BUILD_PATH,
-    help="The path on the host machine to use for building the Observatory Platform.",
-    show_default=True,
-)
-@click.option(
-    "--dags-path",
-    type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    default=DAGS_MODULE,
-    help="The path on the host machine to mount as the Apache Airflow DAGs folder.",
-    show_default=True,
-)
-@click.option(
-    "--data-path",
-    type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    default=DATA_PATH,
-    help="The path on the host machine to mount as the data folder.",
-    show_default=True,
-)
-@click.option(
-    "--logs-path",
-    type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    default=LOGS_PATH,
-    help="The path on the host machine to mount as the logs folder.",
-    show_default=True,
-)
-@click.option(
-    "--postgres-path",
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=False),
-    default=POSTGRES_PATH,
-    help="The path on the host machine to mount as the PostgreSQL data folder.",
-    show_default=True,
-)
-@click.option(
     "--host-uid",
     type=click.INT,
     default=HOST_UID,
@@ -122,64 +69,9 @@ def cli():
     help="The group id of the host system. Used to set the group id in the Docker containers.",
     show_default=True,
 )
-@click.option("--redis-port", type=click.INT, default=REDIS_PORT, help="The host Redis port number.", show_default=True)
-@click.option(
-    "--flower-ui-port",
-    type=click.INT,
-    default=FLOWER_UI_PORT,
-    help="The host's Flower UI port number.",
-    show_default=True,
-)
-@click.option(
-    "--airflow-ui-port",
-    type=click.INT,
-    default=AIRFLOW_UI_PORT,
-    help="The host's Apache Airflow UI port number.",
-    show_default=True,
-)
-@click.option(
-    "--elastic-port",
-    type=click.INT,
-    default=ELASTIC_PORT,
-    help="The host's Elasticsearch port number.",
-    show_default=True,
-)
-@click.option(
-    "--kibana-port", type=click.INT, default=KIBANA_PORT, help="The host's Kibana port number.", show_default=True
-)
-@click.option(
-    "--docker-network-name",
-    type=click.STRING,
-    default=DOCKER_NETWORK_NAME,
-    help="The Docker Network name, used to specify a custom Docker Network.",
-    show_default=True,
-)
-@click.option(
-    "--docker-compose-project-name",
-    type=click.STRING,
-    default=DOCKER_COMPOSE_PROJECT_NAME,
-    help="The namespace for Docker containers.",
-    show_default=True,
-)
 @click.option("--debug", is_flag=True, default=DEBUG, help="Print debugging information.")
 def platform(
-    command: str,
-    config_path: str,
-    build_path: str,
-    dags_path: str,
-    data_path: str,
-    logs_path: str,
-    postgres_path: str,
-    host_uid: int,
-    host_gid: int,
-    redis_port: int,
-    flower_ui_port: int,
-    airflow_ui_port: int,
-    elastic_port: int,
-    kibana_port: int,
-    docker_network_name: Union[None, str],
-    docker_compose_project_name: str,
-    debug,
+    command: str, config_path: str, host_uid: int, host_gid: int, debug,
 ):
     """Run the local Observatory Platform platform.\n
 
@@ -189,24 +81,7 @@ def platform(
     """
 
     # Make the platform command, which encapsulates functionality for running the observatory
-    platform_cmd = PlatformCommand(
-        config_path,
-        build_path=build_path,
-        dags_path=dags_path,
-        data_path=data_path,
-        logs_path=logs_path,
-        postgres_path=postgres_path,
-        host_uid=host_uid,
-        host_gid=host_gid,
-        redis_port=redis_port,
-        flower_ui_port=flower_ui_port,
-        airflow_ui_port=airflow_ui_port,
-        elastic_port=elastic_port,
-        kibana_port=kibana_port,
-        docker_network_name=docker_network_name,
-        docker_compose_project_name=docker_compose_project_name,
-        debug=debug,
-    )
+    platform_cmd = PlatformCommand(config_path, host_uid=host_uid, host_gid=host_gid, debug=debug,)
     generate_cmd = GenerateCommand()
 
     # Check dependencies
@@ -250,10 +125,7 @@ def platform_check_dependencies(platform_cmd: PlatformCommand, generate_cmd: Gen
 
     print(indent("Host machine settings:", INDENT1))
     print(indent(f"- observatory home: {observatory_home()}", INDENT2))
-    print(indent(f"- data-path: {platform_cmd.data_path}", INDENT2))
     print(indent(f"- dags-path: {platform_cmd.dags_path}", INDENT2))
-    print(indent(f"- logs-path: {platform_cmd.logs_path}", INDENT2))
-    print(indent(f"- postgres-path: {platform_cmd.postgres_path}", INDENT2))
     print(indent(f"- host-uid: {platform_cmd.host_uid}", INDENT2))
 
     print(indent("Docker Compose:", INDENT1))

--- a/observatory-platform/observatory/platform/cli/platform_command.py
+++ b/observatory-platform/observatory/platform/cli/platform_command.py
@@ -14,100 +14,41 @@
 
 # Author: James Diprose
 
-from typing import Union
-
+from observatory.platform.observatory_config import BackendType
 from observatory.platform.platform_builder import (
     PlatformBuilder,
-    BUILD_PATH,
-    DAGS_MODULE,
-    DATA_PATH,
-    LOGS_PATH,
-    POSTGRES_PATH,
     HOST_UID,
     HOST_GID,
-    REDIS_PORT,
-    FLOWER_UI_PORT,
-    AIRFLOW_UI_PORT,
-    ELASTIC_PORT,
-    KIBANA_PORT,
-    DOCKER_NETWORK_NAME,
-    DOCKER_COMPOSE_PROJECT_NAME,
     DEBUG,
 )
 from observatory.platform.utils.url_utils import wait_for_url
-from observatory.platform.observatory_config import BackendType
 
 
 class PlatformCommand(PlatformBuilder):
-    def __init__(
-        self,
-        config_path: str,
-        build_path: str = BUILD_PATH,
-        dags_path: str = DAGS_MODULE,
-        data_path: str = DATA_PATH,
-        logs_path: str = LOGS_PATH,
-        postgres_path: str = POSTGRES_PATH,
-        host_uid: int = HOST_UID,
-        host_gid: int = HOST_GID,
-        redis_port: int = REDIS_PORT,
-        flower_ui_port: int = FLOWER_UI_PORT,
-        airflow_ui_port: int = AIRFLOW_UI_PORT,
-        elastic_port: int = ELASTIC_PORT,
-        kibana_port: int = KIBANA_PORT,
-        docker_network_name: Union[None, int] = DOCKER_NETWORK_NAME,
-        docker_compose_project_name: str = DOCKER_COMPOSE_PROJECT_NAME,
-        debug: bool = DEBUG,
-    ):
-        """Create a PlatformCommand, which can be used to start and stop Observatory Platform instances.
+    def __init__(self, config_path: str, host_uid: int = HOST_UID, host_gid: int = HOST_GID, debug: bool = DEBUG):
+        """ Create a PlatformCommand, which can be used to start and stop Observatory Platform instances.
 
         :param config_path: The path to the config.yaml configuration file.
-        :param dags_path: The path on the host machine to mount as the Apache Airflow DAGs folder.
-        :param data_path: The path on the host machine to mount as the data folder.
-        :param logs_path: The path on the host machine to mount as the logs folder.
-        :param postgres_path: The path on the host machine to mount as the PostgreSQL data folder.
         :param host_uid: The user id of the host system. Used to set the user id in the Docker containers.
         :param host_gid: The group id of the host system. Used to set the group id in the Docker containers.
-        :param redis_port: The host Redis port number.
-        :param flower_ui_port: The host's Flower UI port number.
-        :param airflow_ui_port: The host's Apache Airflow UI port number.
-        :param elastic_port: The host's Elasticsearch port number.
-        :param kibana_port: The host's Kibana port number.
-        :param docker_network_name: The Docker Network name, used to specify a custom Docker Network.
         :param debug: Print debugging information.
         """
 
-        is_env_local = True
         super().__init__(
-            config_path,
-            build_path=build_path,
-            dags_path=dags_path,
-            data_path=data_path,
-            logs_path=logs_path,
-            postgres_path=postgres_path,
-            host_uid=host_uid,
-            host_gid=host_gid,
-            redis_port=redis_port,
-            flower_ui_port=flower_ui_port,
-            airflow_ui_port=airflow_ui_port,
-            elastic_port=elastic_port,
-            kibana_port=kibana_port,
-            docker_network_name=docker_network_name,
-            docker_compose_project_name=docker_compose_project_name,
-            debug=debug,
-            backend_type=BackendType.local,
+            config_path=config_path, host_uid=host_uid, host_gid=host_gid, debug=debug, backend_type=BackendType.local
         )
 
     @property
     def ui_url(self) -> str:
-        """Return the URL to Apache Airflow UI.
+        """ Return the URL to Apache Airflow UI.
 
         :return: Apache Airflow UI URL.
         """
 
-        return f"http://localhost:{self.airflow_ui_port}"
+        return f"http://localhost:{self.config.observatory.airflow_ui_port}"
 
     def wait_for_airflow_ui(self, timeout: int = 60) -> bool:
-        """Wait for the Apache Airflow UI to start.
+        """ Wait for the Apache Airflow UI to start.
 
         :param timeout: the number of seconds to wait before timing out.
         :return: whether connecting to the Apache Airflow UI was successful or not.

--- a/observatory-platform/observatory/platform/cli/terraform_command.py
+++ b/observatory-platform/observatory/platform/cli/terraform_command.py
@@ -35,7 +35,6 @@ class TerraformCommand:
 
         self.config_path = config_path
         self.terraform_credentials_path = terraform_credentials_path
-        self.terraform_builder = TerraformBuilder(config_path, debug=debug)
         self.debug = debug
 
         # Load config and
@@ -46,6 +45,7 @@ class TerraformCommand:
         if self.config_exists:
             self.config = TerraformConfig.load(config_path)
             self.config_is_valid = self.config.is_valid
+            self.terraform_builder = TerraformBuilder(config_path, debug=debug)
 
     @property
     def is_environment_valid(self):

--- a/observatory-platform/observatory/platform/config-terraform.yaml.jinja2
+++ b/observatory-platform/observatory/platform/config-terraform.yaml.jinja2
@@ -4,12 +4,13 @@ backend:
   type: terraform
   environment: develop
 
-# Apache Airflow settings
-airflow:
-  fernet_key: {{ fernet_key }}
-  secret_key: {{ secret_key }}
-  ui_user_email: my-email@example.com <--
-  ui_user_password: my-password <--
+# Observatory settings
+observatory:
+  airflow_fernet_key: {{ airflow_fernet_key }}
+  airflow_secret_key: {{ airflow_secret_key }}
+  airflow_ui_user_email: my-email@example.com <--
+  airflow_ui_user_password: my-password <--
+  postgres_password: my-password <--
 
 # Terraform settings
 terraform:
@@ -27,7 +28,7 @@ google_cloud:
 cloud_sql_database:
   tier: db-custom-2-7680
   backup_start_time: '23:00'
-  postgres_password: my-password <--
+
 
 # Settings for the main VM that runs the Apache Airflow scheduler and webserver
 airflow_main_vm:

--- a/observatory-platform/observatory/platform/config.yaml.jinja2
+++ b/observatory-platform/observatory/platform/config.yaml.jinja2
@@ -4,10 +4,10 @@ backend:
   type: local
   environment: develop
 
-# Apache Airflow settings
-airflow:
-  fernet_key: {{ fernet_key }}
-  secret_key: {{ secret_key }}
+# Observatory settings
+observatory:
+  airflow_fernet_key: {{ airflow_fernet_key }}
+  airflow_secret_key: {{ airflow_secret_key }}
 
 # Terraform settings: customise to use the vm_create and vm_destroy DAGs:
 # terraform:

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -65,7 +65,7 @@ x-environment: &environment
   AIRFLOW__CORE__REMOTE_LOGGING: "True"
   AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER: "gs://${AIRFLOW_VAR_AIRFLOW_BUCKET}/logs"
   AIRFLOW__CORE__REMOTE_LOG_CONN_ID: "google_cloud_observatory"
-  AIRFLOW__SECRETS__BACKEND: "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"
+  AIRFLOW__SECRETS__BACKEND: "observatory.platform.airflow.secret_manager.CloudSecretManagerBackend"
   AIRFLOW__SECRETS__BACKEND_KWARGS: "{'connections_prefix': 'airflow-connections', 'variables_prefix': 'airflow-variables', 'sep': '-'}"
   {%- endif %}
 

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -169,8 +169,10 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      {% if config.backend.type.value == 'local' -%}
       postgres:
         condition: service_healthy
+      {%- endif %}
     ports:
       - ${HOST_FLOWER_UI_PORT}:5555
     command: celery flower
@@ -190,8 +192,10 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      {% if config.backend.type.value == 'local' -%}
       postgres:
         condition: service_healthy
+      {%- endif %}
     {% if config.google_cloud.credentials is not none -%}
     secrets:
       - google_application_credentials.json

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -18,37 +18,33 @@ version: '3.8'
 {# Values same for different environments #}
 {%- set postgres_user="observatory" -%}
 {%- set airflow_db_name="airflow" -%}
-
-{# Values different in different environments #}
-{%- if config.backend.type.value == 'local' -%}
-{%- set postgres_password="observatory" -%}
-{%- set postgres_hostname="postgres" -%}
-{%- set redis_hostname="redis" -%}
-{%- set airflow_ui_user_email="airflow@airflow.com" -%}
-{%- set airflow_ui_user_password="airflow" -%}
-
-{%- set host_logs_path="${HOST_LOGS_PATH}" -%}
-{%- set host_dags_path="${HOST_DAGS_PATH}" -%}
-{%- set host_data_path="${HOST_DATA_PATH}" -%}
-{%- set host_platform_package_path="${HOST_PLATFORM_PACKAGE_PATH}" -%}
-{%- set host_api_package_path="${HOST_API_PACKAGE_PATH}" -%}
-{%- set host_postgres_path="${HOST_POSTGRES_PATH}" -%}
-{%- set google_application_credentials="${HOST_GOOGLE_APPLICATION_CREDENTIALS}" -%}
-
-{%- else -%}
-
 {%- set postgres_password="${POSTGRES_PASSWORD}" -%}
-{%- set postgres_hostname="${POSTGRES_HOSTNAME}" -%}
-{%- set redis_hostname="${REDIS_HOSTNAME}" -%}
 {%- set airflow_ui_user_email="${AIRFLOW_UI_USER_EMAIL}" -%}
 {%- set airflow_ui_user_password="${AIRFLOW_UI_USER_PASSWORD}" -%}
 
+{# Values different in different environments #}
+{%- if config.backend.type.value == 'local' -%}
+
+{%- set host_data_path="${HOST_OBSERVATORY_HOME}/data" -%}
+{%- set host_logs_path="${HOST_OBSERVATORY_HOME}/logs" -%}
+{%- set host_postgres_path="${HOST_OBSERVATORY_HOME}/postgres" -%}
+{%- set host_dags_path="${HOST_DAGS_PATH}" -%}
+{%- set host_platform_package_path="${HOST_PLATFORM_PACKAGE_PATH}" -%}
+{%- set host_api_package_path="${HOST_API_PACKAGE_PATH}" -%}
+{%- set google_application_credentials="${HOST_GOOGLE_APPLICATION_CREDENTIALS}" -%}
+{%- set postgres_hostname="postgres" -%}
+{%- set redis_hostname="redis" -%}
+
+{%- else -%}
+
+{%- set host_data_path="/opt/observatory/data" -%}
 {%- set host_logs_path="/opt/airflow/logs" -%}
 {%- set host_dags_path="/opt/observatory-platform/observatory/platform/dags" -%}
-{%- set host_data_path="/opt/observatory/data" -%}
 {%- set host_platform_package_path="/opt/observatory-platform" -%}
 {%- set host_api_package_path="/opt/observatory-api" -%}
 {%- set google_application_credentials="/opt/observatory/google_application_credentials.json" -%}
+{%- set postgres_hostname="${POSTGRES_HOSTNAME}" -%}
+{%- set redis_hostname="${REDIS_HOSTNAME}" -%}
 
 {%- endif -%}
 
@@ -57,19 +53,19 @@ x-environment: &environment
   # Airflow settings
   AIRFLOW__CORE__EXECUTOR: CeleryExecutor
   AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgres+psycopg2://{{ postgres_user }}:{{ postgres_password }}@{{ postgres_hostname }}:5432/{{ airflow_db_name }}"
-  AIRFLOW__CORE__FERNET_KEY: ${FERNET_KEY}
+  AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW_FERNET_KEY}
   AIRFLOW__CORE__AIRFLOW_HOME: /opt/airflow
   AIRFLOW__CORE__LOAD_EXAMPLES: "False"
   AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: "False"
   AIRFLOW__WEBSERVER__RBAC: "True"
-  AIRFLOW__WEBSERVER__SECRET_KEY: ${SECRET_KEY}
+  AIRFLOW__WEBSERVER__SECRET_KEY: ${AIRFLOW_SECRET_KEY}
   AIRFLOW__CELERY__BROKER_URL: "redis://:@{{ redis_hostname }}:6379/0"
   AIRFLOW__CELERY__RESULT_BACKEND: "db+postgresql://{{ postgres_user }}:{{ postgres_password }}@{{ postgres_hostname }}:5432/{{ airflow_db_name }}"
   {%- if config.backend.type.value == 'terraform' %}
   AIRFLOW__CORE__REMOTE_LOGGING: "True"
   AIRFLOW__CORE__REMOTE_BASE_LOG_FOLDER: "gs://${AIRFLOW_VAR_AIRFLOW_BUCKET}/logs"
   AIRFLOW__CORE__REMOTE_LOG_CONN_ID: "google_cloud_observatory"
-  AIRFLOW__SECRETS__BACKEND: "airflow.contrib.secrets.gcp_secrets_manager.CloudSecretsManagerBackend"
+  AIRFLOW__SECRETS__BACKEND: "airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend"
   AIRFLOW__SECRETS__BACKEND_KWARGS: "{'connections_prefix': 'airflow-connections', 'variables_prefix': 'airflow-variables', 'sep': '-'}"
   {%- endif %}
 
@@ -251,7 +247,7 @@ services:
     {%- endif %}
     command: celery worker -q remote_queue
 
-  {%- if config.backend.type.value == 'local' %}
+  {% if config.backend.type.value == 'local' -%}
   elasticsearch:
     image: "docker.elastic.co/elasticsearch/elasticsearch:7.13.3"
     restart: always
@@ -280,7 +276,7 @@ services:
       - POSTGRES_USER={{ postgres_user }}
       - POSTGRES_PASSWORD={{ postgres_password }}
     volumes:
-      - ${HOST_POSTGRES_PATH}:/var/lib/postgresql/data
+      - {{ host_postgres_path }}:/var/lib/postgresql/data
     restart: always
     networks:
       - {{ docker_network_name }}

--- a/observatory-platform/observatory/platform/observatory_config.py
+++ b/observatory-platform/observatory/platform/observatory_config.py
@@ -178,8 +178,8 @@ class Observatory:
 
         airflow_fernet_key = dict_.get("airflow_fernet_key")
         airflow_secret_key = dict_.get("airflow_secret_key")
-        airflow_ui_user_password = dict_.get("airflow_ui_user_password")
-        airflow_ui_user_email = dict_.get("airflow_ui_user_email")
+        airflow_ui_user_email = dict_.get("airflow_ui_user_email", Observatory.airflow_ui_user_email)
+        airflow_ui_user_password = dict_.get("airflow_ui_user_password", Observatory.airflow_ui_user_password)
         observatory_home = dict_.get("observatory_home", Observatory.observatory_home)
         postgres_password = dict_.get("postgres_password", Observatory.postgres_password)
         redis_port = dict_.get("redis_port", Observatory.redis_port)
@@ -756,8 +756,8 @@ class ObservatoryConfig:
 
         # Render template
         template_path = os.path.join(module_file_path("observatory.platform"), template_file_name)
-        fernet_key = Fernet.generate_key()
-        secret_key = generate_secret_key()
+        airflow_fernet_key = Fernet.generate_key()
+        airflow_secret_key = generate_secret_key()
 
         try:
             observatory_dags_path = module_file_path("observatory.dags", nav_back_steps=-3)
@@ -765,7 +765,10 @@ class ObservatoryConfig:
             observatory_dags_path = "/path/to/observatory-platform/observatory-dags"
 
         render = render_template(
-            template_path, fernet_key=fernet_key, secret_key=secret_key, observatory_dags_path=observatory_dags_path
+            template_path,
+            airflow_fernet_key=airflow_fernet_key,
+            airflow_secret_key=airflow_secret_key,
+            airflow_observatory_dags_path=observatory_dags_path,
         )
 
         # Save file

--- a/observatory-platform/observatory/platform/observatory_config.py
+++ b/observatory-platform/observatory/platform/observatory_config.py
@@ -32,11 +32,12 @@ from cryptography.fernet import Fernet
 from observatory.platform.terraform_api import TerraformVariable
 from observatory.platform.utils.airflow_utils import AirflowVariable, AirflowVars
 from observatory.platform.utils.config_utils import module_file_path
+from observatory.platform.utils.config_utils import observatory_home as default_observatory_home
 from observatory.platform.utils.jinja2_utils import render_template
 
 
 def generate_secret_key(length: int = 30) -> str:
-    """Generate a secret key for the Flask Airflow Webserver.
+    """ Generate a secret key for the Flask Airflow Webserver.
 
     :param length: the length of the key to generate.
     :return: the random key.
@@ -46,7 +47,7 @@ def generate_secret_key(length: int = 30) -> str:
 
 
 def save_yaml(file_path: str, dict_: Dict):
-    """Save a yaml file from a dictionary.
+    """ Save a yaml file from a dictionary.
 
     :param file_path: the path to the file to save.
     :param dict_: the dictionary.
@@ -58,7 +59,7 @@ def save_yaml(file_path: str, dict_: Dict):
 
 
 def to_hcl(value: Dict) -> str:
-    """Convert a Python dictionary into HCL.
+    """ Convert a Python dictionary into HCL.
 
     :param value: the dictionary.
     :return: the HCL string.
@@ -68,7 +69,7 @@ def to_hcl(value: Dict) -> str:
 
 
 def from_hcl(string: str) -> Dict:
-    """Convert an HCL string into a Dict.
+    """ Convert an HCL string into a Dict.
 
     :param string: the HCL string.
     :return: the dict.
@@ -94,78 +95,126 @@ class Environment(Enum):
 
 @dataclass
 class Backend:
-    """The backend settings for the Observatory Platform.
+    """ The backend settings for the Observatory Platform.
 
     Attributes:
         type: the type of backend being used (local environment or Terraform).
         environment: what type of environment is being deployed (develop, staging or production).
-    """
+     """
 
     type: BackendType
     environment: Environment
 
     @staticmethod
     def from_dict(dict_: Dict) -> Backend:
-        """Constructs a Backend instance from a dictionary.
+        """ Constructs a Backend instance from a dictionary.
 
         :param dict_: the dictionary.
         :return: the Backend instance.
         """
 
-        type = BackendType(dict_.get("type"))
+        backend_type = BackendType(dict_.get("type"))
         environment = Environment(dict_.get("environment"))
-        return Backend(type, environment)
+
+        return Backend(backend_type, environment,)
 
 
 @dataclass
-class Airflow:
-    """The Apache Airflow settings for the Observatory Platform.
+class Observatory:
+    """ The Observatory settings for the Observatory Platform.
 
     Attributes:
-        fernet_key: the Fernet key.
-        secret_key: the secret key used to run the flask app.
-        ui_user_password: the password for the Apache Airflow UI admin user.
-        ui_user_email: the email address for the Apache Airflow UI admin user.
-    """
+        :param airflow_fernet_key: the Fernet key.
+        :param airflow_secret_key: the secret key used to run the flask app.
+        :param airflow_ui_user_password: the password for the Apache Airflow UI admin user.
+        :param airflow_ui_user_email: the email address for the Apache Airflow UI admin user.
+        :param observatory_home: The observatory home folder.
+        :param postgres_password: the Postgres SQL password.
+        :param redis_port: The host Redis port number.
+        :param flower_ui_port: The host's Flower UI port number.
+        :param airflow_ui_port: The host's Apache Airflow UI port number.
+        :param elastic_port: The host's Elasticsearch port number.
+        :param kibana_port: The host's Kibana port number.
+        :param docker_network_name: The Docker Network name, used to specify a custom Docker Network.
+        :param docker_compose_project_name: The namespace for the Docker Compose containers: https://docs.docker.com/compose/reference/envvars/#compose_project_name.
+     """
 
-    fernet_key: str
-    secret_key: str
-    ui_user_password: str = None
-    ui_user_email: str = None
+    airflow_fernet_key: str
+    airflow_secret_key: str
+    airflow_ui_user_password: str = "airflow@airflow.com"
+    airflow_ui_user_email: str = "airflow"
+    observatory_home: str = default_observatory_home()
+    postgres_password: str = "postgres"
+    redis_port: int = 6379
+    flower_ui_port: int = 5555
+    airflow_ui_port: int = 8080
+    elastic_port: int = 9200
+    kibana_port: int = 5601
+    docker_network_name: str = "observatory-network"
+    docker_compose_project_name: str = "observatory"
+
+    @property
+    def docker_network_is_external(self):
+        return self.docker_network_name != "observatory-network"
 
     def to_hcl(self):
         return to_hcl(
             {
-                "fernet_key": self.fernet_key,
-                "secret_key": self.secret_key,
-                "ui_user_password": self.ui_user_password,
-                "ui_user_email": self.ui_user_email,
+                "airflow_fernet_key": self.airflow_fernet_key,
+                "airflow_secret_key": self.airflow_secret_key,
+                "airflow_ui_user_password": self.airflow_ui_user_password,
+                "airflow_ui_user_email": self.airflow_ui_user_email,
+                "postgres_password": self.postgres_password,
             }
         )
 
     @staticmethod
-    def from_dict(dict_: Dict) -> Airflow:
-        """Constructs an Airflow instance from a dictionary.
+    def from_dict(dict_: Dict) -> Observatory:
+        """ Constructs an Airflow instance from a dictionary.
 
         :param dict_: the dictionary.
         :return: the Airflow instance.
         """
 
-        fernet_key = dict_.get("fernet_key")
-        secret_key = dict_.get("secret_key")
-        ui_user_password = dict_.get("ui_user_password")
-        ui_user_email = dict_.get("ui_user_email")
-        return Airflow(fernet_key, secret_key, ui_user_password=ui_user_password, ui_user_email=ui_user_email)
+        airflow_fernet_key = dict_.get("airflow_fernet_key")
+        airflow_secret_key = dict_.get("airflow_secret_key")
+        airflow_ui_user_password = dict_.get("airflow_ui_user_password")
+        airflow_ui_user_email = dict_.get("airflow_ui_user_email")
+        observatory_home = dict_.get("observatory_home", Observatory.observatory_home)
+        postgres_password = dict_.get("postgres_password", Observatory.postgres_password)
+        redis_port = dict_.get("redis_port", Observatory.redis_port)
+        flower_ui_port = dict_.get("flower_ui_port", Observatory.flower_ui_port)
+        airflow_ui_port = dict_.get("airflow_ui_port", Observatory.airflow_ui_port)
+        elastic_port = dict_.get("elastic_port", Observatory.elastic_port)
+        kibana_port = dict_.get("kibana_port", Observatory.kibana_port)
+        docker_network_name = dict_.get("docker_network_name", Observatory.docker_network_name)
+        docker_compose_project_name = dict_.get("docker_compose_project_name", Observatory.docker_compose_project_name)
+
+        return Observatory(
+            airflow_fernet_key,
+            airflow_secret_key,
+            airflow_ui_user_password=airflow_ui_user_password,
+            airflow_ui_user_email=airflow_ui_user_email,
+            observatory_home=observatory_home,
+            postgres_password=postgres_password,
+            redis_port=redis_port,
+            flower_ui_port=flower_ui_port,
+            airflow_ui_port=airflow_ui_port,
+            elastic_port=elastic_port,
+            kibana_port=kibana_port,
+            docker_network_name=docker_network_name,
+            docker_compose_project_name=docker_compose_project_name,
+        )
 
 
 @dataclass
 class CloudStorageBucket:
-    """Represents a Google Cloud Storage Bucket.
+    """ Represents a Google Cloud Storage Bucket.
 
     Attributes:
         id: the id of the bucket (which gets set as an Airflow variable).
         name: the name of the Google Cloud storage bucket.
-    """
+     """
 
     id: str
     name: str
@@ -177,7 +226,7 @@ class CloudStorageBucket:
 
 @dataclass
 class GoogleCloud:
-    """The Google Cloud settings for the Observatory Platform.
+    """ The Google Cloud settings for the Observatory Platform.
 
     Attributes:
         project_id: the Google Cloud project id.
@@ -186,7 +235,7 @@ class GoogleCloud:
         zone: the Google Cloud zone.
         data_location: the data location for storing buckets.
         buckets: a list of the Google Cloud buckets.
-    """
+     """
 
     project_id: str = None
     credentials: str = None
@@ -214,7 +263,7 @@ class GoogleCloud:
 
     @staticmethod
     def from_dict(dict_: Dict) -> GoogleCloud:
-        """Constructs a GoogleCloud instance from a dictionary.
+        """ Constructs a GoogleCloud instance from a dictionary.
 
         :param dict_: the dictionary.
         :return: the GoogleCloud instance.
@@ -238,7 +287,7 @@ class GoogleCloud:
 
 
 def parse_dict_to_list(dict_: Dict, cls: ClassVar) -> List[Any]:
-    """Parse the key, value pairs in a dictionary into a list of class instances.
+    """ Parse the key, value pairs in a dictionary into a list of class instances.
 
     :param dict_: the dictionary.
     :param cls: the type of class to construct.
@@ -253,13 +302,13 @@ def parse_dict_to_list(dict_: Dict, cls: ClassVar) -> List[Any]:
 
 @dataclass
 class DagsProject:
-    """Represents a project that contains DAGs to load.
+    """ Represents a project that contains DAGs to load.
 
     Attributes:
         package_name: the package name.
         path: the path to the DAGs folder. TODO: check
         dags_module: the Python import path to the module that contains the Apache Airflow DAGs to load.
-    """
+     """
 
     package_name: str
     path: str
@@ -267,7 +316,7 @@ class DagsProject:
 
     @property
     def type(self) -> str:
-        """The type of DAGs project: local, Github or PyPI.
+        """ The type of DAGs project: local, Github or PyPI.
 
         :return: the type of DAGs project.
         """
@@ -276,7 +325,7 @@ class DagsProject:
 
     @staticmethod
     def parse_dags_projects(list: List) -> List[DagsProject]:
-        """Parse the dags_projects list object into a list of DagsProject instances.
+        """ Parse the dags_projects list object into a list of DagsProject instances.
 
         :param list: the list.
         :return: a list of DagsProject instances.
@@ -296,7 +345,7 @@ class DagsProject:
 
 
 def list_to_hcl(items: List[Union[AirflowConnection, AirflowVariable]]) -> str:
-    """Convert a list of AirflowConnection or AirflowVariable instances into HCL.
+    """ Convert a list of AirflowConnection or AirflowVariable instances into HCL.
 
     :param items: the list of AirflowConnection or AirflowVariable instances.
     :return: the HCL string.
@@ -310,19 +359,19 @@ def list_to_hcl(items: List[Union[AirflowConnection, AirflowVariable]]) -> str:
 
 @dataclass
 class AirflowConnection:
-    """An Airflow Connection.
+    """ An Airflow Connection.
 
     Attributes:
         name: the name of the Airflow Connection.
         value: the value of the Airflow Connection.
-    """
+     """
 
     name: str
     value: str
 
     @property
     def conn_name(self) -> str:
-        """The Airflow Connection environment variable name, which is required to set the connection from an
+        """ The Airflow Connection environment variable name, which is required to set the connection from an
         environment variable.
 
         :return: the Airflow Connection environment variable name.
@@ -332,7 +381,7 @@ class AirflowConnection:
 
     @staticmethod
     def parse_airflow_connections(dict_: Dict) -> List[AirflowConnection]:
-        """Parse the airflow_connections dictionary object into a list of AirflowConnection instances.
+        """ Parse the airflow_connections dictionary object into a list of AirflowConnection instances.
 
         :param dict_: the dictionary.
         :return: a list of AirflowConnection instances.
@@ -343,19 +392,19 @@ class AirflowConnection:
 
 @dataclass
 class AirflowVariable:
-    """An Airflow Variable.
+    """ An Airflow Variable.
 
     Attributes:
         name: the name of the Airflow Variable.
         value: the value of the Airflow Variable.
-    """
+     """
 
     name: str
     value: str
 
     @property
     def env_var_name(self):
-        """The Airflow Variable environment variable name, which is required to set the variable from an
+        """ The Airflow Variable environment variable name, which is required to set the variable from an
         environment variable.
 
         :return: the Airflow Variable environment variable name.
@@ -365,7 +414,7 @@ class AirflowVariable:
 
     @staticmethod
     def parse_airflow_variables(dict_: Dict) -> List[AirflowVariable]:
-        """Parse the airflow_variables dictionary object into a list of AirflowVariable instances.
+        """ Parse the airflow_variables dictionary object into a list of AirflowVariable instances.
 
         :param dict_: the dictionary.
         :return: a list of AirflowVariable instances.
@@ -376,17 +425,17 @@ class AirflowVariable:
 
 @dataclass
 class Terraform:
-    """The Terraform settings for the Observatory Platform.
+    """ The Terraform settings for the Observatory Platform.
 
     Attributes:
         organization: the Terraform Organisation name.
-    """
+     """
 
     organization: str
 
     @staticmethod
     def from_dict(dict_: Dict) -> Terraform:
-        """Constructs a Terraform instance from a dictionary.
+        """ Constructs a Terraform instance from a dictionary.
 
         :param dict_: the dictionary.
         """
@@ -397,30 +446,22 @@ class Terraform:
 
 @dataclass
 class CloudSqlDatabase:
-    """The Google Cloud SQL database settings for the Observatory Platform.
+    """ The Google Cloud SQL database settings for the Observatory Platform.
 
     Attributes:
         tier: the database machine tier.
         backup_start_time: the start time for backups in HH:MM format.
-        postgres_password: the Postgres SQL password.
-    """
+     """
 
     tier: str
     backup_start_time: str
-    postgres_password: str
 
     def to_hcl(self):
-        return to_hcl(
-            {
-                "tier": self.tier,
-                "backup_start_time": self.backup_start_time,
-                "postgres_password": self.postgres_password,
-            }
-        )
+        return to_hcl({"tier": self.tier, "backup_start_time": self.backup_start_time})
 
     @staticmethod
     def from_dict(dict_: Dict) -> CloudSqlDatabase:
-        """Constructs a CloudSqlDatabase instance from a dictionary.
+        """ Constructs a CloudSqlDatabase instance from a dictionary.
 
         :param dict_: the dictionary.
         :return: the CloudSqlDatabase instance.
@@ -428,20 +469,19 @@ class CloudSqlDatabase:
 
         tier = dict_.get("tier")
         backup_start_time = dict_.get("backup_start_time")
-        postgres_password = dict_.get("postgres_password")
-        return CloudSqlDatabase(tier, backup_start_time, postgres_password)
+        return CloudSqlDatabase(tier, backup_start_time)
 
 
 @dataclass
 class VirtualMachine:
-    """A Google Cloud virtual machine.
+    """ A Google Cloud virtual machine.
 
     Attributes:
         machine_type: the type of Google Cloud virtual machine.
         disk_size: the size of the disk in GB.
         disk_type: the disk type; pd-standard or pd-ssd.
         create: whether to create the VM or not.
-    """
+     """
 
     machine_type: str
     disk_size: int
@@ -464,7 +504,7 @@ class VirtualMachine:
 
     @staticmethod
     def from_dict(dict_: Dict) -> VirtualMachine:
-        """Constructs a VirtualMachine instance from a dictionary.
+        """ Constructs a VirtualMachine instance from a dictionary.
 
         :param dict_: the dictionary.
         :return: the VirtualMachine instance.
@@ -479,27 +519,22 @@ class VirtualMachine:
 
 @dataclass
 class ElasticSearch:
-    """The elasticsearch settings for the Observatory Platform API.
+    """ The elasticsearch settings for the Observatory Platform API.
 
     Attributes:
         host: the address of the elasticsearch host
         api_key: the api key to use the elasticsearch API.
-    """
+     """
 
     host: str
     api_key: str
 
     def to_hcl(self):
-        return to_hcl(
-            {
-                "host": self.host,
-                "api_key": self.api_key,
-            }
-        )
+        return to_hcl({"host": self.host, "api_key": self.api_key,})
 
     @staticmethod
     def from_dict(dict_: Dict) -> ElasticSearch:
-        """Constructs a CloudSqlDatabase instance from a dictionary.
+        """ Constructs a CloudSqlDatabase instance from a dictionary.
 
         :param dict_: the dictionary.
         :return: the CloudSqlDatabase instance.
@@ -512,13 +547,13 @@ class ElasticSearch:
 
 @dataclass
 class Api:
-    """The API domain name for the Observatory Platform API.
+    """ The API domain name for the Observatory Platform API.
 
     Attributes:
         domain_name: the custom domain name of the API
         subdomain: the subdomain of the API, can be either based on the google project id or the environment. When
         based on the environment, there is no subdomain for the production environment.
-    """
+     """
 
     domain_name: str
     subdomain: str
@@ -528,7 +563,7 @@ class Api:
 
     @staticmethod
     def from_dict(dict_: Dict) -> Api:
-        """Constructs a CloudSqlDatabase instance from a dictionary.
+        """ Constructs a CloudSqlDatabase instance from a dictionary.
 
         :param dict_: the dictionary.
         :return: the CloudSqlDatabase instance.
@@ -540,7 +575,7 @@ class Api:
 
 
 def customise_pointer(field, value, error):
-    """Throw an error when a field contains the value ' <--' which means that the user should customise the
+    """ Throw an error when a field contains the value ' <--' which means that the user should customise the
     value in the config file.
 
     :param field: the field.
@@ -557,7 +592,7 @@ class ObservatoryConfigValidator(Validator):
     """ Custom config Validator"""
 
     def _validate_google_application_credentials(self, google_application_credentials, field, value):
-        """Validate that the Google Application Credentials file exists.
+        """ Validate that the Google Application Credentials file exists.
         The rule's arguments are validated against this schema: {'type': 'boolean'}
         """
         if (
@@ -576,12 +611,12 @@ class ObservatoryConfigValidator(Validator):
 
 @dataclass
 class ValidationError:
-    """A validation error found when parsing a config file.
+    """ A validation error found when parsing a config file.
 
     Attributes:
         key: the key in the config file.
         value: the error.
-    """
+     """
 
     key: str
     value: Any
@@ -591,7 +626,7 @@ class ObservatoryConfig:
     def __init__(
         self,
         backend: Backend = None,
-        airflow: Airflow = None,
+        observatory: Observatory = None,
         google_cloud: GoogleCloud = None,
         terraform: Terraform = None,
         airflow_variables: List[AirflowVariable] = None,
@@ -599,10 +634,10 @@ class ObservatoryConfig:
         dags_projects: List[DagsProject] = None,
         validator: ObservatoryConfigValidator = None,
     ):
-        """Create an ObservatoryConfig instance.
+        """ Create an ObservatoryConfig instance.
 
         :param backend: the backend config.
-        :param airflow: the Airflow config.
+        :param observatory: the Observatory config.
         :param google_cloud: the Google Cloud config.
         :param terraform: the Terraform config.
         :param airflow_variables: a list of Airflow variables.
@@ -612,7 +647,7 @@ class ObservatoryConfig:
         """
 
         self.backend = backend
-        self.airflow = airflow
+        self.observatory = observatory
         self.google_cloud = google_cloud
         self.terraform = terraform
 
@@ -632,7 +667,7 @@ class ObservatoryConfig:
 
     @property
     def is_valid(self) -> bool:
-        """Checks whether the config is valid or not.
+        """ Checks whether the config is valid or not.
 
         :return: whether the config is valid or not.
         """
@@ -641,7 +676,7 @@ class ObservatoryConfig:
 
     @property
     def errors(self) -> List[ValidationError]:
-        """Returns a list of ValidationError instances that were created when parsing the config file.
+        """ Returns a list of ValidationError instances that were created when parsing the config file.
 
         :return: the list of ValidationError instances.
         """
@@ -658,7 +693,7 @@ class ObservatoryConfig:
         return errors
 
     def make_airflow_variables(self) -> List[AirflowVariable]:
-        """Make all airflow variables for the observatory platform.
+        """ Make all airflow variables for the observatory platform.
 
         :return: a list of AirflowVariable objects.
         """
@@ -688,21 +723,21 @@ class ObservatoryConfig:
     def _parse_fields(
         dict_: Dict,
     ) -> Tuple[
-        Backend, Airflow, GoogleCloud, Terraform, List[AirflowVariable], List[AirflowConnection], List[DagsProject]
+        Backend, Observatory, GoogleCloud, Terraform, List[AirflowVariable], List[AirflowConnection], List[DagsProject]
     ]:
         backend = Backend.from_dict(dict_.get("backend", dict()))
-        airflow = Airflow.from_dict(dict_.get("airflow", dict()))
+        observatory = Observatory.from_dict(dict_.get("observatory", dict()))
         google_cloud = GoogleCloud.from_dict(dict_.get("google_cloud", dict()))
         terraform = Terraform.from_dict(dict_.get("terraform", dict()))
         airflow_variables = AirflowVariable.parse_airflow_variables(dict_.get("airflow_variables", dict()))
         airflow_connections = AirflowConnection.parse_airflow_connections(dict_.get("airflow_connections", dict()))
         dags_projects = DagsProject.parse_dags_projects(dict_.get("dags_projects", list()))
 
-        return backend, airflow, google_cloud, terraform, airflow_variables, airflow_connections, dags_projects
+        return backend, observatory, google_cloud, terraform, airflow_variables, airflow_connections, dags_projects
 
     @staticmethod
     def save_default(config_path: str):
-        """Save a default config file.
+        """ Save a default config file.
 
         :param config_path: the path where the config file should be saved.
         :return: None.
@@ -712,7 +747,7 @@ class ObservatoryConfig:
 
     @staticmethod
     def _save_default(config_path: str, template_file_name: str):
-        """Save a default config file.
+        """ Save a default config file.
 
         :param config_path: the path where the config file should be saved.
         :param template_file_name: the name of the template file name.
@@ -739,7 +774,7 @@ class ObservatoryConfig:
 
     @classmethod
     def from_dict(cls, dict_: Dict) -> ObservatoryConfig:
-        """Constructs an ObservatoryConfig instance from a dictionary.
+        """ Constructs an ObservatoryConfig instance from a dictionary.
 
         If the dictionary is invalid, then an ObservatoryConfig instance will be returned with no properties set,
         except for the validator, which contains validation errors.
@@ -755,7 +790,7 @@ class ObservatoryConfig:
         if is_valid:
             (
                 backend,
-                airflow,
+                observatory,
                 google_cloud,
                 terraform,
                 airflow_variables,
@@ -765,7 +800,7 @@ class ObservatoryConfig:
 
             return ObservatoryConfig(
                 backend,
-                airflow,
+                observatory,
                 google_cloud=google_cloud,
                 terraform=terraform,
                 airflow_variables=airflow_variables,
@@ -778,7 +813,7 @@ class ObservatoryConfig:
 
     @classmethod
     def load(cls, path: str):
-        """Load a configuration file.
+        """ Load a configuration file.
 
         :return: the ObservatoryConfig instance (or a subclass of ObservatoryConfig)
         """
@@ -804,7 +839,7 @@ class TerraformConfig(ObservatoryConfig):
     def __init__(
         self,
         backend: Backend = None,
-        airflow: Airflow = None,
+        observatory: Observatory = None,
         google_cloud: GoogleCloud = None,
         terraform: Terraform = None,
         airflow_variables: List[AirflowVariable] = None,
@@ -817,10 +852,10 @@ class TerraformConfig(ObservatoryConfig):
         api: Api = None,
         validator: ObservatoryConfigValidator = None,
     ):
-        """Create a TerraformConfig instance.
+        """ Create a TerraformConfig instance.
 
         :param backend: the backend config.
-        :param airflow: the Airflow config.
+        :param observatory: the Observatory config.
         :param google_cloud: the Google Cloud config.
         :param terraform: the Terraform config.
         :param airflow_variables: a list of Airflow variables.
@@ -834,7 +869,7 @@ class TerraformConfig(ObservatoryConfig):
 
         super().__init__(
             backend=backend,
-            airflow=airflow,
+            observatory=observatory,
             google_cloud=google_cloud,
             terraform=terraform,
             airflow_variables=airflow_variables,
@@ -850,7 +885,7 @@ class TerraformConfig(ObservatoryConfig):
 
     @property
     def terraform_workspace_id(self):
-        """The Terraform workspace id.
+        """ The Terraform workspace id.
 
         :return: the terraform workspace id.
         """
@@ -858,7 +893,7 @@ class TerraformConfig(ObservatoryConfig):
         return TerraformConfig.WORKSPACE_PREFIX + self.backend.environment.value
 
     def make_airflow_variables(self) -> List[AirflowVariable]:
-        """Make all airflow variables for the Observatory Platform.
+        """ Make all airflow variables for the Observatory Platform.
 
         :return: a list of AirflowVariable objects.
         """
@@ -887,7 +922,7 @@ class TerraformConfig(ObservatoryConfig):
         return variables
 
     def terraform_variables(self) -> List[TerraformVariable]:
-        """Create a list of TerraformVariable instances from the Terraform Config.
+        """ Create a list of TerraformVariable instances from the Terraform Config.
 
         :return: a list of TerraformVariable instances.
         """
@@ -895,9 +930,9 @@ class TerraformConfig(ObservatoryConfig):
         sensitive = True
         return [
             TerraformVariable("environment", self.backend.environment.value),
-            TerraformVariable("airflow", self.airflow.to_hcl(), sensitive=sensitive, hcl=True),
+            TerraformVariable("observatory", self.observatory.to_hcl(), sensitive=sensitive, hcl=True),
             TerraformVariable("google_cloud", self.google_cloud.to_hcl(), sensitive=sensitive, hcl=True),
-            TerraformVariable("cloud_sql_database", self.cloud_sql_database.to_hcl(), sensitive=sensitive, hcl=True),
+            TerraformVariable("cloud_sql_database", self.cloud_sql_database.to_hcl(), hcl=True),
             TerraformVariable("airflow_main_vm", self.airflow_main_vm.to_hcl(), hcl=True),
             TerraformVariable("airflow_worker_vm", self.airflow_worker_vm.to_hcl(), hcl=True),
             TerraformVariable(
@@ -912,7 +947,7 @@ class TerraformConfig(ObservatoryConfig):
 
     @classmethod
     def from_dict(cls, dict_: Dict) -> TerraformConfig:
-        """Make an TerraformConfig instance from a dictionary.
+        """ Make an TerraformConfig instance from a dictionary.
 
         If the dictionary is invalid, then an ObservatoryConfig instance will be returned with no properties set,
         except for the validator, which contains validation errors.
@@ -928,7 +963,7 @@ class TerraformConfig(ObservatoryConfig):
         if is_valid:
             (
                 backend,
-                airflow,
+                observatory,
                 google_cloud,
                 terraform,
                 airflow_variables,
@@ -944,7 +979,7 @@ class TerraformConfig(ObservatoryConfig):
 
             return TerraformConfig(
                 backend,
-                airflow,
+                observatory,
                 google_cloud=google_cloud,
                 terraform=terraform,
                 airflow_variables=airflow_variables,
@@ -962,7 +997,7 @@ class TerraformConfig(ObservatoryConfig):
 
     @staticmethod
     def save_default(config_path: str):
-        """Save a default TerraformConfig file.
+        """ Save a default TerraformConfig file.
 
         :param config_path: the path where the config file should be saved.
         :return: None.
@@ -972,7 +1007,7 @@ class TerraformConfig(ObservatoryConfig):
 
 
 def make_schema(backend_type: BackendType) -> Dict:
-    """Make a schema for an Observatory or Terraform config file.
+    """ Make a schema for an Observatory or Terraform config file.
 
     :param backend_type: the type of backend, local or terraform.
     :return: a dictionary containing the schema.
@@ -1034,15 +1069,24 @@ def make_schema(backend_type: BackendType) -> Dict:
             "valuesrules": {"type": "string"},
         }
 
-    # Airflow settings
-    schema["airflow"] = {
+    # Observatory settings
+    schema["observatory"] = {
         "required": True,
         "type": "dict",
         "schema": {
-            "fernet_key": {"required": True, "type": "string"},
-            "secret_key": {"required": True, "type": "string"},
-            "ui_user_password": {"required": is_backend_terraform, "type": "string"},
-            "ui_user_email": {"required": is_backend_terraform, "type": "string"},
+            "airflow_fernet_key": {"required": True, "type": "string"},
+            "airflow_secret_key": {"required": True, "type": "string"},
+            "airflow_ui_user_password": {"required": is_backend_terraform, "type": "string"},
+            "airflow_ui_user_email": {"required": is_backend_terraform, "type": "string"},
+            "observatory_home": {"required": False, "type": "string"},
+            "postgres_password": {"required": is_backend_terraform, "type": "string"},
+            "redis_port": {"required": False, "type": "integer"},
+            "flower_ui_port": {"required": False, "type": "integer"},
+            "airflow_ui_port": {"required": False, "type": "integer"},
+            "elastic_port": {"required": False, "type": "integer"},
+            "kibana_port": {"required": False, "type": "integer"},
+            "docker_network_name": {"required": False, "type": "string"},
+            "docker_compose_project_name": {"required": False, "type": "string"},
         },
     }
 
@@ -1054,7 +1098,6 @@ def make_schema(backend_type: BackendType) -> Dict:
             "schema": {
                 "tier": {"required": True, "type": "string"},
                 "backup_start_time": {"required": True, "type": "string", "regex": r"^\d{2}:\d{2}$"},
-                "postgres_password": {"required": True, "type": "string"},
             },
         }
 
@@ -1063,10 +1106,7 @@ def make_schema(backend_type: BackendType) -> Dict:
         "required": True,
         "type": "dict",
         "schema": {
-            "machine_type": {
-                "required": True,
-                "type": "string",
-            },
+            "machine_type": {"required": True, "type": "string",},
             "disk_size": {"required": True, "type": "integer", "min": 1},
             "disk_type": {"required": True, "type": "string", "allowed": ["pd-standard", "pd-ssd"]},
             "create": {"required": True, "type": "boolean"},
@@ -1104,18 +1144,9 @@ def make_schema(backend_type: BackendType) -> Dict:
         "schema": {
             "type": "dict",
             "schema": {
-                "package_name": {
-                    "required": True,
-                    "type": "string",
-                },
-                "path": {
-                    "required": True,
-                    "type": "string",
-                },
-                "dags_module": {
-                    "required": True,
-                    "type": "string",
-                },
+                "package_name": {"required": True, "type": "string",},
+                "path": {"required": True, "type": "string",},
+                "dags_module": {"required": True, "type": "string",},
             },
         },
     }
@@ -1124,13 +1155,7 @@ def make_schema(backend_type: BackendType) -> Dict:
         schema["elasticsearch"] = {
             "required": True,
             "type": "dict",
-            "schema": {
-                "host": {"required": True, "type": "string"},
-                "api_key": {
-                    "required": True,
-                    "type": "string",
-                },
-            },
+            "schema": {"host": {"required": True, "type": "string"}, "api_key": {"required": True, "type": "string",}},
         }
 
         schema["api"] = {

--- a/observatory-platform/observatory/platform/platform_builder.py
+++ b/observatory-platform/observatory/platform/platform_builder.py
@@ -38,6 +38,7 @@ class PlatformBuilder(ComposeRunner):
         config_path: str,
         host_uid: int = HOST_UID,
         host_gid: int = HOST_GID,
+        docker_build_path: str = None,
         debug: bool = DEBUG,
         backend_type: BackendType = BackendType.local,
     ):
@@ -46,6 +47,7 @@ class PlatformBuilder(ComposeRunner):
         :param config_path: The path to the config.yaml configuration file.
         :param host_uid: The user id of the host system. Used to set the user id in the Docker containers.
         :param host_gid: The group id of the host system. Used to set the group id in the Docker containers.
+        :param docker_build_path: the Docker build path.
         :param debug: Print debugging information.
         :param backend_type: whether we are running the local or terraform environment.
         """
@@ -70,7 +72,9 @@ class PlatformBuilder(ComposeRunner):
         if self.config_exists:
             self.config: Union[ObservatoryConfig, TerraformConfig] = self.config_class.load(config_path)
             self.config_is_valid = self.config.is_valid
-        docker_build_path = os.path.join(self.config.observatory.observatory_home, "build", "docker")
+
+        if docker_build_path is None:
+            docker_build_path = os.path.join(self.config.observatory.observatory_home, "build", "docker")
 
         super().__init__(
             compose_template_path=os.path.join(self.docker_module_path, "docker-compose.observatory.yml.jinja2"),

--- a/observatory-platform/observatory/platform/platform_builder.py
+++ b/observatory-platform/observatory/platform/platform_builder.py
@@ -24,94 +24,44 @@ import requests
 
 from observatory.platform.docker.compose import ComposeRunner
 from observatory.platform.observatory_config import ObservatoryConfig, BackendType, TerraformConfig, DagsProject
-from observatory.platform.utils.config_utils import observatory_home, module_file_path
+from observatory.platform.utils.config_utils import module_file_path
 
-DAGS_MODULE = module_file_path("observatory.platform.dags")
-DATA_PATH = observatory_home("data")
-LOGS_PATH = observatory_home("logs")
-POSTGRES_PATH = observatory_home("postgres")
-BUILD_PATH = observatory_home("build", "local")
 HOST_UID = os.getuid()
 HOST_GID = os.getgid()
-REDIS_PORT = 6379
-FLOWER_UI_PORT = 5555
-AIRFLOW_UI_PORT = 8080
-ELASTIC_PORT = 9200
-KIBANA_PORT = 5601
-DOCKER_NETWORK_NAME = None
-DOCKER_COMPOSE_PROJECT_NAME = "observatory"
 DEBUG = False
 
 
 class PlatformBuilder(ComposeRunner):
     def __init__(
         self,
+        *,
         config_path: str,
-        build_path: str = BUILD_PATH,
-        dags_path: str = DAGS_MODULE,
-        data_path: str = DATA_PATH,
-        logs_path: str = LOGS_PATH,
-        postgres_path: str = POSTGRES_PATH,
         host_uid: int = HOST_UID,
         host_gid: int = HOST_GID,
-        redis_port: int = REDIS_PORT,
-        flower_ui_port: int = FLOWER_UI_PORT,
-        airflow_ui_port: int = AIRFLOW_UI_PORT,
-        elastic_port: int = ELASTIC_PORT,
-        kibana_port: int = KIBANA_PORT,
-        docker_network_name: Union[None, int] = DOCKER_NETWORK_NAME,
-        docker_compose_project_name: str = DOCKER_COMPOSE_PROJECT_NAME,
         debug: bool = DEBUG,
         backend_type: BackendType = BackendType.local,
     ):
         """Create a PlatformBuilder instance, which is used to build, start and stop an Observatory Platform instance.
 
         :param config_path: The path to the config.yaml configuration file.
-        :param dags_path: The path on the host machine to mount as the Apache Airflow DAGs folder.
-        :param data_path: The path on the host machine to mount as the data folder.
-        :param logs_path: The path on the host machine to mount as the logs folder.
-        :param postgres_path: The path on the host machine to mount as the PostgreSQL data folder.
         :param host_uid: The user id of the host system. Used to set the user id in the Docker containers.
         :param host_gid: The group id of the host system. Used to set the group id in the Docker containers.
-        :param redis_port: The host Redis port number.
-        :param flower_ui_port: The host's Flower UI port number.
-        :param airflow_ui_port: The host's Apache Airflow UI port number.
-        :param elastic_port: The host's Elasticsearch port number.
-        :param kibana_port: The host's Kibana port number.
-        :param docker_network_name: The Docker Network name, used to specify a custom Docker Network.
-        :param docker_compose_project_name: The namespace for the Docker Compose containers: https://docs.docker.com/compose/reference/envvars/#compose_project_name.
         :param debug: Print debugging information.
         :param backend_type: whether we are running the local or terraform environment.
         """
 
         self.config_path = config_path
-        self.dags_path = dags_path
-        self.data_path = data_path
-        self.logs_path = logs_path
-        self.postgres_path = postgres_path
         self.host_uid = host_uid
         self.host_gid = host_gid
+        self.dags_path = module_file_path("observatory.platform.dags")
         self.platform_package_path = module_file_path("observatory.platform", nav_back_steps=-3)
         self.api_package_path = module_file_path("observatory.api", nav_back_steps=-3)
-        self.docker_build_path = os.path.join(build_path, "docker")
-        self.redis_port = redis_port
-        self.flower_ui_port = flower_ui_port
-        self.airflow_ui_port = airflow_ui_port
-        self.elastic_port = elastic_port
-        self.kibana_port = kibana_port
-        self.docker_compose_project_name = docker_compose_project_name
         self.backend_type = backend_type
 
         # Set config class based on type of backend
         self.config_class = ObservatoryConfig
         if backend_type == BackendType.terraform:
             self.config_class = TerraformConfig
-
-        # Set Docker Network name
-        self.docker_network_name = "observatory-network"
-        self.docker_network_is_external = docker_network_name is not None
-        if self.docker_network_is_external:
-            self.docker_network_name = docker_network_name
 
         # Load config
         self.config_exists = os.path.exists(config_path)
@@ -120,25 +70,33 @@ class PlatformBuilder(ComposeRunner):
         if self.config_exists:
             self.config: Union[ObservatoryConfig, TerraformConfig] = self.config_class.load(config_path)
             self.config_is_valid = self.config.is_valid
+        docker_build_path = os.path.join(self.config.observatory.observatory_home, "build", "docker")
 
-        path = self.docker_module_path
         super().__init__(
-            compose_template_path=os.path.join(path, "docker-compose.observatory.yml.jinja2"),
-            build_path=self.docker_build_path,
+            compose_template_path=os.path.join(self.docker_module_path, "docker-compose.observatory.yml.jinja2"),
+            build_path=docker_build_path,
             compose_template_kwargs={
                 "config": self.config,
-                "docker_network_is_external": self.docker_network_is_external,
-                "docker_network_name": self.docker_network_name,
+                "docker_network_is_external": self.config.observatory.docker_network_is_external,
+                "docker_network_name": self.config.observatory.docker_network_name,
                 "dags_projects_to_str": DagsProject.dags_projects_to_str,
             },
             debug=debug,
         )
 
         # Add files
-        self.add_template(path=os.path.join(path, "Dockerfile.observatory.jinja2"), config=self.config)
-        self.add_template(path=os.path.join(path, "entrypoint-airflow.sh.jinja2"), config=self.config)
-        self.add_file(path=os.path.join(path, "entrypoint-root.sh"), output_file_name="entrypoint-root.sh")
-        self.add_file(path=os.path.join(path, "elasticsearch.yml"), output_file_name="elasticsearch.yml")
+        self.add_template(
+            path=os.path.join(self.docker_module_path, "Dockerfile.observatory.jinja2"), config=self.config
+        )
+        self.add_template(
+            path=os.path.join(self.docker_module_path, "entrypoint-airflow.sh.jinja2"), config=self.config
+        )
+        self.add_file(
+            path=os.path.join(self.docker_module_path, "entrypoint-root.sh"), output_file_name="entrypoint-root.sh"
+        )
+        self.add_file(
+            path=os.path.join(self.docker_module_path, "elasticsearch.yml"), output_file_name="elasticsearch.yml"
+        )
         self.add_file(
             path=os.path.join(self.platform_package_path, "requirements.txt"),
             output_file_name="requirements.observatory-platform.txt",
@@ -226,28 +184,30 @@ class PlatformBuilder(ComposeRunner):
         env = os.environ.copy()
 
         # Sets the name
-        env["COMPOSE_PROJECT_NAME"] = self.docker_compose_project_name
+        env["COMPOSE_PROJECT_NAME"] = self.config.observatory.docker_compose_project_name
 
         # Host settings
         env["HOST_USER_ID"] = str(self.host_uid)
         env["HOST_GROUP_ID"] = str(self.host_gid)
-        env["HOST_LOGS_PATH"] = self.logs_path
-        env["HOST_DAGS_PATH"] = self.dags_path
-        env["HOST_DATA_PATH"] = self.data_path
-        env["HOST_POSTGRES_PATH"] = self.postgres_path
-        env["HOST_PLATFORM_PACKAGE_PATH"] = self.platform_package_path
-        env["HOST_API_PACKAGE_PATH"] = self.api_package_path
-        env["HOST_REDIS_PORT"] = str(self.redis_port)
-        env["HOST_FLOWER_UI_PORT"] = str(self.flower_ui_port)
-        env["HOST_AIRFLOW_UI_PORT"] = str(self.airflow_ui_port)
-        env["HOST_ELASTIC_PORT"] = str(self.elastic_port)
-        env["HOST_KIBANA_PORT"] = str(self.kibana_port)
+        env["HOST_OBSERVATORY_HOME"] = os.path.normpath(self.config.observatory.observatory_home)
+        env["HOST_DAGS_PATH"] = os.path.normpath(self.dags_path)
+        env["HOST_PLATFORM_PACKAGE_PATH"] = os.path.normpath(self.platform_package_path)
+        env["HOST_API_PACKAGE_PATH"] = os.path.normpath(self.api_package_path)
+
+        env["HOST_REDIS_PORT"] = str(self.config.observatory.redis_port)
+        env["HOST_FLOWER_UI_PORT"] = str(self.config.observatory.flower_ui_port)
+        env["HOST_AIRFLOW_UI_PORT"] = str(self.config.observatory.airflow_ui_port)
+        env["HOST_ELASTIC_PORT"] = str(self.config.observatory.elastic_port)
+        env["HOST_KIBANA_PORT"] = str(self.config.observatory.kibana_port)
 
         # Secrets
         if self.config.google_cloud.credentials is not None:
             env["HOST_GOOGLE_APPLICATION_CREDENTIALS"] = self.config.google_cloud.credentials
-        env["FERNET_KEY"] = self.config.airflow.fernet_key
-        env["SECRET_KEY"] = self.config.airflow.secret_key
+        env["AIRFLOW_FERNET_KEY"] = self.config.observatory.airflow_fernet_key
+        env["AIRFLOW_SECRET_KEY"] = self.config.observatory.airflow_secret_key
+        env["AIRFLOW_UI_USER_EMAIL"] = self.config.observatory.airflow_ui_user_email
+        env["AIRFLOW_UI_USER_PASSWORD"] = self.config.observatory.airflow_ui_user_password
+        env["POSTGRES_PASSWORD"] = self.config.observatory.postgres_password
 
         # Create Airflow variables
         airflow_variables = self.config.make_airflow_variables()

--- a/observatory-platform/observatory/platform/terraform/build.sh
+++ b/observatory-platform/observatory/platform/terraform/build.sh
@@ -18,7 +18,7 @@ sudo usermod -aG docker airflow
 sudo newgrp docker
 
 # Install Docker Compose
-sudo curl -L "https://github.com/docker/compose/releases/download/1.26.0/docker-compose-Linux-x86_64" -o /usr/local/bin/docker-compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
 # Install berglas v0.5.3

--- a/observatory-platform/observatory/platform/terraform/main.tf
+++ b/observatory-platform/observatory/platform/terraform/main.tf
@@ -431,14 +431,14 @@ resource "google_sql_database" "airflow_db" {
 resource "google_sql_user" "users" {
   name = "airflow"
   instance = google_sql_database_instance.observatory_db_instance.name
-  password = var.cloud_sql_database.postgres_password
+  password = var.observatory.postgres_password
 }
 
 // New database user
 resource "google_sql_user" "observatory_user" {
   name = "observatory"
   instance = google_sql_database_instance.observatory_db_instance.name
-  password = var.cloud_sql_database.postgres_password
+  password = var.observatory.postgres_password
 }
 
 // Observatory Platform Database
@@ -493,11 +493,11 @@ module "google_cloud_observatory_connection" {
 
 locals {
   google_cloud_secrets = {
-    airflow_ui_user_email=var.airflow.ui_user_email,
-    airflow_ui_user_password=var.airflow.ui_user_password,
-    fernet_key=var.airflow.fernet_key,
-    secret_key=var.airflow.secret_key,
-    postgres_password=var.cloud_sql_database.postgres_password,
+    airflow_ui_user_email=var.observatory.airflow_ui_user_email,
+    airflow_ui_user_password=var.observatory.airflow_ui_user_password,
+    fernet_key=var.observatory.airflow_fernet_key,
+    secret_key=var.observatory.airflow_secret_key,
+    postgres_password=var.observatory.postgres_password,
 
     # Important: this must be the generated service account, not the developer's service account used to deploy the system
     google_application_credentials=base64decode(google_service_account_key.observatory_service_account_key.private_key)
@@ -634,7 +634,7 @@ module "observatory_api" {
   google_cloud = var.google_cloud
   elasticsearch = var.elasticsearch
   vpc_connector_name = local.vpc_connector_name
-  observatory_db_uri = "postgres://observatory:${urlencode(var.cloud_sql_database.postgres_password)}@${google_sql_database_instance.observatory_db_instance.private_ip_address}:5432/observatory"
+  observatory_db_uri = "postgres://observatory:${urlencode(var.observatory.postgres_password)}@${google_sql_database_instance.observatory_db_instance.private_ip_address}:5432/observatory"
   api = var.api
   # necessary for api-endpoint_service_account, api-backend_service_account and elasticsearch-logins
   depends_on = [google_project_service.services, google_sql_database.observatory_db, google_vpc_access_connector.observatory_vpc_connector]

--- a/observatory-platform/observatory/platform/terraform/main.tf
+++ b/observatory-platform/observatory/platform/terraform/main.tf
@@ -495,8 +495,8 @@ locals {
   google_cloud_secrets = {
     airflow_ui_user_email=var.observatory.airflow_ui_user_email,
     airflow_ui_user_password=var.observatory.airflow_ui_user_password,
-    fernet_key=var.observatory.airflow_fernet_key,
-    secret_key=var.observatory.airflow_secret_key,
+    airflow_fernet_key=var.observatory.airflow_fernet_key,
+    airflow_secret_key=var.observatory.airflow_secret_key,
     postgres_password=var.observatory.postgres_password,
 
     # Important: this must be the generated service account, not the developer's service account used to deploy the system

--- a/observatory-platform/observatory/platform/terraform/startup.tpl.jinja2
+++ b/observatory-platform/observatory/platform/terraform/startup.tpl.jinja2
@@ -20,8 +20,8 @@ export HOST_USER_ID=$(id -u airflow)
 export HOST_GROUP_ID=$(id -g airflow)
 export POSTGRES_HOSTNAME="${postgres_hostname}"
 export POSTGRES_PASSWORD="sm://${project_id}/postgres_password"
-export FERNET_KEY="sm://${project_id}/fernet_key"
-export SECRET_KEY="sm://${project_id}/secret_key"
+export AIRFLOW_FERNET_KEY="sm://${project_id}/airflow_fernet_key"
+export AIRFLOW_SECRET_KEY="sm://${project_id}/airflow_secret_key"
 export REDIS_HOSTNAME="${redis_hostname}"
 export HOST_FLOWER_UI_PORT=5555
 export HOST_REDIS_PORT=6379
@@ -44,8 +44,8 @@ do export AIRFLOW_VAR_$${names[$index]^^}="$${values[$index]}";
 done
 
 # Hardcoded list of environment variables that need to be preserved
-PRESERVE_ENV="HOST_USER_ID,HOST_GROUP_ID,POSTGRES_HOSTNAME,POSTGRES_PASSWORD,FERNET_KEY,SECRET_KEY,REDIS_HOSTNAME,\
-AIRFLOW_UI_USER_PASSWORD,AIRFLOW_UI_USER_EMAIL,HOST_FLOWER_UI_PORT,HOST_REDIS_PORT,HOST_AIRFLOW_UI_PORT"
+PRESERVE_ENV="HOST_USER_ID,HOST_GROUP_ID,POSTGRES_HOSTNAME,POSTGRES_PASSWORD,AIRFLOW_FERNET_KEY,AIRFLOW_SECRET_KEY,\
+REDIS_HOSTNAME,AIRFLOW_UI_USER_PASSWORD,AIRFLOW_UI_USER_EMAIL,HOST_FLOWER_UI_PORT,HOST_REDIS_PORT,HOST_AIRFLOW_UI_PORT"
 
 # Preserve all environment variables that begin with AIRFLOW_VAR or AIRFLOW_CONN
 PRESERVE_ENV=$(printenv | awk -v tmp="$PRESERVE_ENV" -F'=' '$0 ~ /AIRFLOW_VAR|AIRFLOW_CONN/ {printf "%s,", $1} END {print tmp}')

--- a/observatory-platform/observatory/platform/terraform/variables.tf
+++ b/observatory-platform/observatory/platform/terraform/variables.tf
@@ -3,20 +3,22 @@ variable "environment" {
   type = string
 }
 
-variable "airflow" {
+variable "observatory" {
   description = <<EOF
-The Apache Airflow settings for the Observatory Platform.
+The Observatory settings.
 
-fernet_key: the Fernet key.
-secret_key: the secret key used for the Flask Airflow Webserver.
-ui_user_password: the password for the Apache Airflow UI admin user.
-ui_user_email: the email address for the Apache Airflow UI admin user.
+airflow_fernet_key: the Fernet key.
+airflow_secret_key: the secret key used for the Flask Airflow Webserver.
+airflow_ui_user_password: the password for the Apache Airflow UI admin user.
+airflow_ui_user_email: the email address for the Apache Airflow UI admin user.
+postgres_password: the Postgres SQL password.
 EOF
   type = object({
-    fernet_key = string
-    secret_key = string
-    ui_user_email = string
-    ui_user_password = string
+    airflow_fernet_key = string
+    airflow_secret_key = string
+    airflow_ui_user_email = string
+    airflow_ui_user_password = string
+    postgres_password = string
   })
 }
 
@@ -45,12 +47,10 @@ The Google Cloud SQL database settings for the Observatory Platform.
 
 tier: the database machine tier.
 backup_start_time: the start time for backups in HH:MM format.
-postgres_password: the Postgres SQL password.
 EOF
   type = object({
     tier = string
     backup_start_time = string
-    postgres_password = string
   })
 }
 

--- a/observatory-platform/observatory/platform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform_builder.py
@@ -57,18 +57,17 @@ class TerraformBuilder:
         else:
             self.config: TerraformConfig = TerraformConfig.load(config_path)
             self.config_is_valid = self.config.is_valid
-
-            # Set paths
-            self.build_path = os.path.join(self.config.observatory.observatory_home, "build", "terraform")
-            self.platform_builder = PlatformBuilder(
-                config_path=config_path,
-                docker_build_path=os.path.join(self.build_path, "docker"),
-                backend_type=BackendType.terraform,
-            )
-            self.packages_build_path = os.path.join(self.build_path, "packages")
-            self.terraform_build_path = os.path.join(self.build_path, "terraform")
-            os.makedirs(self.packages_build_path, exist_ok=True)
-            os.makedirs(self.terraform_build_path, exist_ok=True)
+            if self.config_is_valid:
+                self.build_path = os.path.join(self.config.observatory.observatory_home, "build", "terraform")
+                self.platform_builder = PlatformBuilder(
+                    config_path=config_path,
+                    docker_build_path=os.path.join(self.build_path, "docker"),
+                    backend_type=BackendType.terraform,
+                )
+                self.packages_build_path = os.path.join(self.build_path, "packages")
+                self.terraform_build_path = os.path.join(self.build_path, "terraform")
+                os.makedirs(self.packages_build_path, exist_ok=True)
+                os.makedirs(self.terraform_build_path, exist_ok=True)
 
     @property
     def is_environment_valid(self) -> bool:

--- a/observatory-platform/observatory/platform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform_builder.py
@@ -51,22 +51,24 @@ class TerraformBuilder:
         self.debug = debug
 
         # Load config
-        self.config_exists = os.path.exists(config_path)
-        self.config_is_valid = False
-        self.config = None
-        if self.config_exists:
+        config_exists = os.path.exists(config_path)
+        if not config_exists:
+            raise FileExistsError(f"Terraform config file does not exist: {config_path}")
+        else:
             self.config: TerraformConfig = TerraformConfig.load(config_path)
             self.config_is_valid = self.config.is_valid
 
-        # Set paths
-        build_path = os.path.join(self.config.observatory.observatory_home, "build", "terraform")
-        self.platform_builder = PlatformBuilder(
-            config_path=config_path,
-            docker_build_path=os.path.join(build_path, "docker"),
-            backend_type=BackendType.terraform,
-        )
-        self.packages_build_path = os.path.join(build_path, "packages")
-        self.terraform_build_path = os.path.join(build_path, "terraform")
+            # Set paths
+            self.build_path = os.path.join(self.config.observatory.observatory_home, "build", "terraform")
+            self.platform_builder = PlatformBuilder(
+                config_path=config_path,
+                docker_build_path=os.path.join(self.build_path, "docker"),
+                backend_type=BackendType.terraform,
+            )
+            self.packages_build_path = os.path.join(self.build_path, "packages")
+            self.terraform_build_path = os.path.join(self.build_path, "terraform")
+            os.makedirs(self.packages_build_path, exist_ok=True)
+            os.makedirs(self.terraform_build_path, exist_ok=True)
 
     @property
     def is_environment_valid(self) -> bool:
@@ -76,7 +78,7 @@ class TerraformBuilder:
         """
 
         return all(
-            [self.packer_exe_path is not None, self.config_exists, self.config_is_valid, self.config is not None]
+            [self.packer_exe_path is not None, self.config_is_valid, self.config is not None]
         )
 
     @property

--- a/observatory-platform/observatory/platform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform_builder.py
@@ -48,7 +48,6 @@ class TerraformBuilder:
         self.terraform_path = module_file_path("observatory.platform.terraform")
         self.api_package_path = module_file_path("observatory.api", nav_back_steps=-3)
         self.api_path = module_file_path("observatory.api.server")
-        self.platform_builder = PlatformBuilder(config_path=config_path, backend_type=BackendType.terraform)
         self.debug = debug
 
         # Load config
@@ -61,6 +60,11 @@ class TerraformBuilder:
 
         # Set paths
         build_path = os.path.join(self.config.observatory.observatory_home, "build", "terraform")
+        self.platform_builder = PlatformBuilder(
+            config_path=config_path,
+            docker_build_path=os.path.join(build_path, "docker"),
+            backend_type=BackendType.terraform,
+        )
         self.packages_build_path = os.path.join(build_path, "packages")
         self.terraform_build_path = os.path.join(build_path, "terraform")
 

--- a/observatory-platform/observatory/platform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform_builder.py
@@ -26,11 +26,9 @@ from observatory.api.server.openapi_renderer import OpenApiRenderer
 from observatory.platform.cli.click_utils import indent, INDENT1
 from observatory.platform.observatory_config import TerraformConfig, BackendType
 from observatory.platform.platform_builder import PlatformBuilder
-from observatory.platform.utils.config_utils import observatory_home, module_file_path
+from observatory.platform.utils.config_utils import module_file_path
 from observatory.platform.utils.jinja2_utils import render_template
 from observatory.platform.utils.proc_utils import stream_process
-
-BUILD_PATH = observatory_home("build", "terraform")
 
 
 def copy_dir(source_path: str, destination_path: str, ignore):
@@ -38,25 +36,19 @@ def copy_dir(source_path: str, destination_path: str, ignore):
 
 
 class TerraformBuilder:
-    def __init__(self, config_path: str, build_path: str = BUILD_PATH, debug: bool = False):
-        """Create a TerraformBuilder instance, which is used to build, start and stop an Observatory Platform instance.
+    def __init__(self, config_path: str, debug: bool = False):
+        """ Create a TerraformBuilder instance, which is used to build, start and stop an Observatory Platform instance.
 
         :param config_path: the path to the config.yaml configuration file.
-        :param build_path: the path to the build folder.
         :param debug: whether to print debug statements.
         """
 
-        self.backend_type = BackendType.terraform
-        self.config_path = config_path
-        self.build_path = build_path
         self.platform_package_path = module_file_path("observatory.platform", nav_back_steps=-3)
         self.api_package_path = module_file_path("observatory.api", nav_back_steps=-3)
         self.terraform_path = module_file_path("observatory.platform.terraform")
         self.api_package_path = module_file_path("observatory.api", nav_back_steps=-3)
         self.api_path = module_file_path("observatory.api.server")
-        self.packages_build_path = os.path.join(build_path, "packages")
-        self.terraform_build_path = os.path.join(build_path, "terraform")
-        self.platform_builder = PlatformBuilder(config_path, build_path=build_path, backend_type=self.backend_type)
+        self.platform_builder = PlatformBuilder(config_path=config_path, backend_type=BackendType.terraform)
         self.debug = debug
 
         # Load config
@@ -67,9 +59,14 @@ class TerraformBuilder:
             self.config: TerraformConfig = TerraformConfig.load(config_path)
             self.config_is_valid = self.config.is_valid
 
+        # Set paths
+        build_path = os.path.join(self.config.observatory.observatory_home, "build", "terraform")
+        self.packages_build_path = os.path.join(build_path, "packages")
+        self.terraform_build_path = os.path.join(build_path, "terraform")
+
     @property
     def is_environment_valid(self) -> bool:
-        """Return whether the environment for building the Packer image is valid.
+        """ Return whether the environment for building the Packer image is valid.
 
         :return: whether the environment for building the Packer image is valid.
         """
@@ -80,7 +77,7 @@ class TerraformBuilder:
 
     @property
     def packer_exe_path(self) -> str:
-        """The path to the Packer executable.
+        """ The path to the Packer executable.
 
         :return: the path or None.
         """
@@ -89,7 +86,7 @@ class TerraformBuilder:
 
     @property
     def gcloud_exe_path(self) -> str:
-        """The path to the Google Cloud SDK executable.
+        """ The path to the Google Cloud SDK executable.
 
         :return: the path or None.
         """
@@ -149,7 +146,7 @@ class TerraformBuilder:
             f.write(render)
 
     def build_terraform(self):
-        """Build the Observatory Platform Terraform files.
+        """ Build the Observatory Platform Terraform files.
 
         :return: None.
         """
@@ -158,7 +155,7 @@ class TerraformBuilder:
         self.platform_builder.make_files()
 
     def build_image(self) -> Tuple[str, str, int]:
-        """Build the Observatory Platform Google Compute image with Packer.
+        """ Build the Observatory Platform Google Compute image with Packer.
 
         :return: output and error stream results and proc return code.
         """

--- a/observatory-platform/observatory/platform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform_builder.py
@@ -76,9 +76,7 @@ class TerraformBuilder:
         :return: whether the environment for building the Packer image is valid.
         """
 
-        return all(
-            [self.packer_exe_path is not None, self.config_is_valid, self.config is not None]
-        )
+        return all([self.packer_exe_path is not None, self.config_is_valid, self.config is not None])
 
     @property
     def packer_exe_path(self) -> str:

--- a/observatory-platform/observatory/platform/utils/config_utils.py
+++ b/observatory-platform/observatory/platform/utils/config_utils.py
@@ -39,7 +39,7 @@ def module_file_path(module_path: str, nav_back_steps: int = -1) -> str:
 
     module = importlib.import_module(module_path)
     file_path = pathlib.Path(module.__file__).resolve()
-    return str(pathlib.Path(*file_path.parts[:nav_back_steps]).resolve())
+    return os.path.normpath(str(pathlib.Path(*file_path.parts[:nav_back_steps]).resolve()))
 
 
 def observatory_home(*subdirs) -> str:

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -478,7 +478,8 @@ class ObservatoryTestCase(unittest.TestCase):
 
         # Turn logging to warning because vcr prints too much at info level
         logging.basicConfig()
-        logging.getLogger().setLevel(logging.WARNING)
+        vcr_log = logging.getLogger("vcr")
+        vcr_log.setLevel(logging.WARNING)
 
     def assert_dag_structure(self, expected: Dict, dag: DAG):
         """Assert the DAG structure.

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -1,4 +1,5 @@
 apache-airflow==2.1.2
+apache-airflow-providers-google==5.0.0
 apache-airflow-providers-slack==4.0.0
 apache-airflow-providers-http==2.0.0
 cerberus==1.3.*
@@ -7,10 +8,6 @@ pyyaml==5.4.*
 natsort==7.1.*
 six==1.16.*
 Jinja2==2.11.*
-google-crc32c==1.1.*
-google-cloud-bigquery==2.1.*
-google-api-python-client==2.0.*
-google-cloud-storage==1.35.*
 beautifulsoup4==4.9.*
 lxml==4.6.*
 numpy==1.20.*
@@ -29,7 +26,6 @@ idna==2.10
 marshmallow==3.12.*
 freezegun==1.1.*
 pysftp==0.2.*
-google-auth-oauthlib==0.4.*
 paramiko==2.7.*
 sftpserver==0.3
 json_lines==0.5.*

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -1,5 +1,4 @@
 apache-airflow==2.1.2
-apache-airflow-providers-google==5.0.0
 apache-airflow-providers-slack==4.0.0
 apache-airflow-providers-http==2.0.0
 cerberus==1.3.*
@@ -32,3 +31,8 @@ json_lines==0.5.*
 elasticsearch==7.13.3
 markupsafe==1.1.*
 typing-extensions==3.7.4.*
+google-crc32c==1.1.*
+google-cloud-bigquery==2.1.*
+google-api-python-client==2.0.*
+google-cloud-storage==1.35.*
+google-auth-oauthlib==0.4.*

--- a/tests/observatory/platform/cli/test_cli.py
+++ b/tests/observatory/platform/cli/test_cli.py
@@ -165,7 +165,12 @@ class TestObservatoryPlatform(unittest.TestCase):
         """ Test that the start and stop command are successful """
 
         runner = CliRunner()
-        with runner.isolated_filesystem():
+        with runner.isolated_filesystem() as t:
+            # Make empty config
+            config_path = os.path.join(t, "config.yaml")
+            open(config_path, "a").close()
+
+            # Mock platform command
             is_environment_valid = True
             docker_exe_path = "/path/to/docker"
             is_docker_running = True
@@ -176,7 +181,6 @@ class TestObservatoryPlatform(unittest.TestCase):
             start_return_code = 0
             stop_return_code = 0
             wait_for_airflow_ui = True
-            config_path = os.path.abspath("config.yaml")
             dags_path = "/path/to/dags"
             mock_cmd.return_value = MockPlatformCommand(
                 is_environment_valid,
@@ -194,11 +198,11 @@ class TestObservatoryPlatform(unittest.TestCase):
             )
 
             # Test that start command works
-            result = runner.invoke(cli, ["platform", "start"])
+            result = runner.invoke(cli, ["platform", "start", "--config-path", config_path])
             self.assertEqual(result.exit_code, os.EX_OK)
 
             # Test that stop command works
-            result = runner.invoke(cli, ["platform", "stop"])
+            result = runner.invoke(cli, ["platform", "stop", "--config-path", config_path])
             self.assertEqual(result.exit_code, os.EX_OK)
 
     @patch("observatory.platform.cli.cli.PlatformCommand")

--- a/tests/observatory/platform/cli/test_cli.py
+++ b/tests/observatory/platform/cli/test_cli.py
@@ -16,7 +16,6 @@
 
 import json
 import os
-import pathlib
 import unittest
 from typing import Any
 from typing import List
@@ -94,7 +93,7 @@ class MockConfig(Mock):
     @property
     def observatory(self):
         mock = Mock()
-        mock.observatory_home = '/path/to/home'
+        mock.observatory_home = "/path/to/home"
         return mock
 
     @property
@@ -178,7 +177,7 @@ class TestObservatoryPlatform(unittest.TestCase):
             stop_return_code = 0
             wait_for_airflow_ui = True
             config_path = os.path.abspath("config.yaml")
-            dags_path = '/path/to/dags'
+            dags_path = "/path/to/dags"
             mock_cmd.return_value = MockPlatformCommand(
                 is_environment_valid,
                 docker_exe_path,
@@ -191,7 +190,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 stop_return_code,
                 wait_for_airflow_ui,
                 config_path,
-                dags_path
+                dags_path,
             )
 
             # Test that start command works
@@ -221,7 +220,7 @@ class TestObservatoryPlatform(unittest.TestCase):
             start_return_code = 0
             stop_return_code = 0
             wait_for_airflow_ui = True
-            dags_path = '/path/to/dags'
+            dags_path = "/path/to/dags"
             mock_cmd.return_value = MockPlatformCommand(
                 is_environment_valid,
                 docker_exe_path,
@@ -234,7 +233,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 stop_return_code,
                 wait_for_airflow_ui,
                 default_config_path,
-                dags_path
+                dags_path,
             )
 
             # Test that start command fails
@@ -264,7 +263,7 @@ class TestObservatoryPlatform(unittest.TestCase):
             start_return_code = 0
             stop_return_code = 0
             wait_for_airflow_ui = True
-            dags_path = '/path/to/dags'
+            dags_path = "/path/to/dags"
             mock_cmd.return_value = MockPlatformCommand(
                 is_environment_valid,
                 docker_exe_path,
@@ -277,7 +276,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 stop_return_code,
                 wait_for_airflow_ui,
                 default_config_path,
-                dags_path
+                dags_path,
             )
 
             # Make empty config
@@ -299,7 +298,7 @@ class TestObservatoryPlatform(unittest.TestCase):
         # Test that invalid config errors show up
         # Test that error message is printed when Docker is installed but not running
         runner = CliRunner()
-        with runner.isolated_filesystem() as t :
+        with runner.isolated_filesystem() as t:
             # Environment invalid, Docker installed but not running
             default_config_path = os.path.join(t, "config.yaml")
             is_environment_valid = False
@@ -325,7 +324,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 stop_return_code,
                 wait_for_airflow_ui,
                 default_config_path,
-                dags_path
+                dags_path,
             )
 
             # Make empty config

--- a/tests/observatory/platform/cli/test_cli.py
+++ b/tests/observatory/platform/cli/test_cli.py
@@ -26,26 +26,10 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from observatory.platform.cli.cli import cli
+from observatory.platform.docker.compose import ProcessOutput
 from observatory.platform.observatory_config import TerraformConfig
 from observatory.platform.observatory_config import ValidationError
-from observatory.platform.docker.compose import ProcessOutput
-from observatory.platform.platform_builder import (
-    BUILD_PATH,
-    DAGS_MODULE,
-    DATA_PATH,
-    LOGS_PATH,
-    POSTGRES_PATH,
-    HOST_UID,
-    HOST_GID,
-    REDIS_PORT,
-    FLOWER_UI_PORT,
-    AIRFLOW_UI_PORT,
-    ELASTIC_PORT,
-    KIBANA_PORT,
-    DOCKER_NETWORK_NAME,
-    DOCKER_COMPOSE_PROJECT_NAME,
-    DEBUG,
-)
+from observatory.platform.platform_builder import HOST_UID, HOST_GID, DEBUG
 from observatory.platform.terraform_api import TerraformApi
 from tests.observatory.test_utils import random_id
 
@@ -139,22 +123,9 @@ class MockPlatformCommand(Mock):
         self.docker_compose_path = docker_compose_path
         self.config_exists = config_exists
         self.config = config
-
         self.config_path = config_path
-        self.build_path = BUILD_PATH
-        self.dags_path = DAGS_MODULE
-        self.data_path = DATA_PATH
-        self.logs_path = LOGS_PATH
-        self.postgres_path = POSTGRES_PATH
         self.host_uid = HOST_UID
         self.host_gid = HOST_GID
-        self.redis_port = REDIS_PORT
-        self.flower_ui_port = FLOWER_UI_PORT
-        self.airflow_ui_port = AIRFLOW_UI_PORT
-        self.elastic_port = ELASTIC_PORT
-        self.kibana_port = KIBANA_PORT
-        self.docker_network_name = DOCKER_NETWORK_NAME
-        self.docker_compose_project_name = DOCKER_COMPOSE_PROJECT_NAME
         self.debug = DEBUG
         self._build_return_code = build_return_code
         self._start_return_code = start_return_code
@@ -356,11 +327,12 @@ class TestObservatoryTerraform(unittest.TestCase):
             config = TerraformConfig.from_dict(
                 {
                     "backend": {"type": "terraform", "environment": "develop"},
-                    "airflow": {
-                        "fernet_key": "random-fernet-key",
-                        "secret_key": "random-secret-key",
-                        "ui_user_password": "password",
-                        "ui_user_email": "password",
+                    "observatory": {
+                        "airflow_fernet_key": "random-fernet-key",
+                        "airflow_secret_key": "random-secret-key",
+                        "airflow_ui_user_password": "password",
+                        "airflow_ui_user_email": "password",
+                        "postgres_password": "my-password",
                     },
                     "terraform": {"organization": self.organisation},
                     "google_cloud": {
@@ -370,11 +342,7 @@ class TestObservatoryTerraform(unittest.TestCase):
                         "zone": "us-west1-c",
                         "data_location": "us",
                     },
-                    "cloud_sql_database": {
-                        "tier": "db-custom-2-7680",
-                        "backup_start_time": "23:00",
-                        "postgres_password": "my-password",
-                    },
+                    "cloud_sql_database": {"tier": "db-custom-2-7680", "backup_start_time": "23:00"},
                     "airflow_main_vm": {
                         "machine_type": "n2-standard-2",
                         "disk_size": 1,
@@ -501,10 +469,11 @@ class TestObservatoryTerraform(unittest.TestCase):
             config = TerraformConfig.from_dict(
                 {
                     "backend": {"type": "terraform", "environment": "develop"},
-                    "airflow": {
-                        "fernet_key": "random-fernet-key",
-                        "ui_user_password": "password",
-                        "ui_user_email": "password",
+                    "observatory": {
+                        "airflow_fernet_key": "random-fernet-key",
+                        "airflow_ui_user_password": "password",
+                        "airflow_ui_user_email": "password",
+                        "postgres_password": "my-password",
                     },
                     "terraform": {"organization": self.organisation},
                     "google_cloud": {
@@ -514,11 +483,7 @@ class TestObservatoryTerraform(unittest.TestCase):
                         "zone": "us-west1-c",
                         "data_location": "us",
                     },
-                    "cloud_sql_database": {
-                        "tier": "db-custom-2-7680",
-                        "backup_start_time": "23:00",
-                        "postgres_password": "my-password",
-                    },
+                    "cloud_sql_database": {"tier": "db-custom-2-7680", "backup_start_time": "23:00"},
                     "airflow_main_vm": {
                         "machine_type": "n2-standard-2",
                         "disk_size": 1,

--- a/tests/observatory/platform/cli/test_platform_command.py
+++ b/tests/observatory/platform/cli/test_platform_command.py
@@ -14,12 +14,17 @@
 
 # Author: James Diprose
 
+import os
 import random
 import unittest
 from datetime import datetime
 from typing import Any
 from unittest.mock import patch, Mock
+
+from click.testing import CliRunner
+
 from observatory.platform.cli.platform_command import PlatformCommand
+from observatory.platform.observatory_config import save_yaml
 
 
 class MockUrlOpen(Mock):
@@ -32,36 +37,66 @@ class MockUrlOpen(Mock):
 
 
 class TestPlatformCommand(unittest.TestCase):
+
     def setUp(self) -> None:
         self.airflow_ui_port = random.randint(1, 65535)
-        self.platform_command = PlatformCommand("config.yaml", airflow_ui_port=self.airflow_ui_port)
+
+    def save_config(self, file_path: str, observatory_home: str):
+        dict_ = {
+            "backend": {"type": "local", "environment": "develop"},
+            "observatory": {
+                "observatory_home": observatory_home,
+                "airflow_fernet_key": "random-fernet-key",
+                "airflow_secret_key": "random-secret-key",
+            }
+        }
+
+        save_yaml(file_path, dict_)
 
     def test_ui_url(self):
-        self.assertEqual(f"http://localhost:{self.airflow_ui_port}", self.platform_command.ui_url)
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
+            self.save_config(config_path, t)
+            cmd = PlatformCommand(config_path)
+            cmd.config.observatory.airflow_ui_port = self.airflow_ui_port
 
-    @patch("urllib.request.urlopen")
+            self.assertEqual(f'http://localhost:{self.airflow_ui_port}', cmd.ui_url)
+
+    @patch('urllib.request.urlopen')
     def test_wait_for_airflow_ui_success(self, mock_url_open):
         # Mock the status code return value: 200 should succeed
         mock_url_open.return_value = MockUrlOpen(200)
 
-        start = datetime.now()
-        state = self.platform_command.wait_for_airflow_ui()
-        end = datetime.now()
-        duration = (end - start).total_seconds()
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
+            self.save_config(config_path, t)
 
-        self.assertTrue(state)
-        self.assertAlmostEquals(0, duration, delta=0.5)
+            cmd = PlatformCommand(config_path)
+            cmd.config.observatory.airflow_ui_port = self.airflow_ui_port
 
-    @patch("urllib.request.urlopen")
+            start = datetime.now()
+            state = cmd.wait_for_airflow_ui()
+            end = datetime.now()
+            duration = (end - start).total_seconds()
+
+            self.assertTrue(state)
+            self.assertAlmostEquals(0, duration, delta=0.5)
+
+    @patch('urllib.request.urlopen')
     def test_wait_for_airflow_ui_failed(self, mock_url_open):
         # Mock the status code return value: 500 should fail
         mock_url_open.return_value = MockUrlOpen(500)
 
-        expected_timeout = 10
-        start = datetime.now()
-        state = self.platform_command.wait_for_airflow_ui(expected_timeout)
-        end = datetime.now()
-        duration = (end - start).total_seconds()
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
+            self.save_config(config_path, t)
+            cmd = PlatformCommand(config_path)
 
-        self.assertFalse(state)
-        self.assertAlmostEquals(expected_timeout, duration, delta=1)
+            expected_timeout = 10
+            start = datetime.now()
+            state = cmd.wait_for_airflow_ui(expected_timeout)
+            end = datetime.now()
+            duration = (end - start).total_seconds()
+
+            self.assertFalse(state)
+            self.assertAlmostEquals(expected_timeout, duration, delta=1)

--- a/tests/observatory/platform/cli/test_platform_command.py
+++ b/tests/observatory/platform/cli/test_platform_command.py
@@ -37,7 +37,6 @@ class MockUrlOpen(Mock):
 
 
 class TestPlatformCommand(unittest.TestCase):
-
     def setUp(self) -> None:
         self.airflow_ui_port = random.randint(1, 65535)
 
@@ -48,7 +47,7 @@ class TestPlatformCommand(unittest.TestCase):
                 "observatory_home": observatory_home,
                 "airflow_fernet_key": "random-fernet-key",
                 "airflow_secret_key": "random-secret-key",
-            }
+            },
         }
 
         save_yaml(file_path, dict_)
@@ -60,9 +59,9 @@ class TestPlatformCommand(unittest.TestCase):
             cmd = PlatformCommand(config_path)
             cmd.config.observatory.airflow_ui_port = self.airflow_ui_port
 
-            self.assertEqual(f'http://localhost:{self.airflow_ui_port}', cmd.ui_url)
+            self.assertEqual(f"http://localhost:{self.airflow_ui_port}", cmd.ui_url)
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_wait_for_airflow_ui_success(self, mock_url_open):
         # Mock the status code return value: 200 should succeed
         mock_url_open.return_value = MockUrlOpen(200)
@@ -82,7 +81,7 @@ class TestPlatformCommand(unittest.TestCase):
             self.assertTrue(state)
             self.assertAlmostEquals(0, duration, delta=0.5)
 
-    @patch('urllib.request.urlopen')
+    @patch("urllib.request.urlopen")
     def test_wait_for_airflow_ui_failed(self, mock_url_open):
         # Mock the status code return value: 500 should fail
         mock_url_open.return_value = MockUrlOpen(500)

--- a/tests/observatory/platform/test_observatory_config.py
+++ b/tests/observatory/platform/test_observatory_config.py
@@ -44,8 +44,8 @@ class TestObservatoryConfigValidator(unittest.TestCase):
         }
 
     def test_validate_google_application_credentials(self):
-        """Check if an error occurs for pointing to a file that does not exist when the
-        'google_application_credentials' tag is present in the schema."""
+        """ Check if an error occurs for pointing to a file that does not exist when the
+        'google_application_credentials' tag is present in the schema. """
 
         with CliRunner().isolated_filesystem():
             # Make google application credentials
@@ -68,7 +68,7 @@ class TestObservatoryConfig(unittest.TestCase):
         # Test that a minimal configuration works
         dict_ = {
             "backend": {"type": "local", "environment": "develop"},
-            "airflow": {"fernet_key": "random-fernet-key", "secret_key": "random-secret-key"},
+            "observatory": {"airflow_fernet_key": "random-fernet-key", "airflow_secret_key": "random-secret-key"},
         }
 
         file_path = "config-valid-minimal.yaml"
@@ -96,7 +96,7 @@ class TestObservatoryConfig(unittest.TestCase):
                         "transform_bucket": "my-transform-bucket-1234",
                     },
                 },
-                "airflow": {"fernet_key": "random-fernet-key", "secret_key": "random-secret-key"},
+                "observatory": {"airflow_fernet_key": "random-fernet-key", "airflow_secret_key": "random-secret-key"},
                 "airflow_variables": {"my-variable-name": "my-variable-value"},
                 "airflow_connections": {"my-connection": "http://:my-token-key@"},
                 "dags_projects": [
@@ -142,7 +142,7 @@ class TestObservatoryConfig(unittest.TestCase):
                     "transform_bucket": "my-transform-bucket-1234",
                 },
             },
-            "airflow": {"fernet_key": 1, "secret_key": 1},
+            "observatory": {"airflow_fernet_key": 1, "airflow_secret_key": 1},
             "airflow_variables": {"my-variable-name": 1},
             "airflow_connections": {"my-connection": "token-key"},
             "dags_projects": [
@@ -171,11 +171,12 @@ class TestTerraformConfig(unittest.TestCase):
 
             dict_ = {
                 "backend": {"type": "terraform", "environment": "develop"},
-                "airflow": {
-                    "fernet_key": "random-fernet-key",
-                    "secret_key": "random-secret-key",
-                    "ui_user_password": "password",
-                    "ui_user_email": "password",
+                "observatory": {
+                    "airflow_fernet_key": "random-fernet-key",
+                    "airflow_secret_key": "random-secret-key",
+                    "airflow_ui_user_password": "password",
+                    "airflow_ui_user_email": "password",
+                    "postgres_password": "my-password",
                 },
                 "terraform": {"organization": "hello world"},
                 "google_cloud": {
@@ -185,11 +186,7 @@ class TestTerraformConfig(unittest.TestCase):
                     "zone": "us-west1-c",
                     "data_location": "us",
                 },
-                "cloud_sql_database": {
-                    "tier": "db-custom-2-7680",
-                    "backup_start_time": "23:00",
-                    "postgres_password": "my-password",
-                },
+                "cloud_sql_database": {"tier": "db-custom-2-7680", "backup_start_time": "23:00"},
                 "airflow_main_vm": {
                     "machine_type": "n2-standard-2",
                     "disk_size": 1,
@@ -220,11 +217,12 @@ class TestTerraformConfig(unittest.TestCase):
             # Test that a typical configuration is loaded
             dict_ = {
                 "backend": {"type": "terraform", "environment": "develop"},
-                "airflow": {
-                    "fernet_key": "random-fernet-key",
-                    "secret_key": "random-secret-key",
-                    "ui_user_password": "password",
-                    "ui_user_email": "password",
+                "observatory": {
+                    "airflow_fernet_key": "random-fernet-key",
+                    "airflow_secret_key": "random-secret-key",
+                    "airflow_ui_user_password": "password",
+                    "airflow_ui_user_email": "password",
+                    "postgres_password": "my-password",
                 },
                 "terraform": {"organization": "hello world"},
                 "google_cloud": {
@@ -234,11 +232,7 @@ class TestTerraformConfig(unittest.TestCase):
                     "zone": "us-west1-c",
                     "data_location": "us",
                 },
-                "cloud_sql_database": {
-                    "tier": "db-custom-2-7680",
-                    "backup_start_time": "23:00",
-                    "postgres_password": "my-password",
-                },
+                "cloud_sql_database": {"tier": "db-custom-2-7680", "backup_start_time": "23:00"},
                 "airflow_main_vm": {
                     "machine_type": "n2-standard-2",
                     "disk_size": 1,
@@ -398,7 +392,7 @@ class TestSchema(unittest.TestCase):
             "backend",
             "terraform",
             "google_cloud",
-            "airflow",
+            "observatory",
             "airflow_variables",
             "airflow_connections",
             "dags_projects",
@@ -413,7 +407,7 @@ class TestSchema(unittest.TestCase):
             "backend",
             "terraform",
             "google_cloud",
-            "airflow",
+            "observatory",
             "airflow_variables",
             "airflow_connections",
             "dags_projects",
@@ -512,26 +506,29 @@ class TestSchema(unittest.TestCase):
             ]
             self.assert_sub_schema_valid(valid_docs, invalid_docs, schema, schema_key, expected_errors)
 
-    def test_local_schema_airflow(self):
+    def test_local_schema_observatory(self):
         schema = make_schema(BackendType.local)
-        schema_key = "airflow"
+        schema_key = "observatory"
 
         valid_docs = [
-            {"airflow": {"fernet_key": "random-fernet-key", "secret_key": "random-secret-key"}},
+            {"observatory": {"airflow_fernet_key": "random-fernet-key", "airflow_secret_key": "random-secret-key"}},
             {
-                "airflow": {
-                    "fernet_key": "password",
-                    "secret_key": "password",
-                    "ui_user_password": "password",
-                    "ui_user_email": "password",
+                "observatory": {
+                    "airflow_fernet_key": "password",
+                    "airflow_secret_key": "password",
+                    "airflow_ui_user_password": "password",
+                    "airflow_ui_user_email": "password",
                 }
             },
         ]
-        invalid_docs = [{}, {"airflow": {"ui_user_password": "password", "ui_user_email": "password"}}]
+        invalid_docs = [
+            {},
+            {"observatory": {"airflow_ui_user_password": "password", "airflow_ui_user_email": "password"}},
+        ]
 
         expected_errors = [
-            {"airflow": ["required field"]},
-            {"airflow": [{"fernet_key": ["required field"], "secret_key": ["required field"]}]},
+            {"observatory": ["required field"]},
+            {"observatory": [{"airflow_fernet_key": ["required field"], "airflow_secret_key": ["required field"]}]},
         ]
         self.assert_sub_schema_valid(valid_docs, invalid_docs, schema, schema_key, expected_errors)
 
@@ -660,32 +657,34 @@ class TestSchema(unittest.TestCase):
             ]
             self.assert_sub_schema_valid(valid_docs, invalid_docs, schema, schema_key, expected_errors)
 
-    def test_terraform_schema_airflow(self):
+    def test_terraform_schema_observatory(self):
         # Test that airflow ui password and email required
         schema = make_schema(BackendType.terraform)
-        schema_key = "airflow"
+        schema_key = "observatory"
 
         valid_docs = [
             {
-                "airflow": {
-                    "fernet_key": "password",
-                    "secret_key": "password",
-                    "ui_user_password": "password",
-                    "ui_user_email": "password",
+                "observatory": {
+                    "airflow_fernet_key": "password",
+                    "airflow_secret_key": "password",
+                    "airflow_ui_user_password": "password",
+                    "airflow_ui_user_email": "password",
+                    "postgres_password": "password",
                 }
             }
         ]
-        invalid_docs = [{}, {"airflow": {}}]
+        invalid_docs = [{}, {"observatory": {}}]
 
         expected_errors = [
-            {"airflow": ["required field"]},
+            {"observatory": ["required field"]},
             {
-                "airflow": [
+                "observatory": [
                     {
-                        "fernet_key": ["required field"],
-                        "secret_key": ["required field"],
-                        "ui_user_email": ["required field"],
-                        "ui_user_password": ["required field"],
+                        "airflow_fernet_key": ["required field"],
+                        "airflow_secret_key": ["required field"],
+                        "airflow_ui_user_email": ["required field"],
+                        "airflow_ui_user_password": ["required field"],
+                        "postgres_password": ["required field"],
                     }
                 ]
             },
@@ -701,15 +700,14 @@ class TestSchema(unittest.TestCase):
             {
                 "cloud_sql_database": {
                     "tier": "db-custom-2-7680",
-                    "backup_start_time": "23:00",
-                    "postgres_password": "my-password",
+                    "backup_start_time": "23:00"
                 }
             }
         ]
         invalid_docs = [
             {},
             {"cloud_sql_database": {}},
-            {"cloud_sql_database": {"tier": 1, "backup_start_time": "2300", "postgres_password": "my-password"}},
+            {"cloud_sql_database": {"tier": 1, "backup_start_time": "2300"}},
         ]
 
         expected_errors = [
@@ -718,8 +716,7 @@ class TestSchema(unittest.TestCase):
                 "cloud_sql_database": [
                     {
                         "backup_start_time": ["required field"],
-                        "tier": ["required field"],
-                        "postgres_password": ["required field"],
+                        "tier": ["required field"]
                     }
                 ]
             },

--- a/tests/observatory/platform/test_observatory_config.py
+++ b/tests/observatory/platform/test_observatory_config.py
@@ -696,14 +696,7 @@ class TestSchema(unittest.TestCase):
         schema = make_schema(BackendType.terraform)
         schema_key = "cloud_sql_database"
 
-        valid_docs = [
-            {
-                "cloud_sql_database": {
-                    "tier": "db-custom-2-7680",
-                    "backup_start_time": "23:00"
-                }
-            }
-        ]
+        valid_docs = [{"cloud_sql_database": {"tier": "db-custom-2-7680", "backup_start_time": "23:00"}}]
         invalid_docs = [
             {},
             {"cloud_sql_database": {}},
@@ -712,14 +705,7 @@ class TestSchema(unittest.TestCase):
 
         expected_errors = [
             {"cloud_sql_database": ["required field"]},
-            {
-                "cloud_sql_database": [
-                    {
-                        "backup_start_time": ["required field"],
-                        "tier": ["required field"]
-                    }
-                ]
-            },
+            {"cloud_sql_database": [{"backup_start_time": ["required field"], "tier": ["required field"]}]},
             {
                 "cloud_sql_database": [
                     {

--- a/tests/observatory/platform/test_platform_builder.py
+++ b/tests/observatory/platform/test_platform_builder.py
@@ -20,7 +20,7 @@ import pathlib
 import unittest
 from typing import Any, Dict
 from unittest.mock import Mock, patch
-from observatory.platform.observatory_config import save_yaml
+
 import requests
 from click.testing import CliRunner
 from redis import Redis
@@ -40,6 +40,7 @@ from observatory.platform.observatory_config import (
     AirflowConnection,
     DagsProject,
 )
+from observatory.platform.observatory_config import save_yaml
 from observatory.platform.platform_builder import PlatformBuilder
 from observatory.platform.utils.config_utils import module_file_path
 from observatory.platform.utils.url_utils import wait_for_url
@@ -96,7 +97,7 @@ class TestPlatformBuilder(unittest.TestCase):
                 "observatory_home": observatory_home,
                 "airflow_fernet_key": "random-fernet-key",
                 "airflow_secret_key": "random-secret-key",
-            }
+            },
         }
 
         save_yaml(file_path, dict_)

--- a/tests/observatory/platform/test_terraform_builder.py
+++ b/tests/observatory/platform/test_terraform_builder.py
@@ -40,37 +40,19 @@ class TestTerraformBuilder(unittest.TestCase):
     def setUp(self) -> None:
         self.is_env_local = True
 
-    def set_dirs(self):
-        # Make directories
-        self.config_path = os.path.abspath("config.yaml")
-        self.build_path = os.path.join(os.path.abspath("build"), "terraform")
-        self.terraform_build_path = os.path.join(self.build_path, "terraform")
-        self.dags_path = os.path.abspath("dags")
-        self.data_path = os.path.abspath("data")
-        self.logs_path = os.path.abspath("logs")
-        self.postgres_path = os.path.abspath("postgres")
-
-        os.makedirs(self.build_path, exist_ok=True)
-        os.makedirs(self.terraform_build_path, exist_ok=True)
-        os.makedirs(self.dags_path, exist_ok=True)
-        os.makedirs(self.data_path, exist_ok=True)
-        os.makedirs(self.logs_path, exist_ok=True)
-        os.makedirs(self.postgres_path, exist_ok=True)
-
-    def make_terraform_builder(self):
-        return TerraformBuilder(self.config_path, build_path=self.build_path)
-
-    def save_terraform_config(self, file_path: str):
+    def save_terraform_config(self, file_path: str, observatory_home: str):
         credentials_path = os.path.abspath("creds.json")
         open(credentials_path, "a").close()
 
         dict_ = {
             "backend": {"type": "terraform", "environment": "develop"},
-            "airflow": {
-                "fernet_key": "random-fernet-key",
-                "secret_key": "random-secret-key",
-                "ui_user_password": "password",
-                "ui_user_email": "password",
+            "observatory": {
+                "observatory_home": observatory_home,
+                "airflow_fernet_key": "random-fernet-key",
+                "airflow_secret_key": "random-secret-key",
+                "airflow_ui_user_password": "password",
+                "airflow_ui_user_email": "password",
+                "postgres_password": "my-password",
             },
             "terraform": {"organization": "hello world"},
             "google_cloud": {
@@ -80,11 +62,7 @@ class TestTerraformBuilder(unittest.TestCase):
                 "zone": "us-west1-c",
                 "data_location": "us",
             },
-            "cloud_sql_database": {
-                "tier": "db-custom-2-7680",
-                "backup_start_time": "23:00",
-                "postgres_password": "my-password",
-            },
+            "cloud_sql_database": {"tier": "db-custom-2-7680", "backup_start_time": "23:00"},
             "airflow_main_vm": {"machine_type": "n2-standard-2", "disk_size": 1, "disk_type": "pd-ssd", "create": True},
             "airflow_worker_vm": {
                 "machine_type": "n2-standard-2",
@@ -101,26 +79,26 @@ class TestTerraformBuilder(unittest.TestCase):
         save_yaml(file_path, dict_)
 
     def test_is_environment_valid(self):
-        with CliRunner().isolated_filesystem():
-            self.set_dirs()
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
 
             # Environment should be invalid because there is no config.yaml
-            cmd = self.make_terraform_builder()
-            self.assertFalse(cmd.is_environment_valid)
+            with self.assertRaises(FileExistsError):
+                TerraformBuilder(config_path=config_path)
 
             # Environment should be valid because there is a config.yaml
             # Assumes that Docker is setup on the system where the tests are run
-            self.save_terraform_config(self.config_path)
-            cmd = self.make_terraform_builder()
+            self.save_terraform_config(config_path, t)
+            cmd = TerraformBuilder(config_path=config_path)
             self.assertTrue(cmd.is_environment_valid)
 
     @unittest.skip
     def test_packer_exe_path(self):
         """ Test that the path to the Packer executable is found """
 
-        with CliRunner().isolated_filesystem():
-            self.set_dirs()
-            cmd = self.make_terraform_builder()
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
+            cmd = TerraformBuilder(config_path=config_path)
             result = cmd.packer_exe_path
             self.assertIsNotNone(result)
             self.assertTrue(result.endswith("packer"))
@@ -128,14 +106,14 @@ class TestTerraformBuilder(unittest.TestCase):
     def test_build_terraform(self):
         """ Test building of the terraform files """
 
-        with CliRunner().isolated_filesystem():
-            self.set_dirs()
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
 
             # Save default config file
-            self.save_terraform_config(self.config_path)
+            self.save_terraform_config(config_path, t)
 
             # Make observatory files
-            cmd = self.make_terraform_builder()
+            cmd = TerraformBuilder(config_path=config_path)
             cmd.build_terraform()
 
             # Test that the expected Terraform files have been written
@@ -154,13 +132,13 @@ class TestTerraformBuilder(unittest.TestCase):
             all_files = secret_files + vm_files + root_files
 
             for file_name in all_files:
-                path = os.path.join(self.build_path, "terraform", file_name)
+                path = os.path.join(cmd.build_path, "terraform", file_name)
                 self.assertTrue(os.path.isfile(path))
 
             # Test that expected packages exists
             packages = ["observatory-api", "observatory-platform"]
             for package in packages:
-                path = os.path.join(self.build_path, "packages", package)
+                path = os.path.join(cmd.build_path, "packages", package)
                 self.assertTrue(os.path.exists(path))
 
             # Test that the expected Docker files have been written
@@ -174,7 +152,7 @@ class TestTerraformBuilder(unittest.TestCase):
                 "requirements.observatory-api.txt",
             ]
             for file_name in build_file_names:
-                path = os.path.join(self.build_path, "docker", file_name)
+                path = os.path.join(cmd.build_path, "docker", file_name)
                 self.assertTrue(os.path.isfile(path))
                 self.assertTrue(os.stat(path).st_size > 0)
 
@@ -184,17 +162,16 @@ class TestTerraformBuilder(unittest.TestCase):
         """ Test building of the observatory platform """
 
         # Check that the environment variables are set properly for the default config
-        with CliRunner().isolated_filesystem():
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
             mock_subprocess.return_value = Popen()
             mock_stream_process.return_value = ("", "")
 
-            self.set_dirs()
-
             # Save default config file
-            self.save_terraform_config(self.config_path)
+            self.save_terraform_config(config_path, t)
 
             # Make observatory files
-            cmd = self.make_terraform_builder()
+            cmd = TerraformBuilder(config_path=config_path)
 
             # Build the image
             output, error, return_code = cmd.build_image()
@@ -209,17 +186,16 @@ class TestTerraformBuilder(unittest.TestCase):
         """ Test activating the gcloud service account """
 
         # Check that the environment variables are set properly for the default config
-        with CliRunner().isolated_filesystem():
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
             mock_subprocess.return_value = Popen()
             mock_stream_process.return_value = ("", "")
 
-            self.set_dirs()
-
             # Save default config file
-            self.save_terraform_config(self.config_path)
+            self.save_terraform_config(config_path, t)
 
             # Make observatory files
-            cmd = self.make_terraform_builder()
+            cmd = TerraformBuilder(config_path=config_path)
 
             # Activate the service account
             output, error, return_code = cmd.gcloud_activate_service_account()
@@ -234,17 +210,16 @@ class TestTerraformBuilder(unittest.TestCase):
         """ Test gcloud builds submit command """
 
         # Check that the environment variables are set properly for the default config
-        with CliRunner().isolated_filesystem():
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
             mock_subprocess.return_value = Popen()
             mock_stream_process.return_value = ("", "")
 
-            self.set_dirs()
-
             # Save default config file
-            self.save_terraform_config(self.config_path)
+            self.save_terraform_config(config_path, t)
 
             # Make observatory files
-            cmd = self.make_terraform_builder()
+            cmd = TerraformBuilder(config_path=config_path)
 
             # Build the image
             output, error, return_code = cmd.gcloud_builds_submit()
@@ -257,14 +232,14 @@ class TestTerraformBuilder(unittest.TestCase):
         """ Test building API image using Docker """
 
         # Check that the environment variables are set properly for the default config
-        with CliRunner().isolated_filesystem():
-            self.set_dirs()
+        with CliRunner().isolated_filesystem() as t:
+            config_path = os.path.join(t, "config.yaml")
 
             # Save default config file
-            self.save_terraform_config(self.config_path)
+            self.save_terraform_config(config_path, t)
 
             # Make observatory files
-            cmd = self.make_terraform_builder()
+            cmd = TerraformBuilder(config_path=config_path)
 
             args = ["docker", "build", "."]
             print("Executing subprocess:")


### PR DESCRIPTION
This pull request:
* Simplifies the command line interface by moving most parameters into the config.yaml file.
* Refactoring that enables the observatory to be deployed with Terraform, with the config file changes and the airflow2 migration.

The `airflow` section of the config file is replaced with an `observatory` section and the `postgres_password` has been moved from `cloud_sql_database` into `observatory`:
```
observatory:
  airflow_fernet_key: random-fernet-key
  airflow_secret_key: random-secret-key
  airflow_ui_user_email: airflow@airflow.com
  airflow_ui_user_password: airflow
  airflow_ui_port: 8081
  observatory_home: /home/user/.observatory/
  postgres_password: random-postgres-password
  redis_port: 6380
  flower_ui_port: 5556
  elastic_port: 9201
  kibana_port: 5602
  docker_network_name: observatory-network
  docker_compose_project_name: observatory
```

In order to get the airflow2 migration working when deployed to Google Cloud, I needed to add the Airflow CloudSecretManagerBackend backend to our project. Normally you would have to add the [apache-airflow-providers-google](https://pypi.org/project/apache-airflow-providers-google/) package, however, we cannot depend on this as it uses Google Cloud packages that are out of date.