### PR TITLE
Include info on Google Analytics data retention in documentation and airflow logging.

### DIFF
--- a/docs/telescopes/google_analytics.md
+++ b/docs/telescopes/google_analytics.md
@@ -3,6 +3,8 @@
 Google Analytics is a web analytics service offered by Google that tracks and reports website traffic.  
 This telescope gets data from Google Analytics for 1 view id per publisher and for several combinations of metrics and dimensions.  
 It is possible to add a regex expression to filter on pagepaths, so only data on relevant pagepaths is collected.  
+Note that Google Analytics data is only available for the last 26 months, see 
+[Data retention - Analytics Help](https://support.google.com/analytics/answer/7667196?hl=en) for more info.
 
 To get access to the analytics data a publisher needs to add the relevant google service account as a user.
 

--- a/observatory-dags/observatory/dags/telescopes/google_analytics.py
+++ b/observatory-dags/observatory/dags/telescopes/google_analytics.py
@@ -100,6 +100,9 @@ class GoogleAnalyticsRelease(SnapshotRelease):
             list_to_jsonl_gz(self.transform_path, results)
             return True
         else:
+            if (pendulum.today("UTC") - self.end_date).in_months() >= 26:
+                logging.info('No data available. Google Analytics data is only available for 26 months, see '
+                             'https://support.google.com/analytics/answer/7667196?hl=en for more info')
             return False
 
 

--- a/observatory-dags/observatory/dags/telescopes/google_analytics.py
+++ b/observatory-dags/observatory/dags/telescopes/google_analytics.py
@@ -101,8 +101,10 @@ class GoogleAnalyticsRelease(SnapshotRelease):
             return True
         else:
             if (pendulum.today("UTC") - self.end_date).in_months() >= 26:
-                logging.info('No data available. Google Analytics data is only available for 26 months, see '
-                             'https://support.google.com/analytics/answer/7667196?hl=en for more info')
+                logging.info(
+                    "No data available. Google Analytics data is only available for 26 months, see "
+                    "https://support.google.com/analytics/answer/7667196?hl=en for more info"
+                )
             return False
 
 


### PR DESCRIPTION
Data is only available for 26 months, include this info in the documentation and task logging to make it clear why no older data is available.