### PR TITLE
Create Google Cloud Secrets for all Airflow Variables

### DIFF
--- a/observatory-platform/observatory/platform/dags/load_dags.py
+++ b/observatory-platform/observatory/platform/dags/load_dags.py
@@ -19,8 +19,24 @@ import json
 import logging
 
 from airflow.models import DagBag, Variable
+from airflow.secrets.environment_variables import EnvironmentVariablesBackend
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.config_utils import module_file_path
+
+
+def get_dags_modules() -> dict:
+    """ Get the dags modules from the Airflow Variable
+
+    :return: Dags modules
+    """
+    # Try to get value from env variable first, saving costs from GC secret usage
+    dags_modules_str = EnvironmentVariablesBackend().get_variable(AirflowVars.DAGS_MODULE_NAMES)
+    if not dags_modules_str:
+        dags_modules_str = Variable.get(AirflowVars.DAGS_MODULE_NAMES)
+    logging.info(f"dags_modules str: {dags_modules_str}")
+    dags_modules = json.loads(dags_modules_str)
+    logging.info(f"dags_modules: {dags_modules}")
+    return dags_modules
 
 
 def load_dag_bag(path: str) -> None:
@@ -38,10 +54,7 @@ def load_dag_bag(path: str) -> None:
 
 
 # Load DAGs for each DAG path
-dags_modules_str = Variable.get(AirflowVars.DAGS_MODULE_NAMES)
-logging.info(f"dags_modules str: {dags_modules_str}")
-dags_modules = json.loads(dags_modules_str)
-logging.info(f"dags_modules: {dags_modules}")
+dags_modules = get_dags_modules()
 for module_name in dags_modules:
     dags_path = module_file_path(module_name)
     logging.info(f"{module_name} DAGs path: {dags_path}")

--- a/observatory-platform/observatory/platform/dags/load_dags.py
+++ b/observatory-platform/observatory/platform/dags/load_dags.py
@@ -19,7 +19,7 @@ import json
 import logging
 
 from airflow.models import DagBag, Variable
-from observatory.platform.utils.airflow_utils import AirflowVariable, AirflowVars
+from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.config_utils import module_file_path
 
 
@@ -38,7 +38,7 @@ def load_dag_bag(path: str) -> None:
 
 
 # Load DAGs for each DAG path
-dags_modules_str = AirflowVariable.get(AirflowVars.DAGS_MODULE_NAMES)
+dags_modules_str = Variable.get(AirflowVars.DAGS_MODULE_NAMES)
 logging.info(f"dags_modules str: {dags_modules_str}")
 dags_modules = json.loads(dags_modules_str)
 logging.info(f"dags_modules: {dags_modules}")

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -85,10 +85,6 @@ x-environment: &environment
   # Variables
   AIRFLOW_VAR_DATA_PATH: "/opt/observatory/data"
   AIRFLOW_VAR_DAGS_MODULE_NAMES: {{ dags_projects_to_str(config.dags_projects)  }}
-  {%- if config.backend.type.value == 'terraform' %}
-  AIRFLOW_VAR_DOWNLOAD_BUCKET: ${AIRFLOW_VAR_DOWNLOAD_BUCKET}
-  AIRFLOW_VAR_TRANSFORM_BUCKET: ${AIRFLOW_VAR_TRANSFORM_BUCKET}
-  {%- endif %}
   {%- for var in config.make_airflow_variables() %}
   {%- if config.backend.type.value == 'local' %}
   {{ var.env_var_name }}: '{{ var.value }}'

--- a/observatory-platform/observatory/platform/observatory_config.py
+++ b/observatory-platform/observatory/platform/observatory_config.py
@@ -30,7 +30,7 @@ from cerberus import Validator
 from cryptography.fernet import Fernet
 
 from observatory.platform.terraform_api import TerraformVariable
-from observatory.platform.utils.airflow_utils import AirflowVariable, AirflowVars
+from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.config_utils import module_file_path
 from observatory.platform.utils.config_utils import observatory_home as default_observatory_home
 from observatory.platform.utils.jinja2_utils import render_template

--- a/observatory-platform/observatory/platform/observatory_config.py
+++ b/observatory-platform/observatory/platform/observatory_config.py
@@ -896,9 +896,7 @@ class TerraformConfig(ObservatoryConfig):
         """
 
         # Create airflow variables from fixed config file values
-        data_path = "/opt/observatory/data"  # Hardcoded in docker-compose.observatory.yml.jinja2
-        variables = [AirflowVariable(AirflowVars.DATA_PATH, data_path),
-                     AirflowVariable(AirflowVars.ENVIRONMENT, self.backend.environment.value)]
+        variables = [AirflowVariable(AirflowVars.ENVIRONMENT, self.backend.environment.value)]
 
         if self.google_cloud.project_id is not None:
             variables.append(AirflowVariable(AirflowVars.PROJECT_ID, self.google_cloud.project_id))

--- a/observatory-platform/observatory/platform/observatory_config.py
+++ b/observatory-platform/observatory/platform/observatory_config.py
@@ -896,10 +896,14 @@ class TerraformConfig(ObservatoryConfig):
         """
 
         # Create airflow variables from fixed config file values
-        variables = [AirflowVariable(AirflowVars.ENVIRONMENT, self.backend.environment.value)]
+        data_path = "/opt/observatory/data"  # Hardcoded in docker-compose.observatory.yml.jinja2
+        variables = [AirflowVariable(AirflowVars.DATA_PATH, data_path),
+                     AirflowVariable(AirflowVars.ENVIRONMENT, self.backend.environment.value)]
 
         if self.google_cloud.project_id is not None:
             variables.append(AirflowVariable(AirflowVars.PROJECT_ID, self.google_cloud.project_id))
+            variables.append(AirflowVariable(AirflowVars.DOWNLOAD_BUCKET, f"{self.google_cloud.project_id}-download"))
+            variables.append(AirflowVariable(AirflowVars.TRANSFORM_BUCKET, f"{self.google_cloud.project_id}-transform"))
 
         if self.google_cloud.data_location:
             variables.append(AirflowVariable(AirflowVars.DATA_LOCATION, self.google_cloud.data_location))

--- a/observatory-platform/observatory/platform/utils/airflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/airflow_utils.py
@@ -34,7 +34,6 @@ from google.api_core.exceptions import PermissionDenied
 class AirflowVars:
     """ Common Airflow Variable names used with the Observatory Platform """
 
-    TEST_DATA_PATH = "test_data_path"
     DATA_PATH = "data_path"
     ENVIRONMENT = "environment"
     PROJECT_ID = "project_id"
@@ -43,8 +42,6 @@ class AirflowVars:
     TRANSFORM_BUCKET = "transform_bucket"
     TERRAFORM_ORGANIZATION = "terraform_organization"
     DAGS_MODULE_NAMES = "dags_module_names"
-    KIBANA_SPACES = "kibana_spaces"
-    OBSERVATORY_API = "observatory_api"
     ORCID_BUCKET = "orcid_bucket"
     VM_DAGS_WATCH_LIST = "vm_dags_watch_list"
 

--- a/observatory-platform/observatory/platform/utils/airflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/airflow_utils.py
@@ -18,17 +18,14 @@
 Airflow utility functions (independent of telescope or google cloud usage)
 """
 
-import json
 import logging
 from typing import Any, List, Optional, Union
 
-import airflow.secrets
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection, TaskInstance, Variable
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookHook
 from airflow.utils.db import create_session
-from google.api_core.exceptions import PermissionDenied
 
 
 class AirflowVars:
@@ -64,44 +61,6 @@ class AirflowConns:
     OBSERVATORY_API = "observatory_api"
     GMAIL_API = "gmail_api"
     ORCID = "orcid"
-
-
-def get_variable(key: str) -> Optional[str]:
-    """Get Airflow Variable by iterating over all Secret Backends.
-
-    :param key: Variable Key
-    :return: Variable Value
-    """
-    for secrets_backend in airflow.configuration.ensure_secrets_loaded():
-        # Added try/except statement.
-        try:
-            var_val = secrets_backend.get_variable(key=key)
-        except PermissionDenied as err:
-            print(f"Secret does not exist or cannot be accessed: {err}")
-            var_val = None
-        if var_val is not None:
-            return var_val
-
-    return None
-
-
-class AirflowVariable(Variable):
-    __NO_DEFAULT_SENTINEL = object()
-
-    @classmethod
-    def get(cls, key: str, default_var: Any = __NO_DEFAULT_SENTINEL, deserialize_json: bool = False, session=None):
-        var_val = get_variable(key=key)
-
-        if var_val is None:
-            if default_var is not cls.__NO_DEFAULT_SENTINEL:
-                return default_var
-            else:
-                raise KeyError("Variable {} does not exist".format(key))
-        else:
-            if deserialize_json:
-                return json.loads(var_val)
-            else:
-                return var_val
 
 
 def change_task_log_level(new_levels: Union[List, int]) -> list:
@@ -143,7 +102,7 @@ def check_variables(*variables):
     is_valid = True
     for name in variables:
         try:
-            AirflowVariable.get(name)
+            Variable.get(name)
         except KeyError:
             logging.error(f"Airflow variable '{name}' not set.")
             is_valid = False

--- a/observatory-platform/observatory/platform/workflows/terraform.py
+++ b/observatory-platform/observatory/platform/workflows/terraform.py
@@ -361,7 +361,7 @@ class TerraformTasks:
         )
 
         # Load VM DAGs watch list
-        vm_dags_watch_list_str = AirflowVariable.get(AirflowVars.VM_DAGS_WATCH_LIST)
+        vm_dags_watch_list_str = Variable.get(AirflowVars.VM_DAGS_WATCH_LIST)
         logging.info(f"vm_dags_watch_list_str str: {vm_dags_watch_list_str}")
         vm_dags_watch_list = json.loads(vm_dags_watch_list_str)
         logging.info(f"vm_dags_watch_list: {vm_dags_watch_list}")

--- a/observatory-platform/observatory/platform/workflows/terraform.py
+++ b/observatory-platform/observatory/platform/workflows/terraform.py
@@ -25,13 +25,13 @@ from airflow.models.dag import DAG
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
+from airflow.models.variable import Variable
 from croniter import croniter
 
 from observatory.platform.observatory_config import TerraformConfig, VirtualMachine
 from observatory.platform.terraform_api import TerraformApi
 from observatory.platform.utils.airflow_utils import (
     AirflowConns,
-    AirflowVariable,
     AirflowVars,
     change_task_log_level,
     check_connections,
@@ -49,10 +49,10 @@ def get_workspace_id() -> str:
     terraform_api = TerraformApi(token)
 
     # Get organization
-    organization = AirflowVariable.get(AirflowVars.TERRAFORM_ORGANIZATION)
+    organization = Variable.get(AirflowVars.TERRAFORM_ORGANIZATION)
 
     # Get workspace
-    environment = AirflowVariable.get(AirflowVars.ENVIRONMENT)
+    environment = Variable.get(AirflowVars.ENVIRONMENT)
     workspace = TerraformConfig.WORKSPACE_PREFIX + environment
 
     # Get workspace ID
@@ -300,7 +300,7 @@ class TerraformTasks:
 
         ti: TaskInstance = kwargs["ti"]
         run_id = ti.xcom_pull(key=TerraformTasks.XCOM_TERRAFORM_RUN_ID, task_ids=TerraformTasks.TASK_ID_RUN)
-        project_id = AirflowVariable.get(AirflowVars.PROJECT_ID)
+        project_id = Variable.get(AirflowVars.PROJECT_ID)
 
         token = BaseHook.get_connection(AirflowConns.TERRAFORM).password
         terraform_api = TerraformApi(token)
@@ -468,7 +468,7 @@ class TerraformTasks:
                         f"{hours_on}."
                         f" Warning limit: {TerraformTasks.VM_RUNTIME_H_WARNING}H"
                     )
-                    project_id = AirflowVariable.get(AirflowVars.PROJECT_ID)
+                    project_id = Variable.get(AirflowVars.PROJECT_ID)
                     slack_hook = create_slack_webhook(comments, project_id, **kwargs)
 
                     # http_hook outputs the secret token, suppressing logging 'info' by setting level to 'warning'

--- a/observatory-platform/observatory/platform/workflows/workflow.py
+++ b/observatory-platform/observatory/platform/workflows/workflow.py
@@ -32,11 +32,11 @@ import pendulum
 from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import chain
+from airflow.models.variable import Variable
 from airflow.operators.python import PythonOperator, ShortCircuitOperator
 from airflow.sensors.base import BaseSensorOperator
 
 from observatory.platform.utils.airflow_utils import (
-    AirflowVariable,
     AirflowVars,
     check_connections,
     check_variables,
@@ -588,14 +588,14 @@ class Release(AbstractRelease):
         """The download bucket name.
         :return: the download bucket name.
         """
-        return AirflowVariable.get(AirflowVars.DOWNLOAD_BUCKET)
+        return Variable.get(AirflowVars.DOWNLOAD_BUCKET)
 
     @property
     def transform_bucket(self):
         """The transform bucket name.
         :return: the transform bucket name.
         """
-        return AirflowVariable.get(AirflowVars.TRANSFORM_BUCKET)
+        return Variable.get(AirflowVars.TRANSFORM_BUCKET)
 
     def cleanup(self) -> None:
         """Delete all files and folders associated with this release.

--- a/tests/observatory/platform/utils/test_config_utils.py
+++ b/tests/observatory/platform/utils/test_config_utils.py
@@ -28,12 +28,6 @@ from observatory.platform.utils.config_utils import (
     observatory_home,
     terraform_credentials_path,
 )
-from observatory.platform.utils.workflow_utils import (
-    SubFolder,
-    reset_variables,
-    workflow_path,
-    test_data_path,
-)
 from observatory.platform.utils.test_utils import test_fixtures_path
 
 

--- a/tests/observatory/platform/utils/test_workflow_utils.py
+++ b/tests/observatory/platform/utils/test_workflow_utils.py
@@ -150,7 +150,7 @@ class MockStreamTelescope(StreamTelescope):
 
 
 class TestTemplateUtils(unittest.TestCase):
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_telescope_path(self, mock_variable_get):
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -181,7 +181,7 @@ class TestTemplateUtils(unittest.TestCase):
             self.assertEqual(expected, path_transformed)
             self.assertTrue(os.path.exists(path_transformed))
 
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_blob_name(self, mock_variable_get):
         with CliRunner().isolated_filesystem() as t:
             data_path = os.path.join(t, "data")
@@ -194,7 +194,7 @@ class TestTemplateUtils(unittest.TestCase):
             self.assertEqual(expected, blob)
 
     @patch("observatory.platform.utils.workflow_utils.upload_files_to_cloud_storage")
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_upload_files_from_list(self, mock_variable_get, mock_upload_files):
 
         with CliRunner().isolated_filesystem() as t:
@@ -275,7 +275,7 @@ class TestTemplateUtils(unittest.TestCase):
     @patch("observatory.platform.utils.workflow_utils.find_schema")
     @patch("observatory.platform.utils.workflow_utils.create_bigquery_dataset")
     @patch("airflow.models.variable.Variable.get")
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_prepare_bq_load(
         self, mock_airflowvariable_get, mock_variable_get, mock_create_bigquery_dataset, mock_find_schema
     ):
@@ -438,7 +438,7 @@ class TestTemplateUtils(unittest.TestCase):
 
     @patch("observatory.platform.utils.workflow_utils.load_bigquery_table")
     @patch("observatory.platform.utils.workflow_utils.prepare_bq_load_v2")
-    @patch("observatory.platform.utils.airflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.airflow_utils.Variable.get")
     def test_bq_load_shard_v2(self, mock_variable_get, mock_prepare_bq_load, mock_load_bigquery_table):
         with CliRunner().isolated_filesystem():
             mock_variable_get.side_effect = side_effect
@@ -583,7 +583,7 @@ class TestTemplateUtils(unittest.TestCase):
 
     @patch("observatory.platform.utils.workflow_utils.load_bigquery_table")
     @patch("observatory.platform.utils.workflow_utils.prepare_bq_load_v2")
-    @patch("observatory.platform.utils.airflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.airflow_utils.Variable.get")
     def test_bq_load_partition(self, mock_variable_get, mock_prepare_bq_load, mock_load_bigquery_table):
         with CliRunner().isolated_filesystem():
             mock_variable_get.side_effect = side_effect
@@ -830,7 +830,7 @@ class TestTemplateUtils(unittest.TestCase):
                     )
 
     @patch("observatory.platform.utils.workflow_utils.create_slack_webhook")
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
     def test_on_failure_callback(self, mock_variable_get, mock_create_slack_webhook):
         mock_variable_get.side_effect = ["develop", "project_id", "staging", "project_id"]
         mock_create_slack_webhook.return_value = Mock(spec=SlackWebhookHook)
@@ -856,7 +856,7 @@ def side_effect(arg, data_path: str = ""):
     return values[arg]
 
 
-@patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
+@patch("observatory.platform.utils.workflow_utils.Variable.get")
 @patch("airflow.models.variable.Variable.get")
 def setup(telescope_class, mock_variable_get, mock_airflowvariable_get):
     mock_airflowvariable_get.side_effect = side_effect

--- a/tests/observatory/platform/utils/test_workflow_utils.py
+++ b/tests/observatory/platform/utils/test_workflow_utils.py
@@ -67,7 +67,6 @@ from observatory.platform.utils.workflow_utils import (
     reset_variables,
     table_ids_from_path,
     workflow_path,
-    test_data_path,
     upload_files_from_list,
 )
 from observatory.platform.utils.workflow_utils import add_partition_date
@@ -181,15 +180,6 @@ class TestTemplateUtils(unittest.TestCase):
             expected = os.path.join(root_path, SubFolder.transformed.value, telescope_name)
             self.assertEqual(expected, path_transformed)
             self.assertTrue(os.path.exists(path_transformed))
-
-    @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
-    def test_test_data_path(self, mock_variable_get):
-        # Mock test data path variable
-        expected_path = "/tmp/test_data"
-        mock_variable_get.return_value = expected_path
-
-        actual_path = test_data_path()
-        self.assertEqual(expected_path, actual_path)
 
     @patch("observatory.platform.utils.workflow_utils.AirflowVariable.get")
     def test_blob_name(self, mock_variable_get):


### PR DESCRIPTION
While working on the telescope documentation I was documenting why we use a custom 'AirflowVariable' class to get values for the Airflow variables.
The explanation is below:

> #### Secrets backend issue, use custom AirflowVariable class
> In the cloud environment that is deployed with terraform, Airflow uses Google Cloud Secret Manager as a secrets
>  backend and both the Airflow variable and connections are stored in there as secrets.
> 
> Unfortunately, there is currently an issue with Airflow's method to obtain variables when using the secrets backend.  
> This issue has been resolved by implementing a custom `AirflowVariable` class inside 
> `observatory-platform/observatory/platform/utils/airflow_utils.py`.  
> This class should always be used to get variables instead of the standard Airflow `Variable` class inside `airflow
> .models.variable.py`.
> 
> For example, to get a variable:  
> ```python
> from observatory.platform.utils.airflow_utils import AirflowVariable, AirflowVars
> variable = AirflowVariable.get(AirflowVars.DOWNLOAD_BUCKET)
> ```
> 
> The problem occurs when Airflow tries to get a variable while the Google Cloud Secrets Manager is set as a secrets
>  backend, but the variable is not stored as a Google Cloud Secret.  
> This is the case for some Airflow variables that are often used in the telescopes (test_data_path, data_path, 
> download_bucket, transform_bucket).  
> They are not set in the 'airflow_variables' section of the `config-terraform.yaml` file and this means that these
>  variables are not stored as Google Cloud Secrets.
> They do exist as valid Airflow variables, but as environment variables instead of Google Cloud Secrets.  
> The search order for variables/connections for Airflow is not configurable and with a secrets backend enabled the
>  order is:   
> ```
> secrets backend > environment variables > metastore
> ```
> 
> The issue is that the current Airflow method to get variables from the secrets backend will return an error when a
>  Google Cloud Secret can not be found.
> This error prevents Airflow from searching for a variable in remaining places (environment variables & metastore),
>  so the value for a variable can never be resolved if it does not exist as a Google Cloud Secret.   
> The custom `AirflowVariable` class solves this by catching the error in a Try/Except clause, meaning that Airflow
>  will continue to look for a variable in the remaining places.

While I still think there is a flaw in Airflow's method to just raise an error whenever a secret does not exist, a better workaround for us might be to just make sure that all the Airflow Variables listed in the AirflowVars class exist (ofcourse the user defined variables depend on whether they are added to the config file).

I've added the `data_path`, `download_bucket` and `transform_bucket` variables as these were the only ones missing.
We can then remove the custom Airflow class and the relevant part from the documentation.

UPDATE:
To prevent excessive costs for accessing secrets I customised the `workflow_path` function to first look for an environment variable instead of a google cloud secret.

I also found that the updated secret_manager_client has a fix so that when a secret cannot be found this is caught with an exception, instead of raising an error. This means that the custom AirflowVariable class is not needed anymore for this reason alone.