### PR TITLE
Feature/oapen workflow

### DIFF
--- a/observatory-dags/observatory/dags/dags/elastic_import_workflow.py
+++ b/observatory-dags/observatory/dags/dags/elastic_import_workflow.py
@@ -124,6 +124,19 @@ configs = [
         kibana_spaces=["oaebu-umich-press", "dev-oaebu-umich-press"],
         kibana_time_fields=OAEBU_KIBANA_TIME_FIELDS,
     ),
+ElasticImportConfig(
+        dag_id=make_dag_id(DAG_PREFIX, "oapen"),
+        project_id="oaebu-oapen",
+        dataset_id=DATASET_ID,
+        bucket_name="oaebu-oapen-transform",
+        data_location=DATA_LOCATION,
+        file_type=FILE_TYPE_JSONL,
+        sensor_dag_ids=[make_dag_id(DAG_ONIX_WORKFLOW_PREFIX, "oapen")],
+        elastic_mappings_path=ELASTIC_MAPPINGS_PATH,
+        elastic_mappings_func=load_elastic_mappings_oaebu,
+        kibana_spaces=["oaebu-oapen", "dev-oaebu-oapen"],
+        kibana_time_fields=OAEBU_KIBANA_TIME_FIELDS,
+    ),
 ]
 
 for config in configs:

--- a/observatory-dags/observatory/dags/dags/oapen_workflow.py
+++ b/observatory-dags/observatory/dags/dags/oapen_workflow.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Richard Hosking
+
+# The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
+# https://airflow.apache.org/docs/stable/faq.html
+
+from observatory.dags.workflows.oaebu_partners import OaebuPartnerName, OaebuPartners
+from observatory.dags.workflows.oapen_workflow import OapenWorkflow
+
+org_name = 'OAPEN'
+gcp_project_id = 'oaebu-oapen'
+gcp_dataset_id = 'oaebu'
+
+# OAEBU dataset id's
+oaebu_dataset= "oaebu"
+oaebu_onix_dataset= "oapen_onix"
+oaebu_intermediate_dataset= "oaebu_intermediate"
+oaebu_elastic_dataset= "data_export"
+
+# IRUS-UK Data
+irus_uk_dag_id_prefix="oapen_irus_uk"
+irus_uk_dataset_id="oapen"
+irus_uk_table_id="oapen_irus_uk"
+
+# Academic Observatory
+ao_gcp_project_id = "academic-observatory"
+
+# OAPEN metadata
+oapen_metadata_dataset_id = "oapen"
+oapen_metadata_table_id = "metadata"
+
+# Public Book Data
+public_book_metadata_dataset_id = "observatory"
+public_book_metadata_table_id = "book"
+
+oapen_workflow = OapenWorkflow(
+    org_name=org_name,
+    gcp_project_id=gcp_project_id,
+)
+
+globals()[oapen_workflow.dag_id] = oapen_workflow.make_dag()

--- a/observatory-dags/observatory/dags/dags/oapen_workflow.py
+++ b/observatory-dags/observatory/dags/dags/oapen_workflow.py
@@ -19,12 +19,5 @@
 
 from observatory.dags.workflows.oapen_workflow import OapenWorkflow
 
-org_name = 'OAPEN'
-gcp_project_id = 'oaebu-oapen'
-
-oapen_workflow = OapenWorkflow(
-    org_name=org_name,
-    gcp_project_id=gcp_project_id,
-)
-
+oapen_workflow = OapenWorkflow()
 globals()[oapen_workflow.dag_id] = oapen_workflow.make_dag()

--- a/observatory-dags/observatory/dags/dags/oapen_workflow.py
+++ b/observatory-dags/observatory/dags/dags/oapen_workflow.py
@@ -17,34 +17,10 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
-from observatory.dags.workflows.oaebu_partners import OaebuPartnerName, OaebuPartners
 from observatory.dags.workflows.oapen_workflow import OapenWorkflow
 
 org_name = 'OAPEN'
 gcp_project_id = 'oaebu-oapen'
-gcp_dataset_id = 'oaebu'
-
-# OAEBU dataset id's
-oaebu_dataset= "oaebu"
-oaebu_onix_dataset= "oapen_onix"
-oaebu_intermediate_dataset= "oaebu_intermediate"
-oaebu_elastic_dataset= "data_export"
-
-# IRUS-UK Data
-irus_uk_dag_id_prefix="oapen_irus_uk"
-irus_uk_dataset_id="oapen"
-irus_uk_table_id="oapen_irus_uk"
-
-# Academic Observatory
-ao_gcp_project_id = "academic-observatory"
-
-# OAPEN metadata
-oapen_metadata_dataset_id = "oapen"
-oapen_metadata_table_id = "metadata"
-
-# Public Book Data
-public_book_metadata_dataset_id = "observatory"
-public_book_metadata_table_id = "book"
 
 oapen_workflow = OapenWorkflow(
     org_name=org_name,

--- a/observatory-dags/observatory/dags/dags/onix_workflow.py
+++ b/observatory-dags/observatory/dags/dags/onix_workflow.py
@@ -36,6 +36,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="google",
             gcp_table_id="google_analytics",
             isbn_field_name="publication_id",
+            title_field_name="title",
             sharded=False,
         ),
         OaebuPartners(
@@ -45,6 +46,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="google",
             gcp_table_id="google_books_sales",
             isbn_field_name="Primary_ISBN",
+            title_field_name="Title",
             sharded=False,
         ),
         OaebuPartners(
@@ -54,6 +56,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="google",
             gcp_table_id="google_books_traffic",
             isbn_field_name="Primary_ISBN",
+            title_field_name="Title",
             sharded=False,
         ),
         OaebuPartners(
@@ -63,6 +66,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="jstor",
             gcp_table_id="jstor_country",
             isbn_field_name="eISBN",
+            title_field_name="Book_Title",
             sharded=False,
         ),
         OaebuPartners(
@@ -72,6 +76,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="jstor",
             gcp_table_id="jstor_institution",
             isbn_field_name="eISBN",
+            title_field_name="Book_Title",
             sharded=False,
         ),
         OaebuPartners(
@@ -81,6 +86,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="oapen",
             gcp_table_id="oapen_irus_uk",
             isbn_field_name="ISBN",
+            title_field_name="book_title",
             sharded=False,
         ),
         OaebuPartners(
@@ -90,6 +96,7 @@ def get_oaebu_partner_data(project_id, org_name):
             gcp_dataset_id="ucl",
             gcp_table_id="ucl_discovery",
             isbn_field_name="ISBN",
+            title_field_name="book_title",
             sharded=False,
         ),
     ]

--- a/observatory-dags/observatory/dags/database/mappings/oaebu-list-mappings.json.jinja2
+++ b/observatory-dags/observatory/dags/database/mappings/oaebu-list-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "ProductForm": {
         "type": "text",
         "analyzer": "text_analyzer",

--- a/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-city-mappings.json.jinja2
+++ b/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-city-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-country-mappings.json.jinja2
+++ b/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-country-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-events-mappings.json.jinja2
+++ b/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-events-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-mappings.json.jinja2
+++ b/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-referrer-mappings.json.jinja2
+++ b/observatory-dags/observatory/dags/database/mappings/oaebu-metrics-referrer-mappings.json.jinja2
@@ -10,6 +10,24 @@
           }
         }
       },
+      "work_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "work_family_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "title": {
         "type": "text",
         "fields": {

--- a/observatory-dags/observatory/dags/database/mappings/oaebu-unmatched-metrics-mappings.json.jinja2
+++ b/observatory-dags/observatory/dags/database/mappings/oaebu-unmatched-metrics-mappings.json.jinja2
@@ -10,6 +10,42 @@
           }
         }
       },
+      "google_analytics_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "google_books_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "jstor_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "oapen_title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "release_date": {
         "type": "date",
         "format": "yyyy-MM-dd"

--- a/observatory-dags/observatory/dags/database/sql/create_book_products.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/create_book_products.sql.jinja2
@@ -110,6 +110,18 @@ empty_ucl_discovery as (
         [STRUCT(CAST(NULL as STRING) as country_name, CAST(NULL as STRING) as country_code, CAST(null as INT64) as download_count)] as downloads_per_country
 ),
 
+empty_work_ids as (
+    SELECT
+        CAST(NULL as STRING) as isbn13,
+        CAST(NULL as STRING) as work_id,
+),
+
+empty_work_family_ids as (
+    SELECT
+        CAST(NULL as STRING) as isbn13,
+        CAST(NULL as STRING) as work_family_id,
+),
+
 onix_ebook_titles as (
     SELECT
         ISBN13,
@@ -311,8 +323,10 @@ metrics as (
 )
 
 SELECT
-    onix_ebook_titles.*, STRUCT(crossref_objects, chapters, events.overall as events, google_books_sales_metadata as google_books_sales, google_books_traffic_metadata as google_books_traffic, jstor_country_metadata as jstor_metadata, jstor_institution_metadata as jstor_institution_metadata, oapen_irus_uk_metadata as oapen_irus_uk_metadata) as metadata, metrics.months
+    onix_ebook_titles.*, empty_work_ids.work_id, empty_work_family_ids.work_family_id, STRUCT(crossref_objects, chapters, events.overall as events, google_books_sales_metadata as google_books_sales, google_books_traffic_metadata as google_books_traffic, jstor_country_metadata as jstor_metadata, jstor_institution_metadata as jstor_institution_metadata, oapen_irus_uk_metadata as oapen_irus_uk_metadata) as metadata, metrics.months
 FROM onix_ebook_titles
+LEFT JOIN {% if onix_workflow %} `{{ project_id }}.{{ dataset_id }}.onix_workid_isbn{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_work_ids {% endif %} as empty_work_ids on empty_work_ids.isbn13 = onix_ebook_titles.isbn13
+LEFT JOIN {% if onix_workflow %} `{{ project_id }}.{{ dataset_id }}.onix_workfamilyid_isbn{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_work_family_ids {% endif %} as empty_work_family_ids on empty_work_family_ids.isbn13 = onix_ebook_titles.isbn13
 LEFT JOIN metrics as metrics on metrics.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN google_books_sales_metadata on google_books_sales_metadata.ISBN13  = onix_ebook_titles.ISBN13
 LEFT JOIN google_books_traffic_metadata on google_books_traffic_metadata.ISBN13  = onix_ebook_titles.ISBN13

--- a/observatory-dags/observatory/dags/database/sql/create_book_products.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/create_book_products.sql.jinja2
@@ -101,6 +101,15 @@ empty_google_analytics as (
         ) as unique_views
 ),
 
+empty_ucl_discovery as (
+    SELECT
+        CAST(NULL as STRING) as isbn,
+        CAST(NULL as STRING) as book_title,
+        CAST(NULL as DATE) as release_date,
+        CAST(NULL as INT64) as total_downloads,
+        [STRUCT(CAST(NULL as STRING) as country_name, CAST(NULL as STRING) as country_code, CAST(null as INT64) as download_count)] as downloads_per_country
+),
+
 onix_ebook_titles as (
     SELECT
         ISBN13,
@@ -229,8 +238,14 @@ oapen_irus_uk_metadata as (
     GROUP BY ISBN
 ),
 
-# TODO UCL Discovery
-
+# UCL Discovery
+ucl_discovery_metrics as (
+    SELECT
+        isbn as ISBN13, release_date, STRUCT(SUM(total_downloads) as total_downloads, ARRAY_CONCAT_AGG(downloads_per_country) as downloads_per_country ) as metrics
+    FROM {% if ucl %} `{{ project_id }}.{{ dataset_id }}.{{ ucl_dataset }}_ucl_discovery_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_ucl_discovery {% endif %} as ucl_discovery
+    WHERE isbn IS NOT NULL
+    GROUP BY isbn, release_date
+),
 
 crossref_events as (
     SELECT
@@ -279,7 +294,8 @@ metrics as (
             google_books_traffic.metrics as google_books_traffic,
             jstor_country.metrics as jstor_country,
             jstor_institution.metrics as jstor_institution,
-            oapen_irus_uk.metrics as oapen_irus_uk
+            oapen_irus_uk.metrics as oapen_irus_uk,
+            ucl_discovery.metrics as ucl_discovery
         ) ORDER BY ebook_months.release_date DESC) as months
     FROM ebook_months
     LEFT JOIN google_analytics_metrics as google_analytics ON ebook_months.ISBN13 = google_analytics.ISBN13 AND ebook_months.release_date = google_analytics.release_date
@@ -288,7 +304,8 @@ metrics as (
     LEFT JOIN jstor_country_metrics as jstor_country ON ebook_months.ISBN13 = jstor_country.ISBN13 AND ebook_months.release_date = jstor_country.release_date
     LEFT JOIN jstor_institution_metrics as jstor_institution ON ebook_months.ISBN13 = jstor_institution.ISBN13 AND ebook_months.release_date = jstor_institution.release_date
     LEFT JOIN oapen_irus_uk_metrics as oapen_irus_uk ON ebook_months.ISBN13 = oapen_irus_uk.ISBN13 AND ebook_months.release_date = oapen_irus_uk.release_date
-    LEFT JOIN crossref_events  as crossref_events ON ebook_months.ISBN13 = crossref_events.ISBN13 AND ebook_months.release_date = crossref_events.release_date
+    LEFT JOIN ucl_discovery_metrics as ucl_discovery ON ebook_months.ISBN13 = ucl_discovery.ISBN13 AND ebook_months.release_date = ucl_discovery.release_date
+    LEFT JOIN crossref_events as crossref_events ON ebook_months.ISBN13 = crossref_events.ISBN13 AND ebook_months.release_date = crossref_events.release_date
     WHERE crossref_events.metrics IS NOT NULL OR google_books_sales.metrics IS NOT NULL OR google_books_traffic.metrics IS NOT NULL OR jstor_country.metrics IS NOT NULL OR jstor_institution.metrics is not null OR oapen_irus_uk.metrics IS NOT NULL
     GROUP BY ebook_months.ISBN13
 )
@@ -302,4 +319,4 @@ LEFT JOIN google_books_traffic_metadata on google_books_traffic_metadata.ISBN13 
 LEFT JOIN jstor_country_metadata on jstor_country_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN jstor_institution_metadata on jstor_institution_metadata.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN oapen_irus_uk_metadata on oapen_irus_uk_metadata.ISBN13 = onix_ebook_titles.ISBN13
-LEFT JOIN `academic-observatory.observatory.book20210529` as public_data on public_data.isbn = onix_ebook_titles.ISBN13
+LEFT JOIN `academic-observatory.observatory.book{{ public_book_release_date.strftime('%Y%m%d') }}` as public_data on public_data.isbn = onix_ebook_titles.ISBN13

--- a/observatory-dags/observatory/dags/database/sql/create_book_products.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/create_book_products.sql.jinja2
@@ -14,6 +14,80 @@
 
 # Author: Richard Hosking #}
 
+CREATE TEMP FUNCTION group_items(items ARRAY<STRUCT<name STRING, value INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      name,
+      SUM(value) as value,
+    FROM UNNEST(items)
+    GROUP BY name)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_jstor_country(items ARRAY<STRUCT<Country_name STRING, Total_Item_Requests INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      Country_name,
+      SUM(Total_Item_Requests) as Total_Item_Requests,
+    FROM UNNEST(items)
+    GROUP BY Country_name)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_jstor_institution(items ARRAY<STRUCT<Institution STRING, Total_Item_Requests INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      Institution,
+      SUM(Total_Item_Requests) as Total_Item_Requests,
+    FROM UNNEST(items)
+    GROUP BY Institution)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_irus_country(items ARRAY<STRUCT<name STRING, code STRING, title_requests INT64, total_item_investigations INT64, total_item_requests INT64, unique_item_investigations INT64, unique_item_requests INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      name,
+      MAX(code) as code,
+      SUM(title_requests) as title_requests,
+      SUM(total_item_investigations) as total_item_investigations,
+      SUM(total_item_requests) as total_item_requests,
+      SUM(unique_item_investigations) as unique_item_investigations,
+      SUM(unique_item_requests) as unique_item_requests
+    FROM UNNEST(items)
+    GROUP BY name)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_irus_location(items ARRAY<STRUCT<latitude FLOAT64, longitude FLOAT64, city STRING, country_name STRING, country_code STRING, title_requests INT64, total_item_investigations INT64, total_item_requests INT64, unique_item_investigations INT64, unique_item_requests INT64>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      MAX(latitude) as latitude,
+      MAX(longitude) as longitude,
+      city,
+      MAX(country_name) as country_name,
+      MAX(country_code) as country_code,
+      SUM(title_requests) as title_requests,
+      SUM(total_item_investigations) as total_item_investigations,
+      SUM(total_item_requests) as total_item_requests,
+      SUM(unique_item_investigations) as unique_item_investigations,
+      SUM(unique_item_requests) as unique_item_requests
+    FROM UNNEST(items)
+    GROUP BY city)
+  )
+);
+
+CREATE TEMP FUNCTION group_items_ucl_country(items ARRAY<STRUCT<download_count INT64, country_name STRING, country_code STRING>>) as (
+  ARRAY(
+    (SELECT AS STRUCT
+      country_code,
+      MAX(country_name) as country_name,
+      SUM(download_count) as download_count,
+    FROM UNNEST(items)
+    GROUP BY country_code)
+  )
+);
+
 WITH empty_oapen as (
     SELECT
         CAST(null as STRING) as ISBN,
@@ -107,7 +181,7 @@ empty_ucl_discovery as (
         CAST(NULL as STRING) as book_title,
         CAST(NULL as DATE) as release_date,
         CAST(NULL as INT64) as total_downloads,
-        [STRUCT(CAST(NULL as STRING) as country_name, CAST(NULL as STRING) as country_code, CAST(null as INT64) as download_count)] as downloads_per_country
+        [STRUCT(CAST(null as INT64) as download_count, CAST(NULL as STRING) as country_name, CAST(NULL as STRING) as country_code)] as downloads_per_country
 ),
 
 empty_work_ids as (
@@ -122,7 +196,7 @@ empty_work_family_ids as (
         CAST(NULL as STRING) as work_family_id,
 ),
 
-onix_ebook_titles as (
+onix_ebook_titles_raw as (
     SELECT
         ISBN13,
         STRUCT(
@@ -170,10 +244,21 @@ onix_ebook_titles as (
     WHERE ProductForm = "Digital download and online" OR ProductForm = "Digital (delivered electronically)" OR ProductForm = "Digital download"
 ),
 
+onix_ebook_titles as (
+    SELECT
+        dedupe.*
+    FROM (
+        SELECT
+            ARRAY_AGG(raw LIMIT 1)[OFFSET(0)] dedupe
+        FROM onix_ebook_titles_raw as raw
+        GROUP BY ISBN13
+    )
+),
+
 # Google Analytics
 google_analytics_metrics as (
     SELECT
-        publication_id as ISBN13, release_date, STRUCT(STRUCT(AVG(average_time) as average_time, ARRAY_CONCAT_AGG(unique_views.country) as country, ARRAY_CONCAT_AGG(unique_views.referrer) as referrer, ARRAY_CONCAT_AGG(unique_views.social_network) as social_network) as unique_views) as metrics
+        publication_id as ISBN13, release_date, STRUCT(STRUCT(AVG(average_time) as average_time, group_items(ARRAY_CONCAT_AGG(unique_views.country)) as country, group_items(ARRAY_CONCAT_AGG(unique_views.referrer)) as referrer, group_items(ARRAY_CONCAT_AGG(unique_views.social_network)) as social_network) as unique_views) as metrics
     FROM {% if google_analytics %} `{{ project_id }}.{{ dataset_id }}.{{ google_analytics_dataset }}_google_analytics_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_analytics {% endif %}
     WHERE publication_whole_or_part = '(citation)' and publication_type = "book"
     GROUP BY publication_id, release_date
@@ -196,8 +281,9 @@ google_books_sales_metadata as (
 
 google_books_traffic_metrics as (
     SELECT
-        Primary_ISBN  as ISBN13, release_date, STRUCT(Book_Visits_BV_, BV_with_Pages_Viewed, Non_Unique_Buy_Clicks, BV_with_Buy_Clicks, Buy_Link_CTR, Pages_Viewed) as metrics
+        Primary_ISBN  as ISBN13, release_date, STRUCT(SUM(Book_Visits_BV_) as Book_Visits_BV_, SUM(BV_with_Pages_Viewed) as BV_with_Pages_Viewed, SUM(Non_Unique_Buy_Clicks) as Non_Unique_Buy_Clicks, SUM(BV_with_Buy_Clicks) as BV_with_Buy_Clicks, SUM(Buy_Link_CTR) as Buy_Link_CTR, SUM(Pages_Viewed) as Pages_Viewed) as metrics
     FROM {% if google_books %} `{{ project_id }}.{{ dataset_id }}.{{ google_books_dataset }}_google_books_traffic_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_google_books_traffic {% endif %} as google_books
+    GROUP BY Primary_ISBN, release_date
 ),
 
 google_books_traffic_metadata as (
@@ -210,7 +296,7 @@ google_books_traffic_metadata as (
 # JSTOR
 jstor_country_metrics as (
     SELECT
-        eISBN as ISBN13, release_date, ARRAY_AGG(STRUCT(Country_name, Total_Item_Requests)) as metrics
+        eISBN as ISBN13, release_date, group_items_jstor_country(ARRAY_AGG(STRUCT(Country_name, Total_Item_Requests))) as metrics
     FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_country_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_country {% endif %} as jstor_country
     GROUP BY eISBN, release_date
 ),
@@ -224,7 +310,7 @@ jstor_country_metadata as (
 
 jstor_institution_metrics as (
     SELECT
-        eISBN as ISBN13, release_date, ARRAY_AGG(STRUCT(Institution, Total_Item_Requests)) as metrics
+        eISBN as ISBN13, release_date, group_items_jstor_institution(ARRAY_AGG(STRUCT(Institution, Total_Item_Requests))) as metrics
     FROM {% if jstor %} `{{ project_id }}.{{ dataset_id }}.{{ jstor_dataset }}_jstor_institution_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_jstor_institution {% endif %} as jstor_institution
     GROUP BY eISBN, release_date
 ),
@@ -239,8 +325,9 @@ jstor_institution_metadata as (
 # OAPEN IRUS UK
 oapen_irus_uk_metrics as (
     SELECT
-        ISBN as ISBN13, release_date, STRUCT(version, title_requests, total_item_investigations, total_item_requests, unique_item_investigations, unique_item_requests, country, locations) as metrics
+        ISBN as ISBN13, release_date, STRUCT(MAX(version) as version, SUM(title_requests) as title_requests, SUM(total_item_investigations) as total_item_investigations, SUM(total_item_requests) as total_item_requests, SUM(unique_item_investigations) as unique_item_investigations, SUM(unique_item_requests) as unique_item_requests, group_items_irus_country(ARRAY_CONCAT_AGG(country)) as country, group_items_irus_location(ARRAY_CONCAT_AGG(locations)) as locations) as metrics
     FROM {% if oapen %} `{{ project_id }}.{{ dataset_id }}.{{ oapen_dataset }}_oapen_irus_uk_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_oapen {% endif %} as oapen_irus_uk
+    GROUP BY ISBN, release_date
 ),
 
 oapen_irus_uk_metadata as (
@@ -253,7 +340,7 @@ oapen_irus_uk_metadata as (
 # UCL Discovery
 ucl_discovery_metrics as (
     SELECT
-        isbn as ISBN13, release_date, STRUCT(SUM(total_downloads) as total_downloads, ARRAY_CONCAT_AGG(downloads_per_country) as downloads_per_country ) as metrics
+        isbn as ISBN13, release_date, STRUCT(SUM(total_downloads) as total_downloads, group_items_ucl_country(ARRAY_CONCAT_AGG(downloads_per_country)) as downloads_per_country ) as metrics
     FROM {% if ucl %} `{{ project_id }}.{{ dataset_id }}.{{ ucl_dataset }}_ucl_discovery_matched{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_ucl_discovery {% endif %} as ucl_discovery
     WHERE isbn IS NOT NULL
     GROUP BY isbn, release_date
@@ -325,8 +412,8 @@ metrics as (
 SELECT
     onix_ebook_titles.*, empty_work_ids.work_id, empty_work_family_ids.work_family_id, STRUCT(crossref_objects, chapters, events.overall as events, google_books_sales_metadata as google_books_sales, google_books_traffic_metadata as google_books_traffic, jstor_country_metadata as jstor_metadata, jstor_institution_metadata as jstor_institution_metadata, oapen_irus_uk_metadata as oapen_irus_uk_metadata) as metadata, metrics.months
 FROM onix_ebook_titles
-LEFT JOIN {% if onix_workflow %} `{{ project_id }}.{{ dataset_id }}.onix_workid_isbn{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_work_ids {% endif %} as empty_work_ids on empty_work_ids.isbn13 = onix_ebook_titles.isbn13
-LEFT JOIN {% if onix_workflow %} `{{ project_id }}.{{ dataset_id }}.onix_workfamilyid_isbn{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_work_family_ids {% endif %} as empty_work_family_ids on empty_work_family_ids.isbn13 = onix_ebook_titles.isbn13
+LEFT JOIN {% if onix_workflow %} `{{ project_id }}.{{ onix_workflow_dataset }}.onix_workid_isbn{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_work_ids {% endif %} as empty_work_ids on empty_work_ids.isbn13 = onix_ebook_titles.isbn13
+LEFT JOIN {% if onix_workflow %} `{{ project_id }}.{{ onix_workflow_dataset }}.onix_workfamilyid_isbn{{ release_date.strftime('%Y%m%d') }}` {% else %} empty_work_family_ids {% endif %} as empty_work_family_ids on empty_work_family_ids.isbn13 = onix_ebook_titles.isbn13
 LEFT JOIN metrics as metrics on metrics.ISBN13 = onix_ebook_titles.ISBN13
 LEFT JOIN google_books_sales_metadata on google_books_sales_metadata.ISBN13  = onix_ebook_titles.ISBN13
 LEFT JOIN google_books_traffic_metadata on google_books_traffic_metadata.ISBN13  = onix_ebook_titles.ISBN13

--- a/observatory-dags/observatory/dags/database/sql/create_mock_onix_data.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/create_mock_onix_data.sql.jinja2
@@ -1,0 +1,64 @@
+{# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Richard Hosking #}
+
+SELECT
+    oapen.identifier.isbn as ISBN13,
+    oapen.identifier.doi as Doi,
+    "Digital download and online" as ProductForm,
+    CAST(NULL as STRING) as EditionNumber,
+
+    [STRUCT(
+        [STRUCT(dc.title.value[SAFE_OFFSET(0)] as TitleText, dc.title.alternative as TitleWithoutPrefix)] as TitleElements,
+        CAST(NULL as STRING) as TitleType,
+        CAST(NULL as STRING) as TitleStatement
+    )] as TitleDetails,
+
+    ARRAY(
+        SELECT AS STRUCT
+            "Publication date" as PublishingDateRole,
+            CAST(FORMAT_DATETIME("%Y%m%d", published) as INT64) as `Date`
+        FROM UNNEST(dc.date.issued) as published
+    )  as PublishingDates,
+
+    ARRAY_CONCAT(
+        ARRAY(
+            SELECT AS STRUCT
+                "BIC_subject_category" as SubjectSchemeIdentifier,
+                code as SubjectCode,
+                ARRAY<STRING>[] as SubjectHeadingText
+            FROM UNNEST(dc.subject.classification_code) as code
+        ),
+        ARRAY(
+            SELECT AS STRUCT
+                "Keywords" as SubjectSchemeIdentifier,
+                CAST(NULL as STRING) as SubjectCode,
+                IF(
+                    ARRAY_TO_STRING(ARRAY_AGG(code), '; ') IS NOT NULL,
+                    [ARRAY_TO_STRING(ARRAY_AGG(code), '; ')],
+                    ARRAY<STRING>[]
+                ) as SubjectHeadingText
+            FROM UNNEST(dc.subject.other) as code
+        )
+    ) as Subjects,
+
+    ARRAY(
+        SELECT AS STRUCT
+            SPLIT(author, '::')[SAFE_OFFSET(0)] as PersonName,
+            SPLIT(author, '::')[SAFE_OFFSET(1)] as ORCID
+        FROM UNNEST(dc.contributor.author) as author
+    )  as Contributors,
+
+FROM `{{ project_id }}.{{ dataset_id }}.{{ table_id }}` as onix

--- a/observatory-dags/observatory/dags/database/sql/export_book_list.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_list.sql.jinja2
@@ -16,6 +16,8 @@
 
 SELECT
     ISBN13 as product_id,
+    work_id,
+    work_family_id,
     onix.ProductForm,
     onix.EditionNumber,
     DATE(CAST(onix.published_year as INT64), 12, 31) AS time_field,

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics.sql.jinja2
@@ -15,7 +15,9 @@
 # Author: Richard Hosking #}
 
 SELECT
-    ISBN13,
+    ISBN13 as product_id,
+    work_id,
+    work_family_id,
     onix.title as title,
     CAST(onix.published_year as INT64) as published_year,
     month.month,

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics.sql.jinja2
@@ -32,5 +32,6 @@ SELECT
         month.oapen_irus_uk.unique_item_investigations,
         month.oapen_irus_uk.unique_item_requests
     ) as oapen_irus_uk,
+    STRUCT(month.ucl_discovery.total_downloads) as ucl_discovery
 FROM `{{ project_id }}.{{ dataset_id }}.book_product{{ release.strftime('%Y%m%d') }}`, UNNEST(months) as month
 WHERE month.oapen_irus_uk IS NOT NULL OR month.google_books_traffic IS NOT NULL OR month.google_books_sales IS NOT NULL

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics_city.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics_city.sql.jinja2
@@ -16,6 +16,8 @@
 
 SELECT
     ISBN13 as product_id,
+    MAX(work_id) as work_id,
+    MAX(work_family_id) as work_family_id,
     MAX(onix.title) as title,
     CAST(MAX(onix.published_year) as INT64) as published_year,
     month.month,

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics_country.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics_country.sql.jinja2
@@ -16,6 +16,8 @@
 
 WITH months as (SELECT
     ISBN13,
+    work_id,
+    work_family_id,
     onix.title as title,
     CAST(onix.published_year as INT64) as published_year,
     month.month,
@@ -36,6 +38,8 @@ countries as (
 month_country as (
     SELECT
         ISBN13,
+        work_id,
+        work_family_id,
         title,
         published_year,
         month,
@@ -81,7 +85,7 @@ google_analytics_month_country as (
         value
     FROM months, UNNEST(google_analytics)) as google
     LEFT JOIN `academic-observatory.settings.country_to_alpha2` as country_code on country_code.country_name = google.country_name
-)
+),
 
 ucl_discovery_month_country as (
     SELECT
@@ -95,6 +99,8 @@ ucl_discovery_month_country as (
 
 SELECT
     month_country.ISBN13 as product_id,
+    month_country.work_id as work_id,
+    month_country.work_family_id as work_family_id,
     month_country.title,
     month_country.published_year,
     month_country.month,

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics_country.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics_country.sql.jinja2
@@ -22,7 +22,7 @@ WITH months as (SELECT
     CAST(onix.published_year as INT64) as published_year,
     month.month,
     month.jstor_country as jstor,
-    month.oapen_irus_uk.locations as oapen_irus_uk,
+    month.oapen_irus_uk.country as oapen_irus_uk,
     month.google_analytics.unique_views.country as google_analytics,
     month.ucl_discovery.downloads_per_country as ucl_discovery
 FROM `{{ project_id }}.{{ dataset_id }}.book_product{{ release.strftime('%Y%m%d') }}`, UNNEST(months) as month
@@ -62,7 +62,7 @@ oapen_month_country as (
     SELECT
         ISBN13,
         month,
-        country_code as alpha2,
+        code as alpha2,
         title_requests,
         total_item_investigations,
         total_item_requests,

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics_country.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics_country.sql.jinja2
@@ -21,9 +21,10 @@ WITH months as (SELECT
     month.month,
     month.jstor_country as jstor,
     month.oapen_irus_uk.locations as oapen_irus_uk,
-    month.google_analytics.unique_views.country as google_analytics
+    month.google_analytics.unique_views.country as google_analytics,
+    month.ucl_discovery.downloads_per_country as ucl_discovery
 FROM `{{ project_id }}.{{ dataset_id }}.book_product{{ release.strftime('%Y%m%d') }}`, UNNEST(months) as month
-WHERE ISBN13 is not null AND month.month is not null AND (month.jstor_country IS NOT NULL OR month.oapen_irus_uk.locations IS NOT NULL)),
+WHERE ISBN13 is not null AND month.month is not null AND (month.jstor_country IS NOT NULL OR month.oapen_irus_uk.locations IS NOT NULL OR month.ucl_discovery.downloads_per_country IS NOT NULL)),
 
 countries as (
     SELECT
@@ -73,6 +74,16 @@ google_analytics_month_country as (
         name as country_name,
         value
     FROM months, UNNEST(google_analytics)
+),
+
+ucl_discovery_month_country as (
+    SELECT
+        ISBN13,
+        month,
+        country_name,
+        country_code as alpha2,
+        download_count
+    FROM months, UNNEST(ucl_discovery)
 )
 
 SELECT
@@ -84,9 +95,11 @@ SELECT
     month_country.country_name,
     STRUCT(jstor.Total_Item_Requests) as jstor,
     STRUCT(oapen.title_requests, oapen.total_item_investigations, oapen.total_item_requests, oapen.unique_item_investigations, oapen.unique_item_requests) as oapen_irus_uk,
-    STRUCT(google.value as value) as google_analytics
+    STRUCT(google.value as value) as google_analytics,
+    STRUCT(ucl_discovery.download_count as download_count) as ucl_discovery
 FROM month_country
 LEFT JOIN jstor_month_country as jstor ON month_country.ISBN13 = jstor.ISBN13 AND month_country.month = jstor.month AND month_country.alpha2 = jstor.alpha2
 LEFT JOIN oapen_month_country as oapen ON month_country.ISBN13 = oapen.ISBN13 AND month_country.month = oapen.month AND month_country.alpha2 = oapen.alpha2
 LEFT JOIN google_analytics_month_country as google ON month_country.ISBN13 = google.ISBN13 AND month_country.month = google.month AND UPPER(month_country.country_name) = UPPER(google.country_name)
+LEFT JOIN ucl_discovery_month_country as ucl_discovery ON month_country.ISBN13 = ucl_discovery.ISBN13 AND month_country.month = ucl_discovery.month AND month_country.alpha2 = ucl_discovery.alpha2
 WHERE jstor.total_item_requests IS NOT NULL OR oapen.title_requests IS NOT NULL OR 	oapen.total_item_requests IS NOT NULL or google.value IS NOT NULL

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics_country.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics_country.sql.jinja2
@@ -71,10 +71,17 @@ google_analytics_month_country as (
     SELECT
         ISBN13,
         month,
+        google.country_name,
+        country_code.country_code,
+        value
+    FROM (SELECT
+        ISBN13,
+        month,
         name as country_name,
         value
-    FROM months, UNNEST(google_analytics)
-),
+    FROM months, UNNEST(google_analytics)) as google
+    LEFT JOIN `academic-observatory.settings.country_to_alpha2` as country_code on country_code.country_name = google.country_name
+)
 
 ucl_discovery_month_country as (
     SELECT
@@ -100,6 +107,6 @@ SELECT
 FROM month_country
 LEFT JOIN jstor_month_country as jstor ON month_country.ISBN13 = jstor.ISBN13 AND month_country.month = jstor.month AND month_country.alpha2 = jstor.alpha2
 LEFT JOIN oapen_month_country as oapen ON month_country.ISBN13 = oapen.ISBN13 AND month_country.month = oapen.month AND month_country.alpha2 = oapen.alpha2
-LEFT JOIN google_analytics_month_country as google ON month_country.ISBN13 = google.ISBN13 AND month_country.month = google.month AND UPPER(month_country.country_name) = UPPER(google.country_name)
+LEFT JOIN google_analytics_month_country as google ON month_country.ISBN13 = google.ISBN13 AND month_country.month = google.month AND month_country.alpha2 = google.country_code
 LEFT JOIN ucl_discovery_month_country as ucl_discovery ON month_country.ISBN13 = ucl_discovery.ISBN13 AND month_country.month = ucl_discovery.month AND month_country.alpha2 = ucl_discovery.alpha2
 WHERE jstor.total_item_requests IS NOT NULL OR oapen.title_requests IS NOT NULL OR 	oapen.total_item_requests IS NOT NULL or google.value IS NOT NULL

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics_event.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics_event.sql.jinja2
@@ -16,6 +16,8 @@
 
 SELECT
     ISBN13 as product_id,
+    MAX(work_id) as work_id,
+    MAX(work_family_id) as work_family_id,
     MAX(onix.title) as title,
     CAST(MAX(onix.published_year) as INT64) as published_year,
     month.month,

--- a/observatory-dags/observatory/dags/database/sql/export_book_metrics_referrer.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_book_metrics_referrer.sql.jinja2
@@ -16,6 +16,8 @@
 
 SELECT
     ISBN13 as product_id,
+    MAX(work_id) as work_id,
+    MAX(work_family_id) as work_family_id,
     MAX(onix.title) as title,
     CAST(MAX(onix.published_year) as INT64) as published_year,
     month.month,

--- a/observatory-dags/observatory/dags/database/sql/export_unmatched_metrics.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/export_unmatched_metrics.sql.jinja2
@@ -18,12 +18,14 @@ WITH google_analytics as (
     {% if google_analytics %}
     SELECT
         {{ google_analytics_isbn }} as ISBN,
+        title,
         release_date,
         "google_analytics" as source
     FROM `{{ project_id }}.{{ dataset_id }}.{{ google_analytics_table }}_unmatched_{{ google_analytics_isbn }}{{ release.strftime('%Y%m%d') }}`
     {% else %}
     SELECT
         CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
         CAST(NULL as DATE) as release_date,
         "google_analytics" as source
     {% endif %}
@@ -33,12 +35,14 @@ google_books as (
     {% if google_books %}
     SELECT
         {{ google_books_isbn }} as ISBN,
+        title,
         release_date,
         "google_books" as source
     FROM `{{ project_id }}.{{ dataset_id }}.{{ google_books_table }}_unmatched_{{ google_books_isbn }}{{ release.strftime('%Y%m%d') }}`
     {% else %}
     SELECT
         CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
         CAST(NULL as DATE) as release_date,
         "google_books" as source
     {% endif %}
@@ -48,12 +52,14 @@ jstor as (
     {% if jstor %}
     SELECT
         {{ jstor_isbn }} as ISBN,
+        title,
         release_date,
         "jstor" as source
     FROM `{{ project_id }}.{{ dataset_id }}.{{ jstor_table }}_unmatched_{{ jstor_isbn }}{{ release.strftime('%Y%m%d') }}`
     {% else %}
     SELECT
         CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
         CAST(NULL as DATE) as release_date,
         "jstor" as source
     {% endif %}
@@ -63,12 +69,14 @@ oapen as (
     {% if oapen %}
     SELECT
         {{ oapen_isbn }} as ISBN,
+        title,
         release_date,
         "oapen" as source
     FROM `{{ project_id }}.{{ dataset_id }}.{{ oapen_table }}_unmatched_{{ oapen_isbn }}{{ release.strftime('%Y%m%d') }}`
     {% else %}
     SELECT
         CAST(NULL as STRING) as ISBN,
+        CAST(NULL as STRING) as title,
         CAST(NULL as DATE) as release_date,
         "oapen" as source
     {% endif %}
@@ -87,6 +95,10 @@ SELECT * FROM oapen
 SELECT
     ISBN,
     release_date,
+    ARRAY_AGG(DISTINCT IF(source = "google_analytics", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as google_analytics_title,
+    ARRAY_AGG(DISTINCT IF(source = "google_books", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as google_books_title,
+    ARRAY_AGG(DISTINCT IF(source = "jstor", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as jstor_title,
+    ARRAY_AGG(DISTINCT IF(source = "oapen", title, NULL) IGNORE NULLS LIMIT 1)[SAFE_OFFSET(0)] as oapen_title,
     "google_analytics" in UNNEST(ARRAY_AGG(source)) as in_google_analytics,
     "google_books" in UNNEST(ARRAY_AGG(source)) as in_google_books,
     "jstor" in UNNEST(ARRAY_AGG(source)) as in_jstor,

--- a/observatory-dags/observatory/dags/database/sql/oaebu_intermediate_metrics.sql.jinja2
+++ b/observatory-dags/observatory/dags/database/sql/oaebu_intermediate_metrics.sql.jinja2
@@ -16,6 +16,7 @@
 
 SELECT
   {{ isbn }},
+  {{ title }} as title,
   release_date
 FROM
   `{{ project_id }}.{{ dataset_id }}.{{ table_id }}`

--- a/observatory-dags/observatory/dags/workflows/oaebu_partners.py
+++ b/observatory-dags/observatory/dags/workflows/oaebu_partners.py
@@ -41,6 +41,7 @@ class OaebuPartners:
     :param gcp_dataset_id: GCP Dataset ID.
     :param gcp_table_id: Table name without the date suffix.
     :param isbn_field_name: Name of the field containing the ISBN.
+    :param title_field_name: Name of the field containing the Title.
     :param sharded: whether the table is sharded or not.
     """
 
@@ -50,4 +51,5 @@ class OaebuPartners:
     gcp_dataset_id: str
     gcp_table_id: str
     isbn_field_name: str
+    title_field_name: str
     sharded: bool

--- a/observatory-dags/observatory/dags/workflows/oapen_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/oapen_workflow.py
@@ -313,11 +313,12 @@ class OapenWorkflow(Workflow):
 
         source_table_id = f"{release.gcp_project_id}.{release.irus_uk_dataset_id}.{release.irus_uk_table_id}"
         destination_table_id = f"{release.gcp_project_id}.{release.oaebu_intermediate_dataset}.{release.irus_uk_dataset_id}_{bigquery_sharded_table_id('oapen_irus_uk_matched', release.release_date)}"
-        success = copy_bigquery_table(source_table_id, destination_table_id, release.dataset_location)
+        status = copy_bigquery_table(source_table_id, destination_table_id, release.dataset_location)
 
-        if not success:
-            logging.error(f"Issue copying table: {source_table_id} to {destination_table_id}")
-
+        if not status:
+            raise AirflowException(
+                f"Issue copying table: {source_table_id} to {destination_table_id}"
+            )
 
     def create_onix_formatted_metadata_output_tasks(
             self,

--- a/observatory-dags/observatory/dags/workflows/oapen_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/oapen_workflow.py
@@ -408,6 +408,7 @@ class OapenWorkflow(Telescope):
             jstor=False,
             oapen=True,
             ucl=False,
+            onix_workflow=False,
             google_analytics_dataset='',
             google_books_dataset='',
             jstor_dataset='',

--- a/observatory-dags/observatory/dags/workflows/oapen_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/oapen_workflow.py
@@ -1,0 +1,554 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Author: Richard Hosking & Tuan Chien
+
+import os
+import shutil
+from functools import partial, update_wrapper
+from pathlib import Path
+from typing import List, Optional
+
+import pendulum
+from airflow.exceptions import AirflowException
+from airflow.sensors.external_task import ExternalTaskSensor
+from google.cloud.bigquery import SourceFormat
+from observatory.dags.config import workflow_sql_templates_path
+
+from observatory.dags.workflows.oaebu_partners import OaebuPartnerName, OaebuPartners
+from observatory.platform.telescopes.telescope import AbstractRelease, Telescope
+from observatory.platform.utils.file_utils import list_to_jsonl_gz
+from observatory.platform.utils.gc_utils import (
+    bigquery_sharded_table_id,
+    create_bigquery_dataset,
+    create_bigquery_table_from_query,
+    run_bigquery_query,
+    select_table_shard_dates,
+    upload_files_to_cloud_storage,
+    copy_bigquery_table
+)
+from observatory.platform.utils.jinja2_utils import render_template
+from observatory.platform.utils.telescope_utils import make_dag_id
+from observatory.platform.utils.template_utils import (
+    bq_load_shard_v2,
+    table_ids_from_path,
+)
+
+
+class OapenWorkflowRelease(AbstractRelease):
+    """
+    Release information for OapenWorkflow.
+    """
+
+    def __init__(
+        self,
+        *,
+        dag_id: str,
+        release_date: pendulum.DateTime,
+        gcp_project_id: str,
+        ao_gcp_project_id: str = "academic-observatory",
+        oapen_metadata_dataset_id: str = "oapen",
+        oapen_metadata_table_id: str = "metadata",
+        public_book_metadata_dataset_id: str = "observatory",
+        public_book_metadata_table_id: str = "book",
+        irus_uk_dag_id_prefix: str = "oapen_irus_uk",
+        irus_uk_dataset_id: str = "oapen",
+        irus_uk_table_id: str = "oapen_irus_uk",
+        oaebu_dataset: str = "oaebu",
+        oaebu_onix_dataset: str = "oapen_onix",
+        oaebu_intermediate_dataset: str = "oaebu_intermediate",
+        oaebu_elastic_dataset: str = "data_export",
+        dataset_location: str = "us",
+        dataset_description: str = "Oapen workflow tables",
+    ):
+        """
+        :param dag_id: DAG ID.
+        :param release_date: The release date. It's the current execution date.
+        :param oapen_release_date: the OAPEN release date.
+        :param gcp_project_id: GCP Project ID.
+        :param ao_gcp_project_id: GCP project ID for the Academic Observatory.
+        :param oapen_metadata_dataset_id: GCP dataset ID for the oapen data.
+        :param oapen_metadata_table_id: GCP table ID for the oapen data.
+        :param public_book_dataset_id: GCP dataset ID for the public book data.
+        :param public_book_table_id: GCP table ID for the public book data.
+        :param irus_uk_dag_id_prefix: OAEBU IRUS_UK dag id prefix.
+        :param irus_uk_dataset_id: OAEBU IRUS_UK dataset id.
+        :param irus_uk_table_id: OAEBU IRUS_UK table id.
+        :param oaebu_dataset: OAEBU dataset.
+        :param oaebu_intermediate_dataset: OAEBU intermediate dataset.
+        :param oaebu_elastic_dataset: OAEBU elastic dataset.
+        """
+
+        self.dag_id = dag_id
+        self.release_date = release_date
+
+        # GCP parameters for oaebu_oapen project
+        self.gcp_project_id = gcp_project_id
+        self.dataset_location = dataset_location
+        self.dataset_description = dataset_description
+
+        self.oaebu_dataset = oaebu_dataset
+        self.oaebu_onix_dataset = oaebu_onix_dataset
+        self.oaebu_intermediate_dataset = oaebu_intermediate_dataset
+        self.oaebu_elastic_dataset = oaebu_elastic_dataset
+
+        # Academic Observatory Reference
+        self.ao_gcp_project_id = ao_gcp_project_id
+
+        # OAPEN Metadata
+        self.oapen_metadata_dataset_id = oapen_metadata_dataset_id
+        self.oapen_metadata_table_id = oapen_metadata_table_id
+
+        # Public Book Data
+        self.public_book_metadata_dataset_id = public_book_metadata_dataset_id
+        self.public_book_metadata_table_id = public_book_metadata_table_id
+
+        # IRUS-UK
+        self.irus_uk_dag_id_prefix = irus_uk_dag_id_prefix
+        self.irus_uk_dataset_id = irus_uk_dataset_id
+        self.irus_uk_table_id = irus_uk_table_id
+
+
+    @property
+    def transform_bucket(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    @property
+    def transform_folder(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    @property
+    def transform_files(self) -> List[str]:
+        """Not used.
+        :return: Empty list.
+        """
+        return list()
+
+    @property
+    def download_bucket(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    @property
+    def download_files(self) -> List[str]:
+        """Not used.
+        :return: Empty list.
+        """
+        return list()
+
+    @property
+    def extract_files(self) -> List[str]:
+        """Not used.
+        :return: Empty list.
+        """
+        return list()
+
+    @property
+    def download_folder(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    @property
+    def extract_folder(self) -> str:
+        """Not used.
+        :return: Empty string.
+        """
+        return str()
+
+    def cleanup(self):
+        """Delete all files and folders associated with this release.
+        :return: None.
+        """
+        pass
+
+
+def make_table_id(*, project_id: str, dataset_id: str, table_id: str, end_date: pendulum.datetime, sharded: bool):
+    """
+    Make a BQ table ID.
+    :param project_id: GCP Project ID.
+    :param dataset_id: GCP Dataset ID.
+    :param table_id: Table name to convert to the suitable BQ table ID.
+    :param end_date: Latest date considered.
+    :param sharded: whether the table is sharded or not.
+    """
+
+    new_table_id = table_id
+    if sharded:
+        table_date = select_table_shard_dates(
+            project_id=project_id,
+            dataset_id=dataset_id,
+            table_id=table_id,
+            end_date=end_date,
+        )[0]
+        new_table_id = f"{table_id}{table_date.strftime('%Y%m%d')}"
+
+    return new_table_id
+
+
+class OapenWorkflow(Telescope):
+    """
+    Workflow for processing the OAPEN metadata and IRUS-UK metrics data
+    """
+
+    DAG_ID_PREFIX = "oapen_workflow"
+
+    def __init__(
+        self,
+        *,
+        org_name: str,
+        gcp_project_id: str,
+        irus_uk_dag_id_prefix: str = "oapen_irus_uk",
+        dag_id: Optional[str] = None,
+        start_date: Optional[pendulum.datetime] = pendulum.datetime(2021, 3, 28),
+        schedule_interval: Optional[str] = "@weekly",
+        catchup: Optional[bool] = False,
+    ):
+        """Initialises the workflow object.
+        :param org_name: Organisation name.
+        :param gcp_project_id: Project ID in GCP.
+        :param gcp_dataset_id: Dataset ID in GCP.
+        :param irus_uk_dag_id_prefix: OAEBU IRUS_UK dag id prefix.
+        :param dag_id: DAG ID.
+        :param start_date: Start date of the DAG.
+        :param schedule_interval: Scheduled interval for running the DAG.
+        :param catchup: Whether to catch up missed DAG runs.
+        """
+
+        self.dag_id = dag_id
+        if dag_id is None:
+            self.dag_id = make_dag_id(self.DAG_ID_PREFIX, org_name)
+
+        self.org_name = org_name
+        self.gcp_project_id = gcp_project_id
+        self.irus_uk_dag_id_prefix = irus_uk_dag_id_prefix
+
+        # Initialise Telesecope base class
+        super().__init__(
+            dag_id=self.dag_id, start_date=start_date, schedule_interval=schedule_interval, catchup=catchup
+        )
+
+        # Wait for irus_uk workflow to finish
+        ext_dag_id = make_dag_id(irus_uk_dag_id_prefix, org_name)
+        sensor = ExternalTaskSensor(task_id=f"{ext_dag_id}_sensor", external_dag_id=ext_dag_id, mode="reschedule")
+        self.add_sensor(sensor)
+
+        # Format OAPEN Metadata like ONIX to enable the next steps
+        self.add_task(
+            self.create_onix_formatted_metadata_output_tasks,
+            task_id="create_onix_formatted_metadata_output_tasks"
+        )
+
+        # Copy IRUS-UK data and add release date
+        self.add_task(
+            self.copy_irus_uk_release,
+            task_id="copy_irus_uk_release"
+        )
+
+        # Create OAEBU book product table
+        self.add_task(
+            self.create_oaebu_book_product_table,
+            task_id="create_oaebu_book_product_table"
+        )
+
+        # Create OAEBU Elastic Export tables
+        self.create_oaebu_export_tasks()
+
+        # Cleanup tasks
+        self.add_task(self.cleanup)
+
+
+    def make_release(self, **kwargs) -> OapenWorkflowRelease:
+        """Creates a release object.
+        :param kwargs: From Airflow. Contains the execution_date.
+        :return: an OapenWorkflowRelease object.
+        """
+
+        # Make release date
+        release_date = kwargs["next_execution_date"].subtract(microseconds=1).date()
+
+        return OapenWorkflowRelease(
+            dag_id=self.dag_id,
+            release_date=release_date,
+            gcp_project_id=self.gcp_project_id,
+        )
+
+
+    def cleanup(self, release: OapenWorkflowRelease, **kwargs):
+        """Cleanup temporary files.
+
+        :param release: Workflow release objects.
+        :param kwargs: Unused.
+        """
+
+        release.cleanup()
+
+
+    def copy_irus_uk_release(
+            self,
+            release: OapenWorkflowRelease,
+            **kwargs,
+    ):
+        """Copy state of the oapen-irus-uk dataset and create a labled release
+        :param release: Oapen workflow release information.
+        """
+
+        source_table_id = f"{release.gcp_project_id}.{release.irus_uk_dataset_id}.{release.irus_uk_table_id}"
+        destination_table_id = f"{release.gcp_project_id}.{release.oaebu_intermediate_dataset}.{release.irus_uk_dataset_id}_{bigquery_sharded_table_id('oapen_irus_uk_matched', release.release_date)}"
+        success = copy_bigquery_table(source_table_id, destination_table_id, release.dataset_location)
+
+        if not success:
+            logging.error(f"Issue copying table: {source_table_id} to {destination_table_id}")
+
+
+    def create_onix_formatted_metadata_output_tasks(
+            self,
+            release: OapenWorkflowRelease,
+            **kwargs,
+    ):
+        """Create the Book Product Table
+        :param release: Oapen workflow release information.
+        """
+
+        output_dataset = release.oaebu_onix_dataset
+        data_location = release.dataset_location
+        project_id = release.gcp_project_id
+
+        output_table = "onix"
+        release_date = release.release_date
+        table_id = bigquery_sharded_table_id(output_table, release_date)
+
+        # SQL reference
+        table_joining_template_file = "create_mock_onix_data.sql.jinja2"
+        template_path = os.path.join(workflow_sql_templates_path(), table_joining_template_file)
+
+        sql = render_template(
+            template_path,
+            project_id=release.ao_gcp_project_id,
+            dataset_id=release.oapen_metadata_dataset_id,
+            table_id=release.oapen_metadata_table_id,
+        )
+
+        create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)
+
+        status = create_bigquery_table_from_query(
+            sql=sql,
+            project_id=project_id,
+            dataset_id=output_dataset,
+            table_id=table_id,
+            location=data_location,
+        )
+
+        if not status:
+            raise AirflowException(
+                f"create_bigquery_table_from_query failed on {project_id}.{output_dataset}.{table_id}"
+            )
+
+
+    def create_oaebu_book_product_table(
+        self,
+        release: OapenWorkflowRelease,
+        **kwargs,
+    ):
+        """Create the Book Product Table
+        :param release: Oapen workflow release information.
+        :param oapen_dataset: dataset_id if it is  a relevant data source for this publisher
+        """
+
+        output_table = "book_product"
+        output_dataset = release.oaebu_dataset
+        project_id = release.gcp_project_id
+
+        data_location = release.dataset_location
+        release_date = release.release_date
+
+        table_joining_template_file = "create_book_products.sql.jinja2"
+        template_path = os.path.join(workflow_sql_templates_path(), table_joining_template_file)
+
+        table_id = bigquery_sharded_table_id(output_table, release_date)
+
+        # Identify latest Book release from the Academic Observatory
+        public_book_release_date = select_table_shard_dates(
+            project_id=release.ao_gcp_project_id,
+            dataset_id=release.public_book_metadata_dataset_id,
+            table_id=release.public_book_metadata_table_id,
+            end_date=release.release_date,
+        )[0]
+
+        sql = render_template(
+            template_path,
+            project_id=project_id,
+            onix_dataset_id=release.oaebu_onix_dataset,
+            dataset_id=release.oaebu_intermediate_dataset,
+            release_date=release_date,
+            onix_release_date=release_date,
+            google_analytics=False,
+            google_books=False,
+            jstor=False,
+            oapen=True,
+            ucl=False,
+            google_analytics_dataset='',
+            google_books_dataset='',
+            jstor_dataset='',
+            oapen_dataset=release.irus_uk_dataset_id,
+            ucl_dataset='',
+            public_book_release_date=public_book_release_date,
+        )
+
+        create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)
+
+        status = create_bigquery_table_from_query(
+            sql=sql,
+            project_id=project_id,
+            dataset_id=output_dataset,
+            table_id=table_id,
+            location=data_location,
+        )
+
+        if not status:
+            raise AirflowException(
+                f"create_bigquery_table_from_query failed on {project_id}.{output_dataset}.{table_id}"
+            )
+
+
+    def export_oaebu_table(
+        self,
+        release: OapenWorkflowRelease,
+        *,
+        output_table: str,
+        query_template: str,
+        **kwargs,
+    ):
+        """Create an exported oaebu table.
+        :param release: Oapen workflow release information.
+        """
+
+        project_id = release.gcp_project_id
+        output_dataset = release.oaebu_elastic_dataset
+        data_location = release.dataset_location
+        release_date = release.release_date
+
+        create_bigquery_dataset(project_id=project_id, dataset_id=output_dataset, location=data_location)
+
+        table_id = bigquery_sharded_table_id(f"{project_id.replace('-', '_')}_{output_table}", release_date)
+        template_path = os.path.join(workflow_sql_templates_path(), query_template)
+
+        sql = render_template(
+            template_path,
+            project_id=project_id,
+            dataset_id=release.oaebu_dataset,
+            release=release_date,
+        )
+
+        status = create_bigquery_table_from_query(
+            sql=sql,
+            project_id=project_id,
+            dataset_id=output_dataset,
+            table_id=table_id,
+            location=data_location,
+        )
+
+        if not status:
+            raise AirflowException(
+                f"create_bigquery_table_from_query failed on {project_id}.{output_dataset}.{table_id}"
+            )
+
+
+    def create_oaebu_export_tasks(self):
+        """Create tasks for exporting final metrics from our OAEBU data.  It will create output tables in the oaebu_elastic dataset.
+        :param data_partners: Oapen workflow release information.
+        """
+
+        export_tables = [
+            {"output_table": "book_product_list", "query_template": "export_book_list.sql.jinja2", "file_type": "json"},
+            {
+                "output_table": "book_product_metrics",
+                "query_template": "export_book_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_country",
+                "query_template": "export_book_metrics_country.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_institution",
+                "query_template": "export_book_metrics_institution.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_city",
+                "query_template": "export_book_metrics_city.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_referrer",
+                "query_template": "export_book_metrics_referrer.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_metrics_events",
+                "query_template": "export_book_metrics_event.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_publisher_metrics",
+                "query_template": "export_book_publisher_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_subject_metrics",
+                "query_template": "export_book_subject_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_year_metrics",
+                "query_template": "export_book_year_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_subject_year_metrics",
+                "query_template": "export_book_subject_year_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+            {
+                "output_table": "book_product_author_metrics",
+                "query_template": "export_book_author_metrics.sql.jinja2",
+                "file_type": "json",
+            },
+        ]
+
+        # Create each export table in BiqQuery
+        for export_table in export_tables:
+            fn = partial(
+                self.export_oaebu_table,
+                output_table=export_table["output_table"],
+                query_template=export_table["query_template"],
+            )
+
+            # Populate the __name__ attribute of the partial object (it lacks one by default).
+            update_wrapper(fn, self.export_oaebu_table)
+            fn.__name__ += f".{export_table['output_table']}"
+
+            self.add_task(fn)

--- a/observatory-dags/observatory/dags/workflows/onix_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/onix_workflow.py
@@ -1411,6 +1411,7 @@ class OnixWorkflow(Workflow):
             orig_dataset_id=data_partner.gcp_dataset_id,
             orig_table=data_partner.gcp_table_id,
             orig_isbn=data_partner.isbn_field_name,
+            orig_title=data_partner.title_field_name,
         )
 
         # Populate the __name__ attribute of the partial object (it lacks one by default).
@@ -1429,6 +1430,7 @@ class OnixWorkflow(Workflow):
         orig_dataset_id: str,
         orig_table: str,
         orig_isbn: str,
+        orig_title: str,
         *args,
         **kwargs,
     ):
@@ -1438,6 +1440,7 @@ class OnixWorkflow(Workflow):
         :param orig_dataset_id: Dataset ID of the original partner data.
         :param orig_table: Original table name for the partner data.
         :param orig_isbn: Name of the ISBN field we're checking.
+        :param orig_title: Name of the title field we're including.
         """
 
         template_file = "oaebu_intermediate_metrics.sql.jinja2"
@@ -1457,6 +1460,7 @@ class OnixWorkflow(Workflow):
             dataset_id=release.oaebu_intermediate_dataset,
             table_id=intermediate_table_id,
             isbn=orig_isbn,
+            title=orig_title,
         )
 
         create_bigquery_dataset(

--- a/observatory-dags/observatory/dags/workflows/onix_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/onix_workflow.py
@@ -637,6 +637,8 @@ class OnixWorkflow(Workflow):
             jstor=include_jstor,
             oapen=include_oapen,
             ucl=include_ucl,
+            onix_workflow=True,
+            onix_workflow_dataset=release.workflow_dataset,
             google_analytics_dataset=google_analytics_dataset,
             google_books_dataset=google_books_dataset,
             jstor_dataset=jstor_dataset,

--- a/observatory-dags/observatory/dags/workflows/onix_workflow.py
+++ b/observatory-dags/observatory/dags/workflows/onix_workflow.py
@@ -617,6 +617,14 @@ class OnixWorkflow(Workflow):
 
         table_id = bigquery_sharded_table_id(output_table, release_date)
 
+        # Identify latest Book release from the Academic Observatory
+        public_book_release_date = select_table_shard_dates(
+            project_id='academic-observatory',
+            dataset_id='observatory',
+            table_id='book',
+            end_date=release.release_date,
+        )[0]
+
         sql = render_template(
             template_path,
             project_id=release.project_id,
@@ -634,6 +642,7 @@ class OnixWorkflow(Workflow):
             jstor_dataset=jstor_dataset,
             oapen_dataset=oapen_dataset,
             ucl_dataset=ucl_dataset,
+            public_book_release_date=public_book_release_date,
         )
 
         create_bigquery_dataset(project_id=release.project_id, dataset_id=output_dataset, location=data_location)

--- a/tests/observatory/dags/workflows/test_oapen_workflow.py
+++ b/tests/observatory/dags/workflows/test_oapen_workflow.py
@@ -159,7 +159,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         self.timestamp = pendulum.now()
         self.oapen_table_id = "oapen"
 
-        self.data_location = os.getenv("TESTS_DATA_LOCATION")
+        self.data_location = os.getenv("TEST_DATA_LOCATION")
 
         self.ao_gcp_project_id = "academic-observatory"
         self.oapen_metadata_dataset_id = "oapen"
@@ -168,7 +168,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         self.public_book_metadata_table_id = "book"
 
         self.org_name = "OAPEN"
-        self.gcp_project_id = os.getenv("TESTS_GOOGLE_CLOUD_PROJECT_ID")
+        self.gcp_project_id = os.getenv("TEST_GOOGLE_CLOUD_PROJECT_ID")
 
         self.gcp_dataset_id = "oaebu"
         self.irus_uk_dag_id_prefix = "oapen_irus_uk"

--- a/tests/observatory/dags/workflows/test_oapen_workflow.py
+++ b/tests/observatory/dags/workflows/test_oapen_workflow.py
@@ -14,27 +14,23 @@
 
 # Author: Richard Hosking
 
-import hashlib
+
 import os
-import unittest
 from unittest.mock import MagicMock, patch
 
 import pendulum
 from click.testing import CliRunner
-
-from observatory.api.server.orm import Organisation
 
 from observatory.dags.workflows.oapen_workflow import OapenWorkflow, OapenWorkflowRelease
 
 from observatory.platform.utils.gc_utils import (
     run_bigquery_query,
 )
-from observatory.platform.utils.telescope_utils import make_dag_id
+from observatory.platform.utils.workflow_utils import make_dag_id
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     make_dummy_dag,
-    random_id,
 )
 
 

--- a/tests/observatory/dags/workflows/test_oapen_workflow.py
+++ b/tests/observatory/dags/workflows/test_oapen_workflow.py
@@ -168,7 +168,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         self.public_book_metadata_table_id = "book"
 
         self.org_name = "OAPEN"
-        self.gcp_project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.gcp_project_id = os.getenv("TESTS_GOOGLE_CLOUD_PROJECT_ID")
 
         self.gcp_dataset_id = "oaebu"
         self.irus_uk_dag_id_prefix = "oapen_irus_uk"

--- a/tests/observatory/dags/workflows/test_oapen_workflow.py
+++ b/tests/observatory/dags/workflows/test_oapen_workflow.py
@@ -159,7 +159,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         self.timestamp = pendulum.now()
         self.oapen_table_id = "oapen"
 
-        self.data_location = os.getenv("TEST_DATA_LOCATION")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
 
         self.ao_gcp_project_id = "academic-observatory"
         self.oapen_metadata_dataset_id = "oapen"
@@ -168,7 +168,7 @@ class TestOapenWorkflowFunctional(ObservatoryTestCase):
         self.public_book_metadata_table_id = "book"
 
         self.org_name = "OAPEN"
-        self.gcp_project_id = os.getenv("TEST_GOOGLE_CLOUD_PROJECT_ID")
+        self.gcp_project_id = os.getenv("TEST_GCP_PROJECT_ID")
 
         self.gcp_dataset_id = "oaebu"
         self.irus_uk_dag_id_prefix = "oapen_irus_uk"

--- a/tests/observatory/dags/workflows/test_oapen_workflow.py
+++ b/tests/observatory/dags/workflows/test_oapen_workflow.py
@@ -1,0 +1,337 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Richard Hosking
+
+import hashlib
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pendulum
+from click.testing import CliRunner
+
+from observatory.api.server.orm import Organisation
+
+from observatory.dags.workflows.oapen_workflow import OapenWorkflow, OapenWorkflowRelease
+
+from observatory.platform.utils.gc_utils import (
+    run_bigquery_query,
+)
+from observatory.platform.utils.telescope_utils import make_dag_id
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    make_dummy_dag,
+    random_id,
+)
+
+
+class TestOapenWorkflow(ObservatoryTestCase):
+    """
+    Test the OapenWorkflow class.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.org_name = "OAPEN"
+        self.gcp_project_id = "project_id"
+        self.data_location = os.getenv("TESTS_DATA_LOCATION")
+
+        # Release Object Defaults for reference
+        self.ao_gcp_project_id = "academic-observatory"
+        self.oapen_metadata_dataset_id = "oapen"
+        self.oapen_metadata_table_id = "metadata"
+        self.public_book_metadata_dataset_id = "observatory"
+        self.public_book_metadata_table_id = "book"
+        self.irus_uk_dag_id_prefix = "oapen_irus_uk"
+        self.irus_uk_dataset_id = "oapen"
+        self.irus_uk_table_id = "oapen_irus_uk"
+
+
+    @patch("observatory.dags.workflows.oapen_workflow.select_table_shard_dates")
+    def test_make_release(self, mock_sel_table_suffixes):
+        mock_sel_table_suffixes.return_value = [pendulum.datetime(2021, 1, 1)]
+
+        with CliRunner().isolated_filesystem():
+            wf = OapenWorkflow(
+                org_name=self.org_name,
+                gcp_project_id=self.gcp_project_id,
+            )
+
+            kwargs = {"next_execution_date": pendulum.datetime(2021, 2, 1)}
+            release = wf.make_release(**kwargs)
+            self.assertIsInstance(release, OapenWorkflowRelease)
+            self.assertEqual(release.dag_id, "oapen_workflow_oapen")
+            self.assertEqual(release.release_date, pendulum.date(2021, 1, 31))
+            self.assertEqual(release.gcp_project_id, "project_id")
+            self.assertEqual("academic-observatory", release.ao_gcp_project_id)
+            self.assertEqual("oapen", release.oapen_metadata_dataset_id)
+            self.assertEqual("metadata", release.oapen_metadata_table_id)
+            self.assertEqual("observatory", release.public_book_metadata_dataset_id)
+            self.assertEqual("book", release.public_book_metadata_table_id)
+
+
+    @patch("observatory.dags.workflows.oapen_workflow.OapenWorkflow.make_release")
+    @patch("observatory.dags.workflows.oapen_workflow.select_table_shard_dates")
+    def test_cleanup(self, mock_sel_table_suffixes, mock_mr):
+        mock_sel_table_suffixes.return_value = [pendulum.datetime(2021, 1, 1)]
+        with CliRunner().isolated_filesystem():
+            wf = OapenWorkflow(
+                org_name=self.org_name,
+                gcp_project_id=self.gcp_project_id,
+            )
+
+            mock_mr.return_value = OapenWorkflowRelease(
+                dag_id="oapen_workflow_test",
+                release_date=pendulum.datetime(2021, 1, 1),
+                gcp_project_id=self.gcp_project_id,
+                oapen_metadata_dataset_id="oapen",
+                oapen_metadata_table_id="metadata",
+            )
+
+            release = wf.make_release(execution_date=pendulum.datetime(2021, 1, 1))
+            wf.cleanup(release)
+
+    def test_dag_structure(self):
+
+        with CliRunner().isolated_filesystem():
+            wf = OapenWorkflow(
+                org_name=self.org_name,
+                gcp_project_id=self.gcp_project_id,
+                irus_uk_dag_id_prefix=self.irus_uk_dag_id_prefix,
+            )
+            dag = wf.make_dag()
+            self.assert_dag_structure(
+                {
+                    "oapen_irus_uk_oapen_sensor": ["create_onix_formatted_metadata_output_tasks"],
+                    "create_onix_formatted_metadata_output_tasks": ["copy_irus_uk_release"],
+                    "copy_irus_uk_release": ["create_oaebu_book_product_table"],
+                    "create_oaebu_book_product_table": ["export_oaebu_table.book_product_list"],
+                    "export_oaebu_table.book_product_list": ["export_oaebu_table.book_product_metrics"],
+                    "export_oaebu_table.book_product_metrics": ["export_oaebu_table.book_product_metrics_country"],
+                    "export_oaebu_table.book_product_metrics_country": [
+                        "export_oaebu_table.book_product_metrics_institution"
+                    ],
+                    "export_oaebu_table.book_product_metrics_institution": [
+                        "export_oaebu_table.book_product_metrics_city"
+                    ],
+                    "export_oaebu_table.book_product_metrics_city": [
+                        "export_oaebu_table.book_product_metrics_referrer"
+                    ],
+                    "export_oaebu_table.book_product_metrics_referrer": [
+                        "export_oaebu_table.book_product_metrics_events"
+                    ],
+                    "export_oaebu_table.book_product_metrics_events": [
+                        "export_oaebu_table.book_product_publisher_metrics"
+                    ],
+                    "export_oaebu_table.book_product_publisher_metrics": [
+                        "export_oaebu_table.book_product_subject_metrics"
+                    ],
+                    "export_oaebu_table.book_product_subject_metrics": ["export_oaebu_table.book_product_year_metrics"],
+                    "export_oaebu_table.book_product_year_metrics": [
+                        "export_oaebu_table.book_product_subject_year_metrics"
+                    ],
+                    "export_oaebu_table.book_product_subject_year_metrics": [
+                        "export_oaebu_table.book_product_author_metrics"
+                    ],
+                    "export_oaebu_table.book_product_author_metrics": ["cleanup"],
+                    "cleanup": [],
+                },
+                dag,
+            )
+
+
+class TestOapenWorkflowFunctional(ObservatoryTestCase):
+    """Functionally test the workflow.  No Google Analytics."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.timestamp = pendulum.now()
+        self.oapen_table_id = "oapen"
+
+        self.data_location = os.getenv("TESTS_DATA_LOCATION")
+
+        self.ao_gcp_project_id = "academic-observatory"
+        self.oapen_metadata_dataset_id = "oapen"
+        self.oapen_metadata_table_id = "metadata"
+        self.public_book_metadata_dataset_id = "observatory"
+        self.public_book_metadata_table_id = "book"
+
+        self.org_name = "OAPEN"
+        self.gcp_project_id = os.getenv("TEST_GCP_PROJECT_ID")
+
+        self.gcp_dataset_id = "oaebu"
+        self.irus_uk_dag_id_prefix = "oapen_irus_uk"
+        self.irus_uk_table_id = "oapen_irus_uk"
+
+        self.irus_uk_dataset_id = "fixtures"
+
+
+    def test_run_workflow_tests(self):
+        """Functional test of the OAPEN workflow"""
+
+        # Setup Observatory environment
+        env = ObservatoryEnvironment(self.gcp_project_id, self.data_location, enable_api=False)
+        org_name = self.org_name
+
+        # Create datasets
+        partner_release_date = pendulum.datetime(2021, 1, 1)
+        oaebu_intermediate_dataset_id = env.add_dataset(prefix="oaebu_intermediate")
+        oaebu_output_dataset_id = env.add_dataset(prefix="oaebu")
+        oaebu_onix_dataset_id = env.add_dataset(prefix="oaebu_onix_dataset")
+        oaebu_elastic_dataset_id = env.add_dataset(prefix="data_export")
+
+
+        # Create the Observatory environment and run tests
+        with env.create(task_logging=True):
+            self.gcp_bucket_name = env.transform_bucket
+
+            # Pull info from Observatory API
+            gcp_project_id = (self.gcp_project_id,)
+
+            # Setup workflow
+            start_date = pendulum.datetime(year=2021, month=5, day=9)
+            workflow = OapenWorkflow(
+                org_name=self.org_name,
+                gcp_project_id=self.gcp_project_id,
+                start_date=start_date,
+            )
+
+            # Make DAG
+            workflow_dag = workflow.make_dag()
+
+            # Test that sensors go into the 'up_for_reschedule' state as the DAGs that they wait for haven't run
+            expected_state = "up_for_reschedule"
+            with env.create_dag_run(workflow_dag, start_date):
+                ti = env.run_task(
+                    f"{make_dag_id(self.irus_uk_dag_id_prefix, org_name)}_sensor", workflow_dag, execution_date=start_date
+                )
+                self.assertEqual(expected_state, ti.state)
+
+            # Run Dummy Dags
+            expected_state = "success"
+            execution_date = pendulum.datetime(year=2021, month=5, day=16)
+            release_date = pendulum.datetime(year=2021, month=5, day=22)
+
+            dag = make_dummy_dag(make_dag_id(self.irus_uk_dag_id_prefix, org_name), execution_date)
+            with env.create_dag_run(dag, execution_date):
+                # Running all of a DAGs tasks sets the DAG to finished
+                ti = env.run_task("dummy_task", dag, execution_date=execution_date)
+                self.assertEqual(expected_state, ti.state)
+
+            # Run end to end tests for DOI DAG
+            with env.create_dag_run(workflow_dag, execution_date):
+                # Test that sensors go into 'success' state as the DAGs that they are waiting for have finished
+                ti = env.run_task(
+                    f"{make_dag_id(self.irus_uk_dag_id_prefix, org_name)}_sensor", workflow_dag, execution_date=execution_date
+                )
+                self.assertEqual(expected_state, ti.state)
+
+                # Mock make_release
+                workflow.make_release = MagicMock(
+                    return_value=OapenWorkflowRelease(
+                        dag_id=make_dag_id(self.irus_uk_dag_id_prefix, org_name),
+                        release_date=release_date,
+                        gcp_project_id=self.gcp_project_id,
+                        oaebu_onix_dataset=oaebu_onix_dataset_id,
+                        oaebu_dataset=oaebu_output_dataset_id,
+                        oaebu_intermediate_dataset=oaebu_intermediate_dataset_id,
+                        oaebu_elastic_dataset=oaebu_elastic_dataset_id,
+                        irus_uk_dataset_id=self.irus_uk_dataset_id,
+                    )
+                )
+
+                # Format OAPEN Metadata like ONIX to enable the next steps
+                ti = env.run_task(
+                    workflow.create_onix_formatted_metadata_output_tasks.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
+                self.assertEqual(expected_state, ti.state)
+
+                # Copy IRUS-UK data and add release date
+                ti = env.run_task(
+                    workflow.copy_irus_uk_release.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
+                self.assertEqual(expected_state, ti.state)
+
+                # Create oaebu output tables
+                ti = env.run_task(
+                    workflow.create_oaebu_book_product_table.__name__,
+                    workflow_dag,
+                    execution_date,
+                )
+                self.assertEqual(expected_state, ti.state)
+
+                # Export oaebu elastic tables
+                export_tables = [
+                    "book_product_list",
+                    "book_product_metrics",
+                    "book_product_metrics_country",
+                    "book_product_metrics_institution",
+                    "book_product_metrics_city",
+                    "book_product_metrics_referrer",
+                    "book_product_metrics_events",
+                    "book_product_publisher_metrics",
+                    "book_product_subject_metrics",
+                    "book_product_year_metrics",
+                    "book_product_subject_year_metrics",
+                    "book_product_author_metrics",
+                ]
+
+                for table in export_tables:
+                    ti = env.run_task(
+                        f"{workflow.export_oaebu_table.__name__}.{table}",
+                        workflow_dag,
+                        execution_date,
+                    )
+                    self.assertEqual(expected_state, ti.state)
+
+
+                # Test conditions
+                release_suffix = release_date.strftime("%Y%m%d")
+
+
+                table_id = f"{self.gcp_project_id}.{oaebu_output_dataset_id}.book_product{release_suffix}"
+                #self.assert_table_integrity(table_id, 2)
+
+                table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset_id}.{self.gcp_project_id.replace('-', '_')}_book_product_list{release_suffix}"
+                #self.assert_table_integrity(table_id, 2)
+
+                table_id = f"{self.gcp_project_id}.{oaebu_elastic_dataset_id}.{self.gcp_project_id.replace('-', '_')}_book_product_publisher_metrics{release_suffix}"
+                #self.assert_table_integrity(table_id, 1)
+
+                # Check Book Product Table
+                sql = f"SELECT ISBN13 from {self.gcp_project_id}.{oaebu_output_dataset_id}.book_product{release_suffix}"
+                records = run_bigquery_query(sql)
+                isbns = set([record["ISBN13"] for record in records])
+                #self.assertEqual(len(isbns), 2)
+                #self.assertTrue("211" in isbns)
+                #self.assertTrue("112" in isbns)
+
+                # Check export tables
+                sql = f"SELECT product_id from {self.gcp_project_id}.{oaebu_elastic_dataset_id}.{self.gcp_project_id.replace('-', '_')}_book_product_list{release_suffix}"
+                records = run_bigquery_query(sql)
+                isbns = set([record["product_id"] for record in records])
+                #self.assertEqual(len(isbns), 2)
+                #self.assertTrue("211" in isbns)
+                #self.assertTrue("112" in isbns)
+
+                # Cleanup
+                env.run_task(workflow.cleanup.__name__, workflow_dag, execution_date)

--- a/tests/observatory/dags/workflows/test_onix_workflow.py
+++ b/tests/observatory/dags/workflows/test_onix_workflow.py
@@ -1494,7 +1494,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
 
             sql_hash = hashlib.md5(call_args["sql"].encode("utf-8"))
             sql_hash = sql_hash.hexdigest()
-            expected_hash = "bca797c0edc0fe8cc30e263a3fb37ee6"
+            expected_hash = "71bc329dd609017504e91bc8fd8931fe"
             self.assertEqual(sql_hash, expected_hash)
 
             mock_bq_table_query.return_value = False

--- a/tests/observatory/dags/workflows/test_onix_workflow.py
+++ b/tests/observatory/dags/workflows/test_onix_workflow.py
@@ -430,7 +430,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
             OaebuPartners(
                 name=OaebuPartnerName.ucl_discovery,
                 dag_id_prefix="ucl_discovery",
-                gcp_project_id=project_id,
+                gcp_project_id="project",
                 gcp_dataset_id="ucl",
                 gcp_table_id="ucl_discovery",
                 isbn_field_name="ISBN",
@@ -584,7 +584,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
             OaebuPartners(
                 name=OaebuPartnerName.ucl_discovery,
                 dag_id_prefix="ucl_discovery",
-                gcp_project_id=project_id,
+                gcp_project_id="project",
                 gcp_dataset_id="ucl",
                 gcp_table_id="ucl_discovery",
                 isbn_field_name="ISBN",

--- a/tests/observatory/dags/workflows/test_onix_workflow.py
+++ b/tests/observatory/dags/workflows/test_onix_workflow.py
@@ -427,16 +427,6 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 title_field_name="Title",
                 sharded=False,
             ),
-            OaebuPartners(
-                name=OaebuPartnerName.ucl_discovery,
-                dag_id_prefix="ucl_discovery",
-                gcp_project_id="project",
-                gcp_dataset_id="ucl",
-                gcp_table_id="ucl_discovery",
-                isbn_field_name="ISBN",
-                title_field_name="book_title",
-                sharded=False,
-            ),
         ]
 
         with CliRunner().isolated_filesystem():
@@ -579,16 +569,6 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_table_id="google_analytics",
                 isbn_field_name="publication_id",
                 title_field_name="title",
-                sharded=False,
-            ),
-            OaebuPartners(
-                name=OaebuPartnerName.ucl_discovery,
-                dag_id_prefix="ucl_discovery",
-                gcp_project_id="project",
-                gcp_dataset_id="ucl",
-                gcp_table_id="ucl_discovery",
-                isbn_field_name="ISBN",
-                title_field_name="book_title",
                 sharded=False,
             ),
         ]
@@ -1501,6 +1481,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 orig_dataset_id="jstor",
                 orig_table="country",
                 orig_isbn="isbn",
+                orig_title="Book_Title",
             )
 
             _, call_args = mock_bq_ds.call_args
@@ -1533,6 +1514,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 orig_dataset_id="jstor",
                 orig_table="country",
                 orig_isbn="isbn",
+                orig_title="Book_Title",
             )
 
 

--- a/tests/observatory/dags/workflows/test_onix_workflow.py
+++ b/tests/observatory/dags/workflows/test_onix_workflow.py
@@ -394,6 +394,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="jstor_country",
                 isbn_field_name="isbn",
+                title_field_name="Book_Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -403,6 +404,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="oapen_irus_uk",
                 isbn_field_name="ISBN",
+                title_field_name="book_title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -412,6 +414,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_books_sales",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -421,6 +424,17 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_books_traffic",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
+                sharded=False,
+            ),
+            OaebuPartners(
+                name=OaebuPartnerName.ucl_discovery,
+                dag_id_prefix="ucl_discovery",
+                gcp_project_id=project_id,
+                gcp_dataset_id="ucl",
+                gcp_table_id="ucl_discovery",
+                isbn_field_name="ISBN",
+                title_field_name="book_title",
                 sharded=False,
             ),
         ]
@@ -524,6 +538,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="jstor_country",
                 isbn_field_name="isbn",
+                title_field_name="Book_Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -533,6 +548,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="oapen_irus_uk",
                 isbn_field_name="ISBN",
+                title_field_name="book_title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -542,6 +558,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_books_sales",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -551,6 +568,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_books_traffic",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             ),
             OaebuPartners(
@@ -560,6 +578,17 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="dataset",
                 gcp_table_id="google_analytics",
                 isbn_field_name="publication_id",
+                title_field_name="title",
+                sharded=False,
+            ),
+            OaebuPartners(
+                name=OaebuPartnerName.ucl_discovery,
+                dag_id_prefix="ucl_discovery",
+                gcp_project_id=project_id,
+                gcp_dataset_id="ucl",
+                gcp_table_id="ucl_discovery",
+                isbn_field_name="ISBN",
+                title_field_name="book_title",
                 sharded=False,
             ),
         ]
@@ -884,6 +913,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="test_dataset",
                 gcp_table_id="test_table",
                 isbn_field_name="isbn",
+                title_field_name="title",
                 sharded=True,
             ),
             OaebuPartners(
@@ -893,6 +923,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="test_dataset",
                 gcp_table_id="test_table2",
                 isbn_field_name="isbn",
+                title_field_name="title",
                 sharded=True,
             ),
         ]
@@ -1078,6 +1109,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="jstor",
                 gcp_table_id="country",
                 isbn_field_name="ISBN",
+                title_field_name="Book_Title",
                 sharded=False,
             )
         ]
@@ -1151,6 +1183,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="google_books",
                 gcp_table_id="sales",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             )
         ]
@@ -1224,6 +1257,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="google_books",
                 gcp_table_id="traffic",
                 isbn_field_name="Primary_ISBN",
+                title_field_name="Title",
                 sharded=False,
             )
         ]
@@ -1295,6 +1329,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="irus_uk",
                 gcp_table_id="oapen_irus_uk",
                 isbn_field_name="ISBN",
+                title_field_name="book_title",
                 sharded=False,
             )
         ]
@@ -1366,6 +1401,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="google",
                 gcp_table_id="google_analytics",
                 isbn_field_name="publication_id",
+                title_field_name="book_title",
                 sharded=False,
             )
         ]
@@ -1439,6 +1475,7 @@ class TestOnixWorkflow(ObservatoryTestCase):
                 gcp_dataset_id="jstor",
                 gcp_table_id="country",
                 isbn_field_name="ISBN",
+                title_field_name="Book_Title",
                 sharded=False,
             )
         ]
@@ -1621,14 +1658,14 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
 
         # Make partners
         partners = []
-        for (name, isbn_field_name, dag_id_prefix), table_id in zip(
+        for (name, isbn_field_name, title_field_name, dag_id_prefix), table_id in zip(
             [
-                (OaebuPartnerName.jstor_country, "ISBN", "jstor"),
-                (OaebuPartnerName.jstor_institution, "ISBN", "jstor"),
-                (OaebuPartnerName.google_books_sales, "Primary_ISBN", "google_books"),
-                (OaebuPartnerName.google_books_traffic, "Primary_ISBN", "google_books"),
-                (OaebuPartnerName.oapen_irus_uk, "ISBN", "oapen_irus_uk"),
-                (OaebuPartnerName.google_analytics, "publication_id", "google_analytics"),
+                (OaebuPartnerName.jstor_country, "ISBN", "Book_Title", "jstor"),
+                (OaebuPartnerName.jstor_institution, "ISBN", "Book_Title", "jstor"),
+                (OaebuPartnerName.google_books_sales, "Primary_ISBN", "Title", "google_books"),
+                (OaebuPartnerName.google_books_traffic, "Primary_ISBN", "Title", "google_books"),
+                (OaebuPartnerName.oapen_irus_uk, "ISBN", "book_title", "oapen_irus_uk"),
+                (OaebuPartnerName.google_analytics, "publication_id", "title", "google_analytics"),
             ],
             table_ids,
         ):
@@ -1640,6 +1677,7 @@ class TestOnixWorkflowFunctional(ObservatoryTestCase):
                     gcp_dataset_id=self.fake_partner_dataset,
                     gcp_table_id=table_id,
                     isbn_field_name=isbn_field_name,
+                    title_field_name=title_field_name,
                     sharded=False,
                 )
             )


### PR DESCRIPTION
Adds the new OAPEN workflow, which will combine the IRUS-UK, and public metrics with the OAPEN metadata. (MEL-217 + MEL-159)

It also adds a range of fixes across the OAEBU workflows:
- corrects matching for countries in google analytics (MEL-371)
- changes irus-uk to use the correct country field not city locations to stop over counting (MEL-391)
- adds UCL metrics for UCL press (MEL-212)
- deduplication of metrics from Google Analytics, IRUS-UK, Google Books, UCL Press and JSTOR (MEL-387, MEL-386, MEL-379)
- ensures that duplicate ONIX product records don't throw off the metrics (MEL-380, MEL-379)
- Adds work and work_family IDs to the exported tables (where it makes sense) (MEL-385)
- Adds titles to the unmatched ISBNs (MEL-384)