### PR TITLE
Update Github actions PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -16,12 +16,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-
-      - name: Install packages
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e observatory-api
-          pip install -e observatory-platform
 
       - name: Build packages
         run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Build packages
         run: |
           cd observatory-api
-          cp ../README.md .
           python3 setup.py sdist
 
           cd ../observatory-platform

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -1,3 +1,6 @@
+# Observatory API
+observatory-api>=0.1.0,<1
+
 # Airflow
 apache-airflow==2.1.3
 apache-airflow-providers-slack==4.0.0

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -1,5 +1,5 @@
 # Observatory API
-observatory-api>=0.1.0,<1
+observatory-api
 
 # Airflow
 apache-airflow==2.1.3


### PR DESCRIPTION
This PR makes a couple of changes to the PyPI publish workflow.

Requirements:
* Adds observatory-api as a dependency to observatory-platform requirements.txt

Github Actions workflow:
* Pin ubuntu-20.04 rather than using latest.
* Removes Install packages step as not needed.
* Don't copy README.md for observatory-api (only for platform)