### PR TITLE
Fix incorrect terraform secret values

### DIFF
--- a/observatory-platform/observatory/platform/terraform/api/main.tf
+++ b/observatory-platform/observatory/platform/terraform/api/main.tf
@@ -43,7 +43,7 @@ module "elasticsearch-logins" {
   for_each = toset(nonsensitive(keys(var.elasticsearch))) # Make keys of variable nonsensitive.
   source = "../secret"
   secret_id = "elasticsearch-${each.key}"
-  secret_data = each.value
+  secret_data = var.elasticsearch[each.key]
   service_account_email = google_service_account.api-backend_service_account.email
 }
 

--- a/observatory-platform/observatory/platform/terraform/main.tf
+++ b/observatory-platform/observatory/platform/terraform/main.tf
@@ -469,7 +469,7 @@ module "airflow_connections" {
   for_each = toset(nonsensitive(keys(var.airflow_connections))) # Make keys of variable nonsensitive.
   source = "./secret"
   secret_id = "airflow-connections-${each.key}"
-  secret_data = each.value
+  secret_data = var.airflow_connections[each.key]
   service_account_email = google_service_account.observatory_service_account.email
   depends_on = [google_project_service.services]
 }

--- a/observatory-platform/observatory/platform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform_builder.py
@@ -115,7 +115,7 @@ class TerraformBuilder:
         # Copy DAGs projects
         for dags_project in self.config.workflows_projects:
             destination_path = os.path.join(self.packages_build_path, dags_project.package_name)
-            copy_dir(dags_project.path, destination_path, ignore)
+            copy_dir(dags_project.package, destination_path, ignore)
 
         # Copy terraform files into build/terraform: ignore jinja2 templates
         copy_dir(self.terraform_path, self.terraform_build_path, shutil.ignore_patterns("*.jinja2", "__pycache__"))


### PR DESCRIPTION
Fix issue where the google cloud secrets that were made had their value set to the secret key instead of the secret value.

Also made a small fix to the terraform builder, because it could not find the dags 'path', this should probably be the dags 'package'.
