### PR TITLE
Fix potential duplicates in table after merge using stream telescope

### DIFF
--- a/observatory-platform/observatory/platform/utils/airflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/airflow_utils.py
@@ -18,15 +18,17 @@
 Airflow utility functions (independent of telescope or google cloud usage)
 """
 
+import datetime
 import logging
 from typing import Any, List, Optional, Union
 
 import validators
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
-from airflow.models import Connection, TaskInstance, Variable
+from airflow.models import Connection, TaskInstance, Variable, DagRun
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookHook
 from airflow.utils.db import create_session
+from airflow.utils.state import TaskInstanceState
 
 
 class AirflowVars:
@@ -157,6 +159,34 @@ def create_slack_webhook(comments: str = "", project_id: str = "?", context: dic
     slack_conn = BaseHook.get_connection(AirflowConns.SLACK)
     slack_hook = SlackWebhookHook(http_conn_id=slack_conn.conn_id, webhook_token=slack_conn.password, message=message)
     return slack_hook
+
+
+def get_prev_start_date_success_task(dag_run: DagRun, task_id: str) -> Optional[datetime.datetime]:
+    """Get the start date of the previous task that is in a success state. This cannot be done with
+    ti.get_previous_ti(TaskInstanceState.SUCCESS), because this method uses the state of the Dag Run, instead of the
+    state of the task instance itself.
+
+    :param dag_run: The current Dag Run
+    :param task_id: The task id
+    :return: The start date
+    """
+    prev_state = None
+    start_date = None
+    while prev_state != TaskInstanceState.SUCCESS:
+        # Get the previous dag run and task instance
+        prev_dag_run = dag_run.get_previous_dagrun()
+        if prev_dag_run:
+            prev_ti = prev_dag_run.get_task_instance(task_id)
+        else:
+            return None
+
+        # Get the state and start date of prev dag run
+        prev_state = prev_ti.state
+        start_date = prev_ti.start_date
+
+        # Update dag run to be the previous dag run
+        dag_run = prev_dag_run
+    return start_date
 
 
 def set_task_state(success: bool, task_id: str):

--- a/observatory-platform/observatory/platform/utils/templates/insert_from_partitions.sql.jinja2
+++ b/observatory-platform/observatory/platform/utils/templates/insert_from_partitions.sql.jinja2
@@ -1,0 +1,33 @@
+{# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Author: Aniek Roelofs -#}
+# Add entries from selected partitions to main table.
+# If there are rows with the same id in multiple partitions, only the row with that id from the latest partition will be added
+INSERT INTO `{{ dataset }}.{{ main_table }}`
+SELECT
+  agg.table.*
+FROM (
+  SELECT
+    {{ merge_condition_field }} as id,
+    # Create an array with table values grouped by id and ordered by partitiondate, then get the entry from latest partition date
+    ARRAY_AGG(
+      STRUCT(table)
+      ORDER BY
+        _PARTITIONDATE DESC
+        )[SAFE_OFFSET(0)]
+    AS agg
+  FROM
+    `{{ dataset }}.{{ partitioned_table }}` AS table WHERE _PARTITIONDATE > '{{ start_date }}' AND _PARTITIONDATE <= '{{ end_date }}'
+  GROUP BY
+    id)

--- a/observatory-platform/observatory/platform/utils/templates/merge_delete_matched.sql.jinja2
+++ b/observatory-platform/observatory/platform/utils/templates/merge_delete_matched.sql.jinja2
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Author: Aniek Roelofs#}
-
+# Author: Aniek Roelofs -#}
 MERGE
   `{{ dataset }}.{{ main_table }}` M
 USING

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -360,8 +360,10 @@ class ObservatoryEnvironment:
         task = dag.get_task(task_id=task_id)
         ti = TaskInstance(task, execution_date)
         ti.refresh_from_db()
+        if ti.state == State.SCHEDULED:
+            ti.set_state(State.NONE)
         ti.init_run_context(raw=True)
-        ti.run(ignore_ti_state=True)
+        ti.run()
         return ti
 
     @contextlib.contextmanager

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -360,10 +360,8 @@ class ObservatoryEnvironment:
         task = dag.get_task(task_id=task_id)
         ti = TaskInstance(task, execution_date)
         ti.refresh_from_db()
-        if ti.state == State.SCHEDULED:
-            ti.set_state(State.NONE)
         ti.init_run_context(raw=True)
-        ti.run()
+        ti.run(ignore_ti_state=True)
         return ti
 
     @contextlib.contextmanager

--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -441,7 +441,7 @@ def bq_load_ingestion_partition(
     given it will automatically partition by ingestion datetime.
 
     :param schema_folder: the path to the SQL schema folder.
-    :param end_date: End date used to find the schema.
+    :param end_date: Release end date, used to find the schema and to create table id.
     :param transform_blob: Name of the transform blob.
     :param dataset_id: Dataset id.
     :param main_table_id: Main table id.
@@ -460,7 +460,7 @@ def bq_load_ingestion_partition(
     uri = f"gs://{bucket_name}/{transform_blob}"
 
     # Include date in table id, so data in table is not overwritten
-    partition_table_id = create_date_table_id(partition_table_id, pendulum.today(), partition_type)
+    partition_table_id = create_date_table_id(partition_table_id, end_date, partition_type)
     success = load_bigquery_table(
         uri,
         dataset_id,

--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -40,7 +40,7 @@ import pysftp
 import six
 from airflow import AirflowException
 from airflow.hooks.base import BaseHook
-from airflow.models import DagBag, Variable
+from airflow.models import DagBag, Variable, DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.secrets.environment_variables import EnvironmentVariablesBackend
 from dateutil.relativedelta import relativedelta
@@ -1307,10 +1307,14 @@ def make_release_date(**kwargs) -> pendulum.DateTime:
     return kwargs["next_execution_date"].subtract(days=1).start_of("day")
 
 
-def is_first_dag_run(**kwargs) -> bool:
-    """ Whether the DAG Run is the first run or not """
+def is_first_dag_run(dag_run: DagRun) -> bool:
+    """Whether the DAG Run is the first run or not
 
-    return kwargs["dag_run"].get_previous_dagrun() is None
+    :param dag_run: A Dag Run instance
+    :return: Whether the DAG run is the first run or not
+    """
+
+    return dag_run.get_previous_dagrun() is None
 
 
 def make_table_name(

--- a/observatory-platform/observatory/platform/workflows/stream_telescope.py
+++ b/observatory-platform/observatory/platform/workflows/stream_telescope.py
@@ -269,7 +269,7 @@ class StreamTelescope(Workflow):
         dag_run: DagRun = kwargs["dag_run"]
         ti: TaskInstance = kwargs["ti"]
         start_date = pendulum.instance(get_prev_start_date_success_task(dag_run, ti.task_id))
-        end_date = pendulum.instance(ti.start_date)
+        end_date = release.end_date
         if (end_date - start_date).days + 1 >= self.bq_merge_days:
             logging.info(
                 f"Deleting old data from main table using partitions after {start_date} and on or before" f" {end_date}"
@@ -322,7 +322,7 @@ class StreamTelescope(Workflow):
         dag_run: DagRun = kwargs["dag_run"]
         ti: TaskInstance = kwargs["ti"]
         start_date = pendulum.instance(get_prev_start_date_success_task(dag_run, ti.task_id))
-        end_date = pendulum.instance(ti.start_date)
+        end_date = release.end_date
         if (end_date - start_date).days + 1 >= self.bq_merge_days:
             logging.info(f"Appending data to main table from partitions after {start_date} and on or before {end_date}")
             for transform_blob, main_table_id, partition_table_id in bq_load_info:

--- a/observatory-platform/observatory/platform/workflows/stream_telescope.py
+++ b/observatory-platform/observatory/platform/workflows/stream_telescope.py
@@ -77,8 +77,6 @@ def get_data_interval(
 
 
 class StreamTelescope(Workflow):
-    XCOM_BQ_DATES = "xcom_bq_dates"
-
     def __init__(
         self,
         dag_id: str,

--- a/tests/observatory/platform/utils/test_airflow_utils.py
+++ b/tests/observatory/platform/utils/test_airflow_utils.py
@@ -14,18 +14,20 @@
 
 # Author: James Diprose, Aniek Roelofs
 
-
 import unittest
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
+from airflow.models import DagRun, TaskInstance, BaseOperator, DAG
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
 from observatory.platform.utils.airflow_utils import (
     create_slack_webhook,
     get_airflow_connection_password,
     get_airflow_connection_url,
+    get_prev_start_date_success_task,
     set_task_state,
 )
 
@@ -110,3 +112,33 @@ class TestAirflowUtils(unittest.TestCase):
             m_basehook.get_connection = MagicMock(return_value=MockConnection(""))
             password = get_airflow_connection_password("")
             self.assertEqual(password, "password")
+
+    def test_get_prev_start_date_success_task(self):
+        """Test the get_prev_start_date_success_task function
+
+        :return: None.
+        """
+        execution_date = datetime(2021, 1, 1, tzinfo=timezone.utc)
+        dag_run = DagRun("dag_id", execution_date=execution_date)
+
+        # Test that start date is None when there is no previous dag run
+        with patch.object(DagRun, "get_previous_dagrun", return_value=None):
+            start_date = get_prev_start_date_success_task(dag_run, "task_id")
+            self.assertIsNone(start_date)
+
+        # Create two task instances with different states
+        with DAG("dag_id", start_date=datetime(2020, 1, 1)):
+            task = BaseOperator(task_id="task_id")
+        ti_skipped = TaskInstance(task, execution_date=execution_date)
+        ti_skipped.start_date = datetime(2020, 8, 1)
+        ti_skipped.state = "skipped"
+
+        ti_success = TaskInstance(task, execution_date=execution_date)
+        ti_success.start_date = datetime(2021, 1, 1)
+        ti_success.state = "success"
+
+        # Test that the start date is the start date of the successful task
+        with patch.object(DagRun, "get_previous_dagrun", return_value=DagRun):
+            with patch.object(DagRun, "get_task_instance", side_effect=[ti_skipped, ti_success]):
+                start_date = get_prev_start_date_success_task(dag_run, "task_id")
+                self.assertEqual(ti_success.start_date, start_date)

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -339,7 +339,7 @@ class TestObservatoryTestCase(unittest.TestCase):
         dag = telescope.make_dag()
 
         # No assertion error
-        expected = {"check_dependencies": []}
+        expected = {"check_dependencies": ["setup_task"], "setup_task": []}
         test_case.assert_dag_structure(expected, dag)
 
         # Raise assertion error

--- a/tests/observatory/platform/utils/test_workflow_utils.py
+++ b/tests/observatory/platform/utils/test_workflow_utils.py
@@ -707,82 +707,74 @@ class TestTemplateUtils(unittest.TestCase):
                 )
 
                 expected_query = (
-                    "\n\nMERGE\n"
-                    "  `{dataset_id}.{main_table}` M\n"
+                    "MERGE\n"
+                    "  `{dataset}.{main_table}` M\n"
                     "USING\n"
-                    "  (SELECT {merge_partition_field} AS id FROM `{dataset_id}.{partition_table}` WHERE _PARTITIONDATE > '{start_date}' AND _PARTITIONDATE <= '{end_date}') P\n"
+                    "  (SELECT {merge_condition_field} AS id FROM `{dataset}.{partitioned_table}` WHERE _PARTITIONDATE > '{start_date}' AND _PARTITIONDATE <= '{end_date}') P\n"
                     "ON\n"
-                    "  M.{merge_partition_field} = P.id\n"
+                    "  M.{merge_condition_field} = P.id\n"
                     "WHEN MATCHED THEN\n"
                     "  DELETE".format(
-                        dataset_id=telescope.dataset_id,
+                        dataset=telescope.dataset_id,
                         main_table=main_table_id,
-                        partition_table=partition_table_id,
-                        merge_partition_field=telescope.merge_partition_field,
+                        partitioned_table=partition_table_id,
+                        merge_condition_field=telescope.merge_partition_field,
                         start_date=start_date_str,
                         end_date=end_date_str,
                     )
                 )
                 mock_run_bigquery_query.assert_called_once_with(expected_query)
 
-    @patch("observatory.platform.utils.workflow_utils.copy_bigquery_table")
-    @patch("observatory.platform.utils.workflow_utils.prepare_bq_load")
+    @patch("observatory.platform.utils.workflow_utils.run_bigquery_query")
     @patch("airflow.models.variable.Variable.get")
-    def test_bq_append_from_partition(self, mock_variable_get, mock_prepare_bq_load, mock_copy_bigquery_table):
+    def test_bq_append_from_partition(self, mock_variable_get, mock_run_bigquery_query):
         with CliRunner().isolated_filesystem():
             mock_variable_get.side_effect = side_effect
-            mock_prepare_bq_load.return_value = ("project_id", "bucket_name", "data_location", "schema.json")
-            mock_copy_bigquery_table.return_value = True
-            schema_path = DEFAULT_SCHEMA_PATH
 
             telescope, release = setup(MockStreamTelescope)
-            start_date = pendulum.datetime(2020, 2, 1)
-            end_date = pendulum.datetime(2020, 2, 3)
+            start_date_str = release.start_date.strftime("%Y-%m-%d")
+            end_date_str = release.end_date.strftime("%Y-%m-%d")
 
             for transform_path in release.transform_files:
                 main_table_id, partition_table_id = table_ids_from_path(transform_path)
                 bq_append_from_partition(
-                    schema_path,
-                    start_date,
-                    end_date,
+                    release.start_date,
+                    release.end_date,
                     telescope.dataset_id,
                     main_table_id,
                     partition_table_id,
-                    telescope.schema_prefix,
-                    telescope.schema_version,
+                    telescope.merge_partition_field
                 )
 
-                mock_prepare_bq_load.assert_called_once_with(
-                    schema_path,
-                    telescope.dataset_id,
-                    main_table_id,
-                    end_date,
-                    telescope.schema_prefix,
-                    telescope.schema_version,
-                )
-                source_table_ids = [
-                    f"project_id.{telescope.dataset_id}.{partition_table_id}$20200202",
-                    f"project_id.{telescope.dataset_id}.{partition_table_id}$20200203",
-                ]
-                mock_copy_bigquery_table.assert_called_once_with(
-                    source_table_ids,
-                    f"project_id.{telescope.dataset_id}." f"{main_table_id}",
-                    "data_location",
-                    bigquery.WriteDisposition.WRITE_APPEND,
-                )
-
-                mock_copy_bigquery_table.return_value = False
-                with self.assertRaises(AirflowException):
-                    bq_append_from_partition(
-                        schema_path,
-                        start_date,
-                        end_date,
-                        telescope.dataset_id,
-                        main_table_id,
-                        partition_table_id,
-                        telescope.schema_prefix,
-                        telescope.schema_version,
+                expected_query = (
+                    "# Add entries from selected partitions to main table.\n"
+                    "# If there are rows with the same id in multiple partitions, only the row with that id from the latest partition will be added\n"
+                    "INSERT INTO `{dataset}.{main_table}`\n"
+                    "SELECT\n"
+                    "  agg.table.*\n"
+                    "FROM (\n"
+                    "  SELECT\n"
+                    "    {merge_condition_field} as id,\n"
+                    "    # Create an array with table values grouped by id and ordered by partitiondate, then get the entry from latest partition date\n"
+                    "    ARRAY_AGG(\n"
+                    "      STRUCT(table)\n"
+                    "      ORDER BY\n"
+                    "        _PARTITIONDATE DESC\n"
+                    "        )[SAFE_OFFSET(0)]\n"
+                    "    AS agg\n"
+                    "  FROM\n"
+                    "    `{dataset}.{partitioned_table}` AS table WHERE _PARTITIONDATE > '{start_date}' AND _PARTITIONDATE <= '{end_date}'\n"
+                    "  GROUP BY\n"
+                    "    id)".format(
+                        dataset=telescope.dataset_id,
+                        main_table=main_table_id,
+                        partitioned_table=partition_table_id,
+                        merge_condition_field=telescope.merge_partition_field,
+                        start_date=start_date_str,
+                        end_date=end_date_str,
                     )
+                )
+                mock_run_bigquery_query.assert_called_once_with(expected_query)
 
     @patch("observatory.platform.utils.workflow_utils.load_bigquery_table")
     @patch("observatory.platform.utils.workflow_utils.prepare_bq_load")

--- a/tests/observatory/platform/utils/test_workflow_utils.py
+++ b/tests/observatory/platform/utils/test_workflow_utils.py
@@ -1025,26 +1025,26 @@ class TestWorkflowUtils(unittest.TestCase):
             # First DAG Run
             with env.create_dag_run(dag=dag, execution_date=first_execution_date) as first_dag_run:
                 # Should be true the first DAG run. Check before and after a task.
-                is_first = is_first_dag_run(**{"dag_run": first_dag_run})
+                is_first = is_first_dag_run(first_dag_run)
                 self.assertTrue(is_first)
 
                 ti = env.run_task("task", dag, execution_date=first_execution_date)
                 self.assertEqual(ti.state, State.SUCCESS)
 
-                is_first = is_first_dag_run(**{"dag_run": first_dag_run})
+                is_first = is_first_dag_run(first_dag_run)
                 self.assertTrue(is_first)
 
             # Second DAG Run
             second_execution_date = pendulum.datetime(2021, 9, 12)
             with env.create_dag_run(dag=dag, execution_date=second_execution_date) as second_dag_run:
                 # Should be false on second DAG Run, check before and after a task.
-                is_first = is_first_dag_run(**{"dag_run": second_dag_run})
+                is_first = is_first_dag_run(second_dag_run)
                 self.assertFalse(is_first)
 
                 ti = env.run_task("task", dag, execution_date=second_execution_date)
                 self.assertEqual(ti.state, State.SUCCESS)
 
-                is_first = is_first_dag_run(**{"dag_run": second_dag_run})
+                is_first = is_first_dag_run(second_dag_run)
                 self.assertFalse(is_first)
 
     @patch("observatory.platform.utils.workflow_utils.select_table_shard_dates")

--- a/tests/observatory/platform/utils/test_workflow_utils.py
+++ b/tests/observatory/platform/utils/test_workflow_utils.py
@@ -743,7 +743,7 @@ class TestTemplateUtils(unittest.TestCase):
                     telescope.dataset_id,
                     main_table_id,
                     partition_table_id,
-                    telescope.merge_partition_field
+                    telescope.merge_partition_field,
                 )
 
                 expected_query = (
@@ -765,7 +765,7 @@ class TestTemplateUtils(unittest.TestCase):
                     "  FROM\n"
                     "    `{dataset}.{partitioned_table}` AS table WHERE _PARTITIONDATE > '{start_date}' AND _PARTITIONDATE <= '{end_date}'\n"
                     "  GROUP BY\n"
-                    "    id)".format(
+                    "    id)\n".format(
                         dataset=telescope.dataset_id,
                         main_table=main_table_id,
                         partitioned_table=partition_table_id,

--- a/tests/observatory/platform/utils/test_workflow_utils.py
+++ b/tests/observatory/platform/utils/test_workflow_utils.py
@@ -572,7 +572,7 @@ class TestTemplateUtils(unittest.TestCase):
                     telescope.dataset_description,
                 )
                 date_table_id = create_date_table_id(
-                    partition_table_id, pendulum.today(), bigquery.TimePartitioningType.DAY
+                    partition_table_id, release.end_date, bigquery.TimePartitioningType.DAY
                 )
                 mock_load_bigquery_table.assert_called_once_with(
                     "gs://bucket_name/telescopes/dag_id/2021_02_01-2021_03_01/file.txt",

--- a/tests/observatory/platform/workflows/test_stream_telescope.py
+++ b/tests/observatory/platform/workflows/test_stream_telescope.py
@@ -131,16 +131,34 @@ class TestTestStreamTelescope(ObservatoryTestCase):
             "date": pendulum.datetime(year=2020, month=1, day=1),
             "first_release": True,
             "bq_append_from_file": True,
+            "bq_load_partition": False,
+            "bq_delete_old": False,
+            "bq_append_from_partition": False,
         }
-        run2 = {"date": pendulum.datetime(year=2020, month=1, day=2), "first_release": False, "bq_load_partition": True}
+        run2 = {
+            "date": pendulum.datetime(year=2020, month=1, day=2),
+            "first_release": False,
+            "bq_append_from_file": False,
+            "bq_load_partition": True,
+            "bq_delete_old": False,
+            "bq_append_from_partition": False,
+        }
         run3 = {
             "date": pendulum.datetime(year=2020, month=1, day=8),
             "first_release": False,
+            "bq_append_from_file": False,
             "bq_load_partition": True,
             "bq_delete_old": True,
             "bq_append_from_partition": True,
         }
-        run4 = {"date": pendulum.datetime(year=2020, month=1, day=9), "first_release": False, "bq_load_partition": True}
+        run4 = {
+            "date": pendulum.datetime(year=2020, month=1, day=9),
+            "first_release": False,
+            "bq_append_from_file": False,
+            "bq_load_partition": True,
+            "bq_delete_old": False,
+            "bq_append_from_partition": False,
+        }
 
         # Setup Observatory environment
         env = ObservatoryEnvironment(self.project_id, self.data_location)
@@ -195,7 +213,7 @@ class TestTestStreamTelescope(ObservatoryTestCase):
 
                     # Test whether the correct bq load functions are called for different runs
                     ti = env.run_task(telescope.bq_load_partition.__name__)
-                    if run.get("bq_load_partition", False):
+                    if run["bq_load_partition"]:
                         transform_blob = blob_name(transform_path)
                         main_table_id, partition_table_id = table_ids_from_path(transform_path)
                         table_description = telescope.table_descriptions.get(main_table_id, "")
@@ -220,7 +238,7 @@ class TestTestStreamTelescope(ObservatoryTestCase):
 
                     # Test whether the correct bq delete functions are called for different runs
                     ti = env.run_task(telescope.bq_delete_old.__name__)
-                    if run.get("bq_delete_old", False):
+                    if run["bq_delete_old"]:
                         # Use previous ti, because after running task new xcoms have been pushed
                         previous_ti = ti.get_previous_ti()
                         start_date = pendulum.from_format(
@@ -246,7 +264,7 @@ class TestTestStreamTelescope(ObservatoryTestCase):
 
                     # Test whether the correct bq append functions are called for different runs
                     ti = env.run_task(telescope.bq_append_new.__name__)
-                    if run.get("bq_append_from_partition", False):
+                    if run["bq_append_from_partition"]:
                         # Use previous ti, because after running task new xcoms have been pushed
                         previous_ti = ti.get_previous_ti()
                         start_date = pendulum.from_format(
@@ -266,7 +284,7 @@ class TestTestStreamTelescope(ObservatoryTestCase):
                             telescope.merge_partition_field,
                         )
                         self.assertEqual("success", ti.state)
-                    elif run.get("bq_append_from_file", False):
+                    elif run["bq_append_from_file"]:
                         transform_blob = blob_name(transform_path)
                         main_table_id, partition_table_id = table_ids_from_path(transform_path)
                         table_description = telescope.table_descriptions.get(main_table_id, "")

--- a/tests/observatory/platform/workflows/test_stream_telescope.py
+++ b/tests/observatory/platform/workflows/test_stream_telescope.py
@@ -152,6 +152,7 @@ class TestTestStreamTelescope(ObservatoryTestCase):
         # Setup Telescope
         telescope = TestStreamTelescope(dataset_id=dataset_id)
         dag = telescope.make_dag()
+        release = None
 
         # Create the Observatory environment and run tests
         with env.create(task_logging=True):


### PR DESCRIPTION
From Jira issue:

> Tuan Chien picked up while working on the Unpaywall telescope that there is a bug in the functionality of the stream telescope.
> 
> It is possible to add multiple partitions at once to the main table, when the bq_merge_days that is set is less frequent than the schedule interval. 
> E.g. if the telescope runs daily and the bq_merge_days is set to 7, there will be possibly 7 partitions all added at once.
> The issue occurs when there is a row/entry with the same id in e.g. 3 of those partitions, because this entry changed 3 times over those 7 days.
> The partitions are all just copied to the main table, so the entry that was in those 3 partitions is now in the main table 3 times.
> The correct behaviour would be to only add the entry from the most recent partition and ignore the ones from the other 2 partitions.
> 
> To fix the issue I have changed the ‘append’ function to use a BigQuery DML INSERT query, rather than just copying the partitions directly to the table.
> This query will create an array with table values grouped by id and ordered by partitiondate, and then gets the entry from latest partition date. I’ve used this answer of stackoverflow for inspiration (Scalable Solution to get latest row for each ID in BigQuery ).
> 
> As discussed during our infrastructure standup this morning, another alternative would be to leave out the functionality to only merge partitions every x days, and just merge the partition every time the telescope is run.
> Originally this functionality was added upon request to save costs by reducing the number of merge queries, but it is unclear how much this actually saves, while it does add some complexity to the telescope code.

Changes in this PR:
- Append data to main table using insert query instead of directly copying partitions. When an entry is in multiple partitions the insert query only adds the entry of the most recent partition.
- Use xcoms to pass on information on when data was last merged.
I found that since the Airflow 2 update the `previous_start_date_success` property of a task instance is not working as expected. It was used to get the start date of the previous time the task was successful (and thus data was merged). When the data is not merged the task is skipped (but the dagrun is successful).
It seems the `previous_start_date_success` property returns the start date for that task of the previous succesful dagrun, so the dagrun might be successful but the task was actually skipped.
The information on when data was last merged is now passed on using xcoms instead.
- Added unit tests for the stream telescope to capture the correct behaviour for each of the different bq load tasks for different run dates.
- Change the bq_load_partition task to load a ingestion partition where the ingestion time and table id is based on the end date of the release instead of the current day.