### PR TITLE
Inf 40/create unpaywall data feed telescope

### DIFF
--- a/observatory-platform/observatory/platform/utils/airflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/airflow_utils.py
@@ -183,7 +183,8 @@ def get_airflow_connection_url(conn_id: str) -> str:
     :return: Connection URL with a trailing / added if necessary, or raise an exception if it is not a valid URL.
     """
 
-    url = BaseHook.get_connection(conn_id)
+    conn = BaseHook.get_connection(conn_id)
+    url = conn.get_uri()
 
     if validators.url(url) != True:
         raise AirflowException(f"Airflow connection id {conn_id} does not have a valid url: {url}")
@@ -192,3 +193,15 @@ def get_airflow_connection_url(conn_id: str) -> str:
         url += "/"
 
     return url
+
+
+def get_airflow_connection_password(conn_id: str) -> str:
+    """Get the Airflow connection password. Assumes the connection_id exists.
+
+    :param conn_id: Airflow connection id.
+    :return: Connection password.
+    """
+
+    conn = BaseHook.get_connection(conn_id)
+    password = conn.get_password()
+    return password

--- a/observatory-platform/observatory/platform/utils/file_utils.py
+++ b/observatory-platform/observatory/platform/utils/file_utils.py
@@ -333,3 +333,45 @@ def zip_files(file_list: List[str]):
                 shutil.copyfileobj(f_in, f_out)
 
     return zip_list
+
+
+def unzip_files(*, file_list: List[str], output_dir: str = None):
+    """Gunzip the list of files.
+
+    :param file_list: List of files to unzip.
+    :param output_dir: Optional output directory.
+    """
+
+    for file_path in file_list:
+        if file_path[-3:] != ".gz":  # Skip files without .gz extension
+            continue
+
+        logging.info(f"Unzipping file {file_path}")
+
+        if output_dir is None:
+            output_dir = os.path.dirname(file_path)
+
+        filename = os.path.basename(file_path)
+        filename = filename[:-3]  # Strip .gz extension
+        dst = os.path.join(output_dir, filename)
+
+        with gzip.open(file_path, "rb") as f_in:
+            with open(dst, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+
+def find_replace_file(*, src: str, dst: str, pattern: str, replacement: str):
+    """Find an expression (can be a regex) in lines of a text file and replace it with a replacement string.
+    You can optionally save the file in a different location.
+
+    :param src: Input file.
+    :param dst: Destination file.
+    :param pattern: Expression to search for.
+    :param replacement: Replacement string.
+    """
+
+    with open(src, "r") as f_in:
+        with open(dst, "w") as f_out:
+            for line in f_in:
+                output = re.sub(pattern=pattern, repl=replacement, string=line)
+                f_out.write(output)

--- a/observatory-platform/observatory/platform/utils/file_utils.py
+++ b/observatory-platform/observatory/platform/utils/file_utils.py
@@ -335,7 +335,7 @@ def zip_files(file_list: List[str]):
     return zip_list
 
 
-def unzip_files(*, file_list: List[str], output_dir: str = None):
+def gunzip_files(*, file_list: List[str], output_dir: str = None):
     """Gunzip the list of files.
 
     :param file_list: List of files to unzip.

--- a/observatory-platform/observatory/platform/utils/proc_utils.py
+++ b/observatory-platform/observatory/platform/utils/proc_utils.py
@@ -17,7 +17,7 @@
 import logging
 import subprocess
 from subprocess import Popen
-from typing import Tuple
+from typing import List, Tuple, Union
 
 from airflow.exceptions import AirflowException
 
@@ -58,14 +58,15 @@ def stream_process(proc: Popen, debug: bool) -> Tuple[str, str]:
     return output_concat, error_concat
 
 
-def run_bash_cmd(cmd: str):
-    """Run a command in the bash shell and wait until it's done.  Log the output.
-    Raise an exception where there's stderr.
+def run_cmd(cmd: Union[str, List[str]], shell: bool = False, executable: Union[None, str] = None):
+    """Run a command (program).
 
-    :param cmd: Command to run.
+    :param cmd: Command to run. Either a single string, or a list of strings.
+    :param shell: Whether to use a shell to invoke it.
+    :param executable: If you set shell to True, you have to specify this to the shell path, e.g., /bin/bash
     """
 
-    p = Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable="/bin/bash")
+    p = Popen(cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable=executable)
     stdout, stderr = wait_for_process(p)
 
     if stdout:
@@ -74,3 +75,13 @@ def run_bash_cmd(cmd: str):
     success = p.returncode == 0
     if not success:
         raise AirflowException(f"Command {cmd} failed: {stderr}")
+
+
+def run_bash_cmd(cmd: str):
+    """Run a command in the bash shell and wait until it's done.  Log the output.
+    Raise an exception where there's stderr.
+
+    :param cmd: Command to run.
+    """
+
+    run_cmd(cmd=cmd, shell=True, executable="/bin/bash")

--- a/observatory-platform/observatory/platform/utils/proc_utils.py
+++ b/observatory-platform/observatory/platform/utils/proc_utils.py
@@ -14,8 +14,12 @@
 
 # Author: James Diprose
 
+import logging
+import subprocess
 from subprocess import Popen
 from typing import Tuple
+
+from airflow.exceptions import AirflowException
 
 
 def wait_for_process(proc: Popen) -> Tuple[str, str]:
@@ -52,3 +56,20 @@ def stream_process(proc: Popen, debug: bool) -> Tuple[str, str]:
         if proc.poll() is not None:
             break
     return output_concat, error_concat
+
+
+def run_bash_cmd(cmd: str):
+    """Run a command in the bash shell and wait until it's done.  Log the output.
+    Raise an exception where there's stderr.
+
+    :param cmd: Command to run.
+    """
+
+    p = Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable="/bin/bash")
+    stdout, stderr = wait_for_process(p)
+
+    if stdout:
+        logging.info(stdout)
+
+    if stderr:
+        raise AirflowException(f"Command {cmd} failed: {stderr}")

--- a/observatory-platform/observatory/platform/utils/proc_utils.py
+++ b/observatory-platform/observatory/platform/utils/proc_utils.py
@@ -71,5 +71,6 @@ def run_bash_cmd(cmd: str):
     if stdout:
         logging.info(stdout)
 
-    if stderr:
+    success = p.returncode == 0
+    if not success:
         raise AirflowException(f"Command {cmd} failed: {stderr}")

--- a/observatory-platform/observatory/platform/utils/url_utils.py
+++ b/observatory-platform/observatory/platform/utils/url_utils.py
@@ -114,7 +114,7 @@ def get_http_text_response(url: str) -> str:
     HTTP_OK = 200
     response = retry_session().get(url)
     if response.status_code != HTTP_OK:
-        raise ConnectionError(f"Error requesting {url}")
+        raise ConnectionError(f"Error requesting {url}. Status: {response.status_code}")
 
     return response.text
 

--- a/tests/fixtures/utils/find_replace.txt
+++ b/tests/fixtures/utils/find_replace.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:941b4eefe51c99662bbe693632f32e08d72d78f783ffcff5cb6f96e919f904ab
+size 110

--- a/tests/fixtures/utils/testzip.txt
+++ b/tests/fixtures/utils/testzip.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9025945b94748d60b37e400a4a44c70df3f41e168ba32da8fdf78f67cbff5311
+size 13

--- a/tests/fixtures/utils/testzip.txt.gz
+++ b/tests/fixtures/utils/testzip.txt.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97f6457aee5f6f13debb9408ef20df92852929abace4168f8ac0c439e8d0d66a
+size 45

--- a/tests/observatory/platform/utils/test_file_utils.py
+++ b/tests/observatory/platform/utils/test_file_utils.py
@@ -26,10 +26,10 @@ from observatory.platform.utils.file_utils import (
     find_replace_file,
     get_file_hash,
     get_hasher_,
+    gunzip_files,
     is_gzip,
     load_csv,
     load_jsonl,
-    unzip_files,
     validate_file_hash,
     yield_csv,
     yield_jsonl,
@@ -126,7 +126,7 @@ class TestFileUtils(unittest.TestCase):
 
         self.assertTrue(validate_file_hash(file_path=file_path, expected_hash=expected_hash))
 
-    def test_unzip_files(self):
+    def test_gunzip_files(self):
         fixture_dir = test_fixtures_path("utils")
         filename = "testzip.txt.gz"
         expected_hash = "62d83685cff9cd962ac5abb563c61f38"
@@ -138,20 +138,20 @@ class TestFileUtils(unittest.TestCase):
             dst = os.path.join(tmpdir, filename)
             shutil.copyfile(src, dst)
 
-            unzip_files(file_list=[dst])
+            gunzip_files(file_list=[dst])
             self.assertTrue(validate_file_hash(file_path=output_file, expected_hash=expected_hash))
 
         # Specify save dir
         with CliRunner().isolated_filesystem() as tmpdir:
             dst = os.path.join(tmpdir, filename)
-            unzip_files(file_list=[src], output_dir=tmpdir)
+            gunzip_files(file_list=[src], output_dir=tmpdir)
             self.assertTrue(validate_file_hash(file_path=output_file, expected_hash=expected_hash))
 
         # Skip non gz files
         with CliRunner().isolated_filesystem() as tmpdir:
             dst = os.path.join(tmpdir, filename)
             src_path = os.path.join(fixture_dir, output_file)
-            unzip_files(file_list=[src_path], output_dir=tmpdir)
+            gunzip_files(file_list=[src_path], output_dir=tmpdir)
             self.assertFalse(os.path.exists(dst))
 
     def test_find_replace_file(self):

--- a/tests/observatory/platform/utils/test_proc_utils.py
+++ b/tests/observatory/platform/utils/test_proc_utils.py
@@ -1,0 +1,35 @@
+# Copyright 2019 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Tuan Chien
+
+
+import unittest
+from unittest.mock import patch
+
+from airflow.exceptions import AirflowException
+from observatory.platform.utils.proc_utils import run_bash_cmd
+
+
+class TestProcUtils(unittest.TestCase):
+    def test_run_bash_cmd(self):
+        # Run echo with stdout
+        with patch("observatory.platform.utils.proc_utils.logging.info") as m_log:
+            cmd = "echo hello"
+            run_bash_cmd(cmd)
+            self.assertEqual(m_log.call_count, 1)
+
+        # Have stderr
+        cmd = "echo Hello >&2"
+        self.assertRaises(AirflowException, run_bash_cmd, cmd)

--- a/tests/observatory/platform/utils/test_proc_utils.py
+++ b/tests/observatory/platform/utils/test_proc_utils.py
@@ -30,6 +30,6 @@ class TestProcUtils(unittest.TestCase):
             run_bash_cmd(cmd)
             self.assertEqual(m_log.call_count, 1)
 
-        # Have stderr
-        cmd = "echo Hello >&2"
+        # Have an error
+        cmd = "$(exit 1)"
         self.assertRaises(AirflowException, run_bash_cmd, cmd)


### PR DESCRIPTION
- bugfix: get_airflow_connection_url
- add get_airflow_connection_password
- add unzip_files function
- add find_replace_file  (sed cli replacement)
- add fn to wrap shell cmd calls. treats non zero exit as error.

Using unzip/find_replace makes the platform slightly more portable compared to calling a cli program in bash. unzip is faster than cli + bash pipe equivalent.  find_replace is about same speed as sed + bash pipe.
