### PR TITLE
Install apache-airflow-providers-google==5.1.0 with --no-deps

### DIFF
--- a/observatory-platform/observatory/platform/docker/Dockerfile.observatory.jinja2
+++ b/observatory-platform/observatory/platform/docker/Dockerfile.observatory.jinja2
@@ -37,7 +37,7 @@ USER airflow
 RUN pip freeze | xargs pip uninstall -y
 RUN python -m pip install --upgrade pip
 RUN pip cache purge
-RUN pip install apache-airflow-providers-google==5.1.0
+RUN pip install apache-airflow-providers-google==5.1.0 --no-deps
 
 # Install dependencies for all projects
 {% for package in config.python_packages %}

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -14,6 +14,7 @@ google-cloud-bigquery==2.1.*
 google-api-python-client==2.0.*
 google-cloud-storage==1.35.*
 google-auth-oauthlib>=0.4.5,<1
+google-cloud-secret-manager<2.0.0,>=0.2.0 # for Google Cloud Secret Manager backend
 
 # Elasticsearch
 elasticsearch>=7.13.3,<8


### PR DESCRIPTION
Install apache-airflow-providers-google==5.1.0 with --no-deps so that pip doesn't spend forever trying to resolve dependencies for the package. We only use it for the the logging features and the Google Cloud Secret Manager backend; google cloud storage is already a dependency and google-cloud-secret-manager is added as a dependency in requirements.txt.