### PR TITLE
Fix StreamTelescope BQ merge functions

### DIFF
--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -264,12 +264,13 @@ def get_bq_load_info(
 
     :return: List with tuples of transform_blob, main_table_id and partition_table_id
     """
+    bq_info = []
     if batch_load:
-        transform_blob = batch_blob_name(transform_folder)
-        main_table_id, partition_table_id = (dag_id, f"{dag_id}_partitions")
-        bq_info = [(transform_blob, main_table_id, partition_table_id)]
+        if transform_files:
+            transform_blob = batch_blob_name(transform_folder)
+            main_table_id, partition_table_id = (dag_id, f"{dag_id}_partitions")
+            bq_info = [(transform_blob, main_table_id, partition_table_id)]
     else:
-        bq_info = []
         for transform_path in transform_files:
             transform_blob = blob_name(transform_path)
             main_table_id, partition_table_id = table_ids_from_path(transform_path)

--- a/tests/observatory/platform/workflows/test_stream_telescope.py
+++ b/tests/observatory/platform/workflows/test_stream_telescope.py
@@ -147,7 +147,7 @@ class TestTestStreamTelescope(ObservatoryTestCase):
             "merge": False,
         }
         # Fourth release, load partition and update main table (test when days between merge is exactly bq_merge_days)
-        run4 = {"date": pendulum.datetime(year=2020, month=10, day=25), "first_release": False, "merge": True}
+        run4 = {"date": pendulum.datetime(year=2020, month=10, day=18), "first_release": False, "merge": True}
 
         # Setup Observatory environment
         env = ObservatoryEnvironment(self.project_id, self.data_location)
@@ -259,7 +259,9 @@ class TestTestStreamTelescope(ObservatoryTestCase):
                         elif run["merge"]:
                             self.assertEqual(len(bq_load_info), bq_delete_old.call_count)
 
-                            start_date = pendulum.instance(get_prev_start_date_success_task(env.dag_run, ti.task_id))
+                            start_date = pendulum.instance(
+                                get_prev_start_date_success_task(env.dag_run, ti.task_id)
+                            ).start_of("day")
                             end_date = release.end_date
                             expected_calls = []
                             for _, main_table_id, partition_table_id in bq_load_info:
@@ -306,7 +308,9 @@ class TestTestStreamTelescope(ObservatoryTestCase):
                         elif run["merge"]:
                             self.assertEqual(len(bq_load_info), bq_append_from_partition.call_count)
 
-                            start_date = pendulum.instance(get_prev_start_date_success_task(env.dag_run, ti.task_id))
+                            start_date = pendulum.instance(
+                                get_prev_start_date_success_task(env.dag_run, ti.task_id)
+                            ).start_of("day")
                             end_date = release.end_date
                             expected_calls = []
                             for _, main_table_id, partition_table_id in bq_load_info:


### PR DESCRIPTION
- Use task instance start date to determine days between last merge and now, instead of release end date. The release end date is still used to determine the ingestion partition date.
- Check if transform files are available when creating bq_info in case batch_load is set to true. 
Because the bq_delete_old, bq_append_new and cleanup tasks have a trigger rule of 'none_failed', these tasks won't be skipped even when the setup tasks return False (because e.g. no new releases are available). For the case of the unpaywall feed it would try to load a non-existing partition into the main table.