### PR TITLE
Fix double bucket delete race

### DIFF
--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -78,6 +78,7 @@ from typing import Dict, List
 from unittest.mock import patch
 
 import croniter
+import google
 import httpretty
 import paramiko
 import pendulum
@@ -290,6 +291,8 @@ class ObservatoryEnvironment:
             bucket.delete(force=True)
         except requests.exceptions.ReadTimeout:
             pass
+        except google.api_core.exceptions.NotFound:
+            logging.warning(f"Bucket {bucket_id} not found. Did you mean to call _delete_bucket on the same bucket twice?")
 
     def add_dataset(self, prefix: str = "") -> str:
         """Add a BigQuery dataset to the Observatory environment.

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -139,6 +139,9 @@ class TestObservatoryEnvironment(unittest.TestCase):
         env._delete_bucket(bucket_id)
         self.assertFalse(bucket.exists())
 
+        # Test double delete is handled gracefully
+        env._delete_bucket(bucket_id)
+
         # No Google Cloud variables raises error
         bucket_id = random_id()
         with self.assertRaises(AssertionError):

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import unittest
 from datetime import timedelta
@@ -24,7 +25,6 @@ from unittest.mock import patch
 
 import croniter
 import httpretty
-import logging
 import pendulum
 import pysftp
 import timeout_decorator
@@ -197,7 +197,8 @@ class TestObservatoryEnvironment(unittest.TestCase):
                 ti = env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
                 self.assertFalse(ti.log.propagate)
 
-        # Test environment with logging enabled
+            # Test environment with logging enabled
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
         with env.create(task_logging=True):
             with env.create_dag_run(dag, execution_date):
                 # Test add_variable
@@ -213,7 +214,8 @@ class TestObservatoryEnvironment(unittest.TestCase):
                 ti = env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
                 self.assertTrue(ti.log.propagate)
 
-        # Test that previous tasks have to be finished to run next task
+            # Test that previous tasks have to be finished to run next task
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
         with env.create(task_logging=True):
             with env.create_dag_run(dag, execution_date):
                 # Add_variable
@@ -283,6 +285,7 @@ class TestObservatoryEnvironment(unittest.TestCase):
                 self.assertEqual(ti1.job_id, ti2.previous_ti.job_id)
 
         # Use DAG run without freezing time
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
         with env.create():
             # Test add_variable
             env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
@@ -316,12 +319,13 @@ class TestObservatoryEnvironment(unittest.TestCase):
         env = ObservatoryEnvironment(self.project_id, self.data_location)
         telescope = TelescopeTest(schedule_interval=timedelta(days=1))
         dag = telescope.make_dag()
-        execution_date = pendulum.datetime(2021,1,1)
-        expected_dag_date = pendulum.datetime(2021,1,2)
+        execution_date = pendulum.datetime(2021, 1, 1)
+        expected_dag_date = pendulum.datetime(2021, 1, 2)
         with env.create():
             with env.create_dag_run(dag, execution_date):
                 self.assertIsNotNone(env.dag_run)
                 self.assertEqual(expected_dag_date.date(), env.dag_run.start_date.date())
+
 
 class TestObservatoryTestCase(unittest.TestCase):
     """Test the ObservatoryTestCase class"""


### PR DESCRIPTION
calling env.create() more than once on the same ObservatoryEnvironment object can lead it the context trying to clean up the same bucket more than once, causing sporadic test failures.