### PR TITLE
Inf 278/workflow xcom cleanup

### DIFF
--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -60,6 +60,7 @@ from observatory.platform.utils.jinja2_utils import (
     render_template,
 )
 from sqlalchemy import and_
+from sqlalchemy.orm import Session
 
 ScheduleInterval = Union[str, timedelta, relativedelta]
 
@@ -1094,7 +1095,7 @@ def get_chunks(*, input_list: List[Any], chunk_size: int = 8) -> List[Any]:
 
 @provide_session
 def delete_old_xcoms(
-    session: "Callable" = None,
+    session: Session = None,
     dag_id: str = None,
     execution_date: pendulum.DateTime = None,
     retention_days: int = 31,

--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -34,11 +34,11 @@ import pysftp
 import six
 from airflow import AirflowException
 from airflow.hooks.base import BaseHook
-from airflow.models import DagBag, DagRun, Variable
+from airflow.models import DagBag, DagRun, Variable, XCom
 from airflow.secrets.environment_variables import EnvironmentVariablesBackend
+from airflow.utils.db import provide_session
 from dateutil.relativedelta import relativedelta
 from google.cloud import bigquery
-
 from observatory.platform.observatory_config import Environment
 from observatory.platform.utils.airflow_utils import (
     AirflowConns,
@@ -59,6 +59,7 @@ from observatory.platform.utils.jinja2_utils import (
     make_sql_jinja2_filename,
     render_template,
 )
+from sqlalchemy import and_
 
 ScheduleInterval = Union[str, timedelta, relativedelta]
 
@@ -1089,3 +1090,28 @@ def get_chunks(*, input_list: List[Any], chunk_size: int = 8) -> List[Any]:
     n = len(input_list)
     for i in range(0, n, chunk_size):
         yield input_list[i : i + chunk_size]
+
+
+@provide_session
+def delete_old_xcoms(
+    session: "Callable" = None,
+    dag_id: str = None,
+    execution_date: pendulum.DateTime = None,
+    retention_days: int = 31,
+):
+    """Delete XCom messages created by the DAG with the given ID that are as old or older than than
+    execution_date - retention_days.  Defaults to 31 days of retention.
+
+    :param session: DB session.
+    :param dag_id: DAG ID.
+    :param execution_date: DAG execution date.
+    :param retention_days: Days of messages to retain.
+    """
+
+    cut_off_date = execution_date.subtract(days=retention_days)
+    session.query(XCom).filter(
+        and_(
+            XCom.dag_id == dag_id,
+            XCom.execution_date <= cut_off_date,
+        )
+    ).delete()

--- a/observatory-platform/observatory/platform/workflows/organisation_telescope.py
+++ b/observatory-platform/observatory/platform/workflows/organisation_telescope.py
@@ -19,16 +19,16 @@ from typing import Dict, List
 import pendulum
 from google.cloud import bigquery
 from google.cloud.bigquery import SourceFormat
-
 from observatory.api.client.model.organisation import Organisation
-from observatory.platform.workflows.workflow import Release, Workflow
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.workflow_utils import (
     blob_name,
     bq_load_partition,
+    delete_old_xcoms,
     table_ids_from_path,
     upload_files_from_list,
 )
+from observatory.platform.workflows.workflow import Release, Workflow
 
 
 class OrganisationRelease(Release):
@@ -195,7 +195,7 @@ class OrganisationTelescope(Workflow):
                 )
 
     def cleanup(self, releases: List[OrganisationRelease], **kwargs):
-        """Delete files of downloaded, extracted and transformed release.
+        """Delete files of downloaded, extracted and transformed release. Deletes old xcoms.
 
         :param releases: a list of releases.
         :param kwargs:
@@ -203,3 +203,6 @@ class OrganisationTelescope(Workflow):
         """
         for release in releases:
             release.cleanup()
+
+        execution_date = kwargs["execution_date"]
+        delete_old_xcoms(dag_id=self.dag_id, execution_date=execution_date)

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -67,4 +67,4 @@ numpy>=1.20.3,<2
 six>=1.16.0,<2
 
 oauth2client==4.1.*
-importlib-metadata==2.0
+importlib-metadata==3.7.3

--- a/tests/observatory/platform/workflows/test_snapshot_telescope.py
+++ b/tests/observatory/platform/workflows/test_snapshot_telescope.py
@@ -82,3 +82,13 @@ class TestSnapshotTelescope(ObservatoryTestCase):
         releases[0].transform = MagicMock()
         telescope.transform(releases)
         self.assertEqual(releases[0].transform.call_count, 1)
+
+    @patch("observatory.platform.workflows.snapshot_telescope.delete_old_xcoms")
+    @patch("observatory.platform.utils.workflow_utils.Variable.get")
+    def test_cleanup(self, m_get, m_delxcoms):
+        m_get.return_value = "data"
+        telescope = MockTelescope()
+        releases = telescope.make_release()
+        execution_date = pendulum.now()
+        telescope.cleanup(releases, execution_date=execution_date)
+        self.assertEqual(m_delxcoms.call_count, 1)


### PR DESCRIPTION
- Update importlib-metadata to 3.7.3 [Fixes recent general unit test failures in the observatory-platform]
- Add code to cleanup tasks in the telescope templates to delete old (>= 31 days old) xcom messages.