### PR TITLE
on_failure_callback: handle exception value that is a string

### DIFF
--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -675,10 +675,9 @@ def on_failure_callback(context):
         logging.info("Not sending slack notification in develop environment.")
     else:
         exception = context.get("exception")
-        tb = exception
         if isinstance(exception, Exception):
             formatted_exception = "".join(
-                traceback.format_exception(etype=type(exception), value=exception, tb=tb)
+                traceback.format_exception(etype=type(exception), value=exception, tb=exception.__traceback__)
             ).strip()
         else:
             formatted_exception = exception

--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -675,9 +675,14 @@ def on_failure_callback(context):
         logging.info("Not sending slack notification in develop environment.")
     else:
         exception = context.get("exception")
-        formatted_exception = "".join(
-            traceback.format_exception(etype=type(exception), value=exception, tb=exception.__traceback__)
-        ).strip()
+        tb = exception
+        if isinstance(exception, Exception):
+            formatted_exception = "".join(
+                traceback.format_exception(etype=type(exception), value=exception, tb=tb)
+            ).strip()
+        else:
+            formatted_exception = exception
+
         comments = f"Task failed, exception:\n{formatted_exception}"
         ti = context["ti"]
         execution_date = context["execution_date"]


### PR DESCRIPTION
In the on_failure_callback function, the exception value can be a string, which causes exception.__traceback__ to throw an error.