### PR TITLE
Add functionality to use multiple instances for Elastic Import workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,8 +62,6 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_application_credentials.json
           TEST_TERRAFORM_TOKEN: ${{ secrets.TEST_TERRAFORM_TOKEN }}
           TEST_TERRAFORM_ORGANISATION: ${{ secrets.TEST_TERRAFORM_ORGANISATION }}
-          TEST_ELASTIC_HOST: ${{ secrets.TEST_ELASTIC_HOST }}
-          TEST_KIBANA_HOST: ${{ secrets.TEST_KIBANA_HOST }}
           AIRFLOW__CORE__LOAD_EXAMPLES: false
         run: |
           echo "${TEST_GCP_SERVICE_KEY}" | base64 --decode > /tmp/google_application_credentials.json

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,13 @@ Tutorials
 
     tutorials/index
 
+Workflows
+=======================
+.. toctree::
+    :maxdepth: 2
+
+    workflows/index
+
 REST API
 =========================
 .. toctree::

--- a/docs/workflows/elastic_import.md
+++ b/docs/workflows/elastic_import.md
@@ -4,7 +4,7 @@
 +------------------------------+---------+
 | Summary                      |         |
 +==============================+=========+
-| Runs on remote worker        | True    |
+| Runs on remote worker        | False   |
 +------------------------------+---------+
 | Catchup missed runs          | False   |
 +------------------------------+---------+
@@ -34,8 +34,8 @@ Elasticsearch
   Privileges: 'all'
   
 Kibana  
-- To create/delete index patterns, for a limited set of kibana spaces
-  Spaces: <required spaces>
+- To create/delete index patterns, for a limited set of kibana spaces  
+  Spaces: <required spaces>  
   Privileges: Customize -> Management -> Index Pattern Management: All
 
 ### Creating an API key

--- a/docs/workflows/elastic_import.md
+++ b/docs/workflows/elastic_import.md
@@ -1,0 +1,109 @@
+# Elastic Import
+
+```eval_rst
++------------------------------+---------+
+| Summary                      |         |
++==============================+=========+
+| Runs on remote worker        | True    |
++------------------------------+---------+
+| Catchup missed runs          | False   |
++------------------------------+---------+
+| Credentials Required         | Yes     |
++------------------------------+---------+
+| Uses Telescope Template      | Workflow|
++------------------------------+---------+
+```
+
+## Authentication
+This workflow connects to both the Elasticsearch and Kibana server.  
+Through the Elasticsearch client old indices are deleted and new indices as well as aliases are created. 
+Through the Kibana API new index patterns are created in each of the given kibana spaces.  
+Both servers are accessed using the same API key, see below for info on how to create this.
+
+### Required permissions
+It is recommended to create a separate user account for this workflow through the Kibana UI, and to assign a role
+ with a limited set of permissions to this account.
+The minimal permissions that are required for this workflow are:
+
+Elasticsearch  
+- To create new indices  
+  Indices: '*'  
+  Privileges: 'create_index'
+- To delete indices and add/remove aliases, for a limited set of indices  
+  Indices: 'custom-*'
+  Privileges: 'all'
+  
+Kibana  
+- To create/delete index patterns, for a limited set of kibana spaces
+  Spaces: <required spaces>
+  Privileges: Customize -> Management -> Index Pattern Management: All
+
+### Creating an API key
+After setting up the permissions and creating a dedicated user account, it is possible to create an API key for this
+ user through the Elasticsearch API. 
+Creating an API key for a user other than yourself does require the cluster privilege 'grant_api_key' on your
+ Elasticsearch user account.
+ 
+For example to create an API key for the new user account named 'airflow', with the password 'my_password':
+```
+POST /_security/api_key/grant
+{
+  "grant_type": "password",
+  "username" : "airflow",
+  "password" : "my_password",
+  "api_key" : {
+    "name": "elastic_import_workflow"
+  }
+}
+```
+
+This will return a response with the API key id, name and api_key, for example:
+```
+{
+  "id" : "OmyIQn4BWGb2uJ7Wu4uX",
+  "name" : "elastic_import_workflow",
+  "api_key" : "nNfS6FiGQdWJFGSo-4ACGg"
+}
+```
+
+## Airflow connections
+Note that all values need to be urlencoded. 
+In the DAG file for this workflow are ElasticImportConfig instances defined.
+In each config instance, there is a 'elastic_conn_key' and 'kibana_conn_key' variable defined.
+These refer to the Airflow connections that are used to connect to the Elasticsearch/Kibana servers.
+
+For example, if in one of the configs elastic_conn_key="elastic_main" and kibana_conn_key="kibana_main":
+
+### elastic_main
+The elastic_main Airflow connection is used to connect to the Elasticsearch server.  
+To get the api_key_id and api_key, see the section above at 'Creating an API key'.
+The Elasticsearch address and port can be found from the 'endpoint' info at the elastic.co portal. 
+
+```yaml
+elastic_main: https://<api_key_id>:<api_key>@<elastic_address>:<port>
+```
+
+For example if the api_key_id=OmyIQn4BWGb2uJ7Wu4uX, api_key=nNfS6FiGQdWJFGSo-4ACGg and the endpoint info shows 
+ 'https://gcp-project.es.us-west1.gcp.cloud.es.io:9243'
+
+```yaml
+elastic_main: https://OmyIQn4BWGb2uJ7Wu4uX:nNfS6FiGQdWJFGSo-4ACGg@gcp-project.es.us-west1.gcp.cloud.es.io:9243
+```
+ 
+### kibana_main
+The kibana_main Airflow connection is used to connect to the Kibana server.
+
+This connection is similar to the elastic Airflow connection, the only difference is that the kibana_address is used
+ instead of the elastic_address. 
+The api_key_id and api_key are likely to be the same.
+
+```yaml
+kibana_main: https://<api_key_id>:<api_key>@<kibana_address>:<port>
+```
+
+For example if the api_key_id=OmyIQn4BWGb2uJ7Wu4uX, api_key=nNfS6FiGQdWJFGSo-4ACGg and the endpoint info shows 
+ 'https://gcp-project.kb.us-west1.gcp.cloud.es.io:9243'
+
+```yaml
+kibana_main: https://OmyIQn4BWGb2uJ7Wu4uX:nNfS6FiGQdWJFGSo-4ACGg@gcp-project.kb.us-west1.gcp.cloud.es.io:9243
+```

--- a/docs/workflows/index.rst
+++ b/docs/workflows/index.rst
@@ -1,0 +1,6 @@
+Workflows
+----------------------------
+.. toctree::
+    :maxdepth: 1
+
+    elastic_import

--- a/observatory-platform/observatory/platform/docker/compose.py
+++ b/observatory-platform/observatory/platform/docker/compose.py
@@ -23,7 +23,7 @@ from subprocess import Popen
 from typing import Dict, List
 
 from observatory.platform.utils.jinja2_utils import render_template
-from observatory.platform.utils.proc_utils import stream_process
+from observatory.platform.utils.proc_utils import wait_for_process
 
 
 @dataclasses.dataclass
@@ -281,6 +281,6 @@ class ComposeRunner(ComposeRunnerInterface):
         )
 
         # Wait for results
-        output, error = stream_process(proc, self.debug)
+        output, error = wait_for_process(proc)
 
         return ProcessOutput(output, error, proc.returncode)

--- a/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
+++ b/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
@@ -85,6 +85,7 @@ services:
       - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
       - xpack.security.transport.ssl.verification_mode=certificate
       - xpack.license.self_generated.type=${LICENSE}
+    mem_limit: 1073741824
     ulimits:
       memlock:
         soft: -1
@@ -114,6 +115,7 @@ services:
       - ELASTICSEARCH_USERNAME=kibana_system
       - ELASTICSEARCH_PASSWORD={{ password }}
       - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
+    mem_limit: 1073741824
     healthcheck:
       test:
         [

--- a/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
+++ b/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
@@ -1,127 +1,20 @@
-{# Copyright 2022 Curtin University
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Author: Aniek Roelofs -#}
-version: "2.2"
-
 services:
-  setup:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:7.16.2"
+    restart: always
     volumes:
-      - ./certs:/usr/share/elasticsearch/config/certs
-    user: "0"
-    command: >
-      bash -c '
-        if [ ! -f certs/ca.zip ]; then
-          echo "Creating CA";
-          bin/elasticsearch-certutil ca --silent --pem -out config/certs/ca.zip;
-          unzip config/certs/ca.zip -d config/certs;
-        fi;
-        if [ ! -f certs/certs.zip ]; then
-          echo "Creating certs";
-          echo -ne \
-          "instances:\n"\
-          "  - name: es01\n"\
-          "    dns:\n"\
-          "      - es01\n"\
-          "      - localhost\n"\
-          "    ip:\n"\
-          "      - 127.0.0.1\n"\
-          > config/certs/instances.yml;
-          bin/elasticsearch-certutil cert --silent --pem -out config/certs/certs.zip --in config/certs/instances.yml --ca-cert config/certs/ca/ca.crt --ca-key config/certs/ca/ca.key;
-          unzip config/certs/certs.zip -d config/certs;
-        fi;
-        echo "Setting file permissions"
-        chown -R root:root config/certs;
-        find . -type d -exec chmod 750 \{\} \;;
-        find . -type f -exec chmod 640 \{\} \;;
-        echo "Waiting for Elasticsearch availability";
-        until curl -s --cacert config/certs/ca/ca.crt https://es01:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
-        echo "Setting kibana_system password";
-        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:{{ password }} -H "Content-Type: application/json" https://es01:9200/_security/user/kibana_system/_password -d "{\"password\":\"{{ password }}\"}" | grep -q "^{}"; do sleep 10; done;
-        echo "All done!";
-      '
-    healthcheck:
-      test: ["CMD-SHELL", "[ -f config/certs/es01/es01.crt ]"]
-      interval: 1s
-      timeout: 5s
-      retries: 120
-
-  es01:
-    depends_on:
-      setup:
-        condition: service_healthy
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
-    volumes:
-      - ./certs:/usr/share/elasticsearch/config/certs
+      - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
     ports:
       - {{ elastic_port }}:9200
     environment:
-      - ELASTIC_PASSWORD={{ password }}
       - discovery.type=single-node
-      - node.name=es01
-      - cluster.name=${CLUSTER_NAME}
-      - bootstrap.memory_lock=true
-      - xpack.security.enabled=true
-      - xpack.security.http.ssl.enabled=true
-      - xpack.security.http.ssl.key=certs/es01/es01.key
-      - xpack.security.http.ssl.certificate=certs/es01/es01.crt
-      - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
-      - xpack.security.http.ssl.verification_mode=certificate
-      - xpack.security.transport.ssl.enabled=true
-      - xpack.security.transport.ssl.key=certs/es01/es01.key
-      - xpack.security.transport.ssl.certificate=certs/es01/es01.crt
-      - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
-      - xpack.security.transport.ssl.verification_mode=certificate
-      - xpack.license.self_generated.type=${LICENSE}
-    mem_limit: 1073741824
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'",
-        ]
-      interval: 10s
-      timeout: 10s
-      retries: 120
+      - ELASTIC_PASSWORD={{ password }}
 
   kibana:
-    depends_on:
-      es01:
-        condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    volumes:
-      - ./certs:/usr/share/kibana/config/certs
+    image: "docker.elastic.co/kibana/kibana:7.16.2"
+    restart: always
     ports:
       - {{ kibana_port }}:5601
     environment:
-      - SERVERNAME=kibana
-      - ELASTICSEARCH_HOSTS=https://es01:9200
       - ELASTICSEARCH_USERNAME=kibana_system
       - ELASTICSEARCH_PASSWORD={{ password }}
-      - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
-    mem_limit: 1073741824
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
-        ]
-      interval: 10s
-      timeout: 10s
-      retries: 120

--- a/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
+++ b/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
@@ -1,16 +1,125 @@
+{# Copyright 2022 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Aniek Roelofs -#}
+version: "2.2"
+
 services:
-  elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.13.3"
-    restart: always
+  setup:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
     volumes:
-      - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
+      - ./certs:/usr/share/elasticsearch/config/certs
+    user: "0"
+    command: >
+      bash -c '
+        if [ ! -f certs/ca.zip ]; then
+          echo "Creating CA";
+          bin/elasticsearch-certutil ca --silent --pem -out config/certs/ca.zip;
+          unzip config/certs/ca.zip -d config/certs;
+        fi;
+        if [ ! -f certs/certs.zip ]; then
+          echo "Creating certs";
+          echo -ne \
+          "instances:\n"\
+          "  - name: es01\n"\
+          "    dns:\n"\
+          "      - es01\n"\
+          "      - localhost\n"\
+          "    ip:\n"\
+          "      - 127.0.0.1\n"\
+          > config/certs/instances.yml;
+          bin/elasticsearch-certutil cert --silent --pem -out config/certs/certs.zip --in config/certs/instances.yml --ca-cert config/certs/ca/ca.crt --ca-key config/certs/ca/ca.key;
+          unzip config/certs/certs.zip -d config/certs;
+        fi;
+        echo "Setting file permissions"
+        chown -R root:root config/certs;
+        find . -type d -exec chmod 750 \{\} \;;
+        find . -type f -exec chmod 640 \{\} \;;
+        echo "Waiting for Elasticsearch availability";
+        until curl -s --cacert config/certs/ca/ca.crt https://es01:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
+        echo "Setting kibana_system password";
+        until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:{{ password }} -H "Content-Type: application/json" https://es01:9200/_security/user/kibana_system/_password -d "{\"password\":\"{{ password }}\"}" | grep -q "^{}"; do sleep 10; done;
+        echo "All done!";
+      '
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f config/certs/es01/es01.crt ]"]
+      interval: 1s
+      timeout: 5s
+      retries: 120
+
+  es01:
+    depends_on:
+      setup:
+        condition: service_healthy
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    volumes:
+      - ./certs:/usr/share/elasticsearch/config/certs
     ports:
       - {{ elastic_port }}:9200
     environment:
+      - ELASTIC_PASSWORD={{ password }}
       - discovery.type=single-node
+      - node.name=es01
+      - cluster.name=${CLUSTER_NAME}
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.http.ssl.key=certs/es01/es01.key
+      - xpack.security.http.ssl.certificate=certs/es01/es01.crt
+      - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.http.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.key=certs/es01/es01.key
+      - xpack.security.transport.ssl.certificate=certs/es01/es01.crt
+      - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.license.self_generated.type=${LICENSE}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
 
   kibana:
-    image: "docker.elastic.co/kibana/kibana:7.13.3"
-    restart: always
+    depends_on:
+      es01:
+        condition: service_healthy
+    image: docker.elastic.co/kibana/kibana:${VERSION}
+    volumes:
+      - ./certs:/usr/share/kibana/config/certs
     ports:
       - {{ kibana_port }}:5601
+    environment:
+      - SERVERNAME=kibana
+      - ELASTICSEARCH_HOSTS=https://es01:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD={{ password }}
+      - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120

--- a/observatory-platform/observatory/platform/elastic/elastic.py
+++ b/observatory-platform/observatory/platform/elastic/elastic.py
@@ -143,12 +143,13 @@ class StaleIndexCleaner:
 class Elastic:
     def __init__(
         self,
-        host: str = "http://elasticsearch:9200/",
+        host: str,
         thread_count: int = cpu_count(),
         chunk_size: int = 10000,
         timeout: int = 30000,
         api_key_id: str = None,
         api_key: str = None,
+        elasticsearch_kwargs: dict = None,
     ):
         """Create an Elastic API client.
 
@@ -164,7 +165,11 @@ class Elastic:
         self.thread_count = thread_count
         self.chunk_size = chunk_size
         self.timeout = timeout
-        self.es = Elasticsearch(hosts=[self.host], timeout=timeout, api_key=(api_key_id, api_key))
+        if not elasticsearch_kwargs:
+            elasticsearch_kwargs = {}
+        self.es = Elasticsearch(
+            hosts=[self.host], timeout=timeout, api_key=(api_key_id, api_key), **elasticsearch_kwargs
+        )
 
     def query(self, index: str, query: Dict = None):
         if query is None:

--- a/observatory-platform/observatory/platform/elastic/elastic.py
+++ b/observatory-platform/observatory/platform/elastic/elastic.py
@@ -149,7 +149,6 @@ class Elastic:
         timeout: int = 30000,
         api_key_id: str = None,
         api_key: str = None,
-        elasticsearch_kwargs: dict = None,
     ):
         """Create an Elastic API client.
 
@@ -165,11 +164,7 @@ class Elastic:
         self.thread_count = thread_count
         self.chunk_size = chunk_size
         self.timeout = timeout
-        if not elasticsearch_kwargs:
-            elasticsearch_kwargs = {}
-        self.es = Elasticsearch(
-            hosts=[self.host], timeout=timeout, api_key=(api_key_id, api_key), **elasticsearch_kwargs
-        )
+        self.es = Elasticsearch(hosts=[self.host], timeout=timeout, api_key=(api_key_id, api_key))
 
     def query(self, index: str, query: Dict = None):
         if query is None:

--- a/observatory-platform/observatory/platform/elastic/elastic.py
+++ b/observatory-platform/observatory/platform/elastic/elastic.py
@@ -147,6 +147,8 @@ class Elastic:
         thread_count: int = cpu_count(),
         chunk_size: int = 10000,
         timeout: int = 30000,
+        api_key_id: str = None,
+        api_key: str = None,
     ):
         """Create an Elastic API client.
 
@@ -154,13 +156,15 @@ class Elastic:
         :param thread_count: the number of threads to use when loading data into Elastic.
         :param chunk_size: the batch size for loading documents.
         :param timeout: the timeout in seconds.
+        :param api_key_id: the Elastic API key id.
+        :param api_key: the Elastic API key.
         """
 
         self.host = host
         self.thread_count = thread_count
         self.chunk_size = chunk_size
         self.timeout = timeout
-        self.es = Elasticsearch(hosts=[self.host], timeout=timeout)
+        self.es = Elasticsearch(hosts=[self.host], timeout=timeout, api_key=(api_key_id, api_key))
 
     def query(self, index: str, query: Dict = None):
         if query is None:
@@ -219,7 +223,6 @@ class Elastic:
         """
 
         # Load mapping and create index
-
         body = {
             "settings": {
                 "index": {"number_of_shards": 1, "number_of_replicas": 1},

--- a/observatory-platform/observatory/platform/elastic/elastic.py
+++ b/observatory-platform/observatory/platform/elastic/elastic.py
@@ -143,7 +143,7 @@ class StaleIndexCleaner:
 class Elastic:
     def __init__(
         self,
-        host: str,
+        host: str = "http://elasticsearch:9200/",
         thread_count: int = cpu_count(),
         chunk_size: int = 10000,
         timeout: int = 30000,

--- a/observatory-platform/observatory/platform/elastic/elastic_environment.py
+++ b/observatory-platform/observatory/platform/elastic/elastic_environment.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: James Diprose
+# Author: James Diprose, Aniek Roelofs
 
 import logging
 import os
@@ -29,11 +29,19 @@ from observatory.platform.utils.config_utils import module_file_path
 class ElasticEnvironment(ComposeRunner):
     HTTP_OK = 200
 
+    # Version of Elastic products
+    VERSION = "7.16.2"
+    # Set the cluster name
+    CLUSTER_NAME = "docker-cluster"
+    # Set to 'basic' or 'trial' to automatically start the 30-day trial
+    LICENSE = "basic"
+
     def __init__(
         self,
         build_path: str,
         elastic_port: int = 9200,
         kibana_port: int = 5601,
+        password: str = "observatory",
         wait: bool = True,
         wait_time_secs: int = 120,
     ):
@@ -49,18 +57,17 @@ class ElasticEnvironment(ComposeRunner):
         self.elastic_module_path = module_file_path("observatory.platform.elastic")
         self.wait = wait
         self.wait_time_secs = wait_time_secs
-        self.elastic_uri = f"http://localhost:{elastic_port}/"
+        self.elastic_port = elastic_port
+        self.elastic_uri = f"https://localhost:{elastic_port}/"
         self.kibana_uri = f"http://localhost:{kibana_port}/"
+        self.password = password
+        self.build_path = build_path
+        self.ca_certs_path = os.path.join(self.build_path, "certs", "ca", "ca.crt")
         super().__init__(
             compose_template_path=os.path.join(self.elastic_module_path, "docker-compose.yml.jinja2"),
             build_path=build_path,
-            compose_template_kwargs={"elastic_port": elastic_port, "kibana_port": kibana_port},
+            compose_template_kwargs={"elastic_port": elastic_port, "kibana_port": kibana_port, "password": password},
             debug=True,
-        )
-
-        # Add files
-        self.add_file(
-            path=os.path.join(self.elastic_module_path, "elasticsearch.yml"), output_file_name="elasticsearch.yml"
         )
 
         # Stop the awful unnecessary Elasticsearch connection warnings being logged
@@ -72,8 +79,8 @@ class ElasticEnvironment(ComposeRunner):
 
         :return: the environment.
         """
-
-        return os.environ.copy()
+        elastic_settings = {"VERSION": self.VERSION, "CLUSTER_NAME": self.CLUSTER_NAME, "LICENSE": self.LICENSE}
+        return {**os.environ.copy(), **elastic_settings}
 
     def start(self) -> ProcessOutput:
         """Start the Elastic environment.
@@ -86,6 +93,22 @@ class ElasticEnvironment(ComposeRunner):
         if self.wait:
             self.wait_until_started()
         return process_output
+
+    def create_api_key(self) -> [str, str]:
+        """Create an API key for the 'elastic' superuser
+
+        :return: API key id and API key
+        """
+        es = Elasticsearch(
+            [f"elastic:{self.password}@localhost:{self.elastic_port}/"],
+            use_ssl=True,
+            verify_certs=True,
+            ca_certs=self.ca_certs_path,
+        )
+        response = es.security.create_api_key(body={"name": "elastic_environment_key"})
+        api_key_id = response["id"]
+        api_key = response["api_key"]
+        return api_key_id, api_key
 
     def kibana_ping(self):
         """Check if Kibana has started or not.
@@ -105,8 +128,12 @@ class ElasticEnvironment(ComposeRunner):
 
         :return: whether started or not.
         """
-
-        es = Elasticsearch([self.elastic_uri])
+        es = Elasticsearch(
+            [f"https://elastic:{self.password}@localhost:{self.elastic_port}/"],
+            use_ssl=True,
+            verify_certs=True,
+            ca_certs=self.ca_certs_path,
+        )
         start = time.time()
         while True:
             elastic_found = es.ping()

--- a/observatory-platform/observatory/platform/elastic/elasticsearch.yml
+++ b/observatory-platform/observatory/platform/elastic/elasticsearch.yml
@@ -1,0 +1,3 @@
+cluster.name: "test-es-cluster"
+network.host: 0.0.0.0
+discovery.zen.minimum_master_nodes: 1

--- a/observatory-platform/observatory/platform/elastic/elasticsearch.yml
+++ b/observatory-platform/observatory/platform/elastic/elasticsearch.yml
@@ -1,3 +1,0 @@
-cluster.name: "test-es-cluster"
-network.host: 0.0.0.0
-discovery.zen.minimum_master_nodes: 1

--- a/observatory-platform/observatory/platform/elastic/kibana.py
+++ b/observatory-platform/observatory/platform/elastic/kibana.py
@@ -59,15 +59,28 @@ class Kibana:
 
     headers = {"Content-Type": "application/json", "kbn-xsrf": "true"}
 
-    def __init__(self, host: str = "http://kibana:5601/", api_key_id: str = None, api_key: str = None):
+    def __init__(
+        self,
+        host: str = "http://kibana:5601/",
+        username: str = None,
+        password: str = None,
+        api_key_id: str = None,
+        api_key: str = None,
+    ):
         """Create a Kibana API client.
 
         :param host: the host including the hostname and port.
+        :param username: the Kibana username
+        :param password: the Kibana password
         :param api_key_id: the Kibana API key id.
         :param api_key: the Kibana API key.
         """
 
         self.host = host
+
+        if username and password:
+            auth = base64.b64encode(f"{username}:{password}".encode()).decode()
+            self.headers["Authroization"] = f"Basic {auth}"
 
         if api_key_id and api_key:
             auth = base64.b64encode(f"{api_key_id}:{api_key}".encode()).decode()

--- a/observatory-platform/observatory/platform/elastic/kibana.py
+++ b/observatory-platform/observatory/platform/elastic/kibana.py
@@ -56,8 +56,6 @@ class ObjectType(Enum):
 class Kibana:
     HTTP_NOT_FOUND = 404
 
-    headers: dict = None
-
     def __init__(
         self,
         host: str = "http://kibana:5601/",
@@ -65,6 +63,7 @@ class Kibana:
         password: str = None,
         api_key_id: str = None,
         api_key: str = None,
+        headers: dict = None,
     ):
         """Create a Kibana API client.
 
@@ -73,7 +72,9 @@ class Kibana:
         :param password: the Kibana password
         :param api_key_id: the Kibana API key id.
         :param api_key: the Kibana API key.
+        :param headers: the headers that will be used with the Kibana API
         """
+        self.headers = headers
         if not self.headers:
             self.headers = {"Content-Type": "application/json", "kbn-xsrf": "true"}
 

--- a/observatory-platform/observatory/platform/elastic/kibana.py
+++ b/observatory-platform/observatory/platform/elastic/kibana.py
@@ -43,25 +43,6 @@ class TimeField:
     field_name: str = None
 
 
-def parse_kibana_url(url):
-    """Parse a Kibana URL into host + port and username and password.
-
-    :param url: the full url.
-    :return: the host + port, username and password.
-    """
-
-    parts = urlparse(url)
-    username = parts.username
-    password = parts.password
-    port = parts.port
-    parts = parts._replace(netloc=parts.hostname)
-    kibana_host = parts.geturl()
-    if port is not None:
-        kibana_host += f":{port}"
-
-    return kibana_host, username, password
-
-
 class ObjectType(Enum):
     """Valid Kibana saved object types"""
 

--- a/observatory-platform/observatory/platform/elastic/kibana.py
+++ b/observatory-platform/observatory/platform/elastic/kibana.py
@@ -80,7 +80,7 @@ class Kibana:
 
         if username and password:
             auth = base64.b64encode(f"{username}:{password}".encode()).decode()
-            self.headers["Authroization"] = f"Basic {auth}"
+            self.headers["Authorization"] = f"Basic {auth}"
 
         if api_key_id and api_key:
             auth = base64.b64encode(f"{api_key_id}:{api_key}".encode()).decode()

--- a/observatory-platform/observatory/platform/elastic/kibana.py
+++ b/observatory-platform/observatory/platform/elastic/kibana.py
@@ -26,7 +26,6 @@ import logging
 from enum import Enum
 from posixpath import join as urljoin
 from typing import Dict, List
-from urllib.parse import urlparse
 
 import requests
 
@@ -57,7 +56,7 @@ class ObjectType(Enum):
 class Kibana:
     HTTP_NOT_FOUND = 404
 
-    headers = {"Content-Type": "application/json", "kbn-xsrf": "true"}
+    headers: dict = None
 
     def __init__(
         self,
@@ -75,6 +74,8 @@ class Kibana:
         :param api_key_id: the Kibana API key id.
         :param api_key: the Kibana API key.
         """
+        if not self.headers:
+            self.headers = {"Content-Type": "application/json", "kbn-xsrf": "true"}
 
         self.host = host
 

--- a/observatory-platform/observatory/platform/utils/airflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/airflow_utils.py
@@ -51,8 +51,6 @@ class AirflowConns:
     CROSSREF = "crossref"
     TERRAFORM = "terraform"
     SLACK = "slack"
-    ELASTIC = "elastic"
-    KIBANA = "kibana"
     GEOIP_LICENSE_KEY = "geoip_license_key"
     OAPEN_IRUS_UK_API = "oapen_irus_uk_api"
     OAPEN_IRUS_UK_LOGIN = "oapen_irus_uk_login"

--- a/strategy.ini
+++ b/strategy.ini
@@ -66,4 +66,4 @@ Pillow: >=7.2.0
 precipy: >=0.2.2
 
 # Apache 2.0 license, but this is not classified properly, see https://github.com/p1c2u/openapi-spec-validator/issues/138
-openapi-spec-validator>=0.3.1,<1
+openapi-spec-validator: >=0.3.1,<1

--- a/strategy.ini
+++ b/strategy.ini
@@ -64,3 +64,6 @@ Pillow: >=7.2.0
 
 # Precipy was developed for the project, a license will be added to the repo shortly
 precipy: >=0.2.2
+
+# Apache 2.0 license, but this is not classified properly, see https://github.com/p1c2u/openapi-spec-validator/issues/138
+openapi-spec-validator>=0.3.1,<1

--- a/tests/observatory/platform/elastic/test_elastic.py
+++ b/tests/observatory/platform/elastic/test_elastic.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: James Diprose
+# Author: James Diprose, Aniek Roelofs
 
 import json
 import os
+import shutil
+import tempfile
 import unittest
 
 import pendulum
@@ -26,15 +28,42 @@ from observatory.platform.elastic.elastic import (
     make_elastic_uri,
     make_sharded_index,
 )
+from observatory.platform.elastic.elastic_environment import ElasticEnvironment
 from observatory.platform.utils.file_utils import load_file, yield_csv
 from observatory.platform.utils.test_utils import random_id, test_fixtures_path
 
 
 class TestElastic(unittest.TestCase):
+    es: ElasticEnvironment = None
+    temp_dir: str = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Create a temporary directory
+        cls.temp_dir = tempfile.mkdtemp()
+
+        # Start an Elastic environment
+        elastic_build_path = os.path.join(cls.temp_dir, "elastic")
+        cls.es = ElasticEnvironment(build_path=elastic_build_path)
+        cls.es.start()
+
+        # Create API key
+        api_key_id, api_key = cls.es.create_api_key()
+
+        # Create elasticsearch client
+        es_settings = {"use_ssl": True, "verify_certs": True, "ca_certs": cls.es.ca_certs_path}
+        cls.client = Elastic(
+            host=cls.es.elastic_uri, api_key_id=api_key_id, api_key=api_key, elasticsearch_kwargs=es_settings
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if os.path.isdir(cls.temp_dir):
+            shutil.rmtree(cls.temp_dir)
+        cls.es.stop()
+
     def __init__(self, *args, **kwargs):
         super(TestElastic, self).__init__(*args, **kwargs)
-        self.host: str = os.getenv("TEST_ELASTIC_HOST")
-        assert self.host is not None, "TestElastic: please set the TEST_ELASTIC_HOST environment variable."
 
         fixtures_path = test_fixtures_path("elastic")
         self.csv_file_path = os.path.join(fixtures_path, "load_csv_gz.csv.gz")
@@ -73,76 +102,71 @@ class TestElastic(unittest.TestCase):
     ################
 
     def test_index_delete_documents(self):
-        # Make client and identifiers
-        client = Elastic(host=self.host)
         index_id = random_id()
 
         def index_exists():
-            return client.es.indices.exists(index_id)
+            return self.client.es.indices.exists(index_id)
 
         def doc_count():
-            return client.es.count(index=index_id, body={"query": {"match_all": {}}})["count"]
+            return self.client.es.count(index=index_id, body={"query": {"match_all": {}}})["count"]
 
         try:
             # Index
             mapping_dict = json.loads(load_file(self.mappings_file_path))
-            success = client.index_documents(index_id, mapping_dict, yield_csv(self.csv_file_path))
+            success = self.client.index_documents(index_id, mapping_dict, yield_csv(self.csv_file_path))
             self.assertTrue(success)
             self.assertTrue(index_exists())
             self.assertEqual(4, doc_count())
 
             # Delete
-            client.delete_index(index_id)
+            self.client.delete_index(index_id)
             self.assertFalse(index_exists())
         finally:
             # Cleanup
-            client.delete_index(index_id)
+            self.client.delete_index(index_id)
 
     def test_get_alias_indexes(self):
         """Test that a list of indexes associated with an alias are returned"""
 
-        # Make client and identifiers
-        client = Elastic(host=self.host)
+        # Make identifiers
         index_id = random_id()
         alias_id = random_id()
 
         try:
             # Make index
-            client.es.indices.create(index=index_id)
+            self.client.es.indices.create(index=index_id)
 
             # Make aliases
-            client.es.indices.update_aliases({"actions": [{"add": {"index": index_id, "alias": alias_id}}]})
+            self.client.es.indices.update_aliases({"actions": [{"add": {"index": index_id, "alias": alias_id}}]})
 
-            index_ids = client.get_alias_indexes(alias_id)
+            index_ids = self.client.get_alias_indexes(alias_id)
             self.assertListEqual([index_id], index_ids)
         finally:
             # Delete index and aliases
-            client.es.indices.update_aliases({"actions": [{"remove": {"index": index_id, "alias": alias_id}}]})
-            client.delete_index(index_id)
+            self.client.es.indices.update_aliases({"actions": [{"remove": {"index": index_id, "alias": alias_id}}]})
+            self.client.delete_index(index_id)
 
     def test_index_create_list_delete(self):
-        client = Elastic(host=self.host)
         index = random_id()
         index2 = random_id()
 
-        client.create_index(index)
-        client.create_index(index2)
-        indices = client.list_indices(index)
+        self.client.create_index(index)
+        self.client.create_index(index2)
+        indices = self.client.list_indices(index)
         self.assertEqual(len(indices), 1)
 
-        indices = client.list_indices(index2)
+        indices = self.client.list_indices(index2)
         self.assertEqual(len(indices), 1)
 
-        client.delete_indices([index, index2])
+        self.client.delete_indices([index, index2])
 
-        indices = client.list_indices(index)
+        indices = self.client.list_indices(index)
         self.assertEqual(len(indices), 0)
 
-        indices = client.list_indices(index2)
+        indices = self.client.list_indices(index2)
         self.assertEqual(len(indices), 0)
 
     def test_delete_stale_indices_newest(self):
-        client = Elastic(host=self.host)
         prefix = random_id()
 
         index1 = f"{prefix}-first-notendinginyyyymmdd"
@@ -156,35 +180,34 @@ class TestElastic(unittest.TestCase):
 
         indices = [index1, index2, index3, index4, index5, index6, index7]
         for idx in indices:
-            client.create_index(idx)
+            self.client.create_index(idx)
 
         # Test stale deletion
-        client.delete_stale_indices(index=f"{prefix}*", keep_info=KeepInfo(ordering=KeepOrder.newest, num=2))
-        val_indices = client.list_indices(index1)
+        self.client.delete_stale_indices(index=f"{prefix}*", keep_info=KeepInfo(ordering=KeepOrder.newest, num=2))
+        val_indices = self.client.list_indices(index1)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index2)
+        val_indices = self.client.list_indices(index2)
         self.assertEqual(len(val_indices), 0)
 
-        val_indices = client.list_indices(index3)
+        val_indices = self.client.list_indices(index3)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index4)
+        val_indices = self.client.list_indices(index4)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index5)
+        val_indices = self.client.list_indices(index5)
         self.assertEqual(len(val_indices), 0)
 
-        val_indices = client.list_indices(index6)
+        val_indices = self.client.list_indices(index6)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index7)
+        val_indices = self.client.list_indices(index7)
         self.assertEqual(len(val_indices), 1)
 
-        client.delete_indices(indices)
+        self.client.delete_indices(indices)
 
     def test_delete_stale_indices_oldest(self):
-        client = Elastic(host=self.host)
         prefix = random_id()
 
         index1 = f"{prefix}-first-notendinginyyyymmdd"
@@ -198,29 +221,29 @@ class TestElastic(unittest.TestCase):
 
         indices = [index1, index2, index3, index4, index5, index6, index7]
         for idx in indices:
-            client.create_index(idx)
+            self.client.create_index(idx)
 
         # Test stale deletion
-        client.delete_stale_indices(index=f"{prefix}*", keep_info=KeepInfo(ordering=KeepOrder.oldest, num=2))
-        val_indices = client.list_indices(index1)
+        self.client.delete_stale_indices(index=f"{prefix}*", keep_info=KeepInfo(ordering=KeepOrder.oldest, num=2))
+        val_indices = self.client.list_indices(index1)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index2)
+        val_indices = self.client.list_indices(index2)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index3)
+        val_indices = self.client.list_indices(index3)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index4)
+        val_indices = self.client.list_indices(index4)
         self.assertEqual(len(val_indices), 0)
 
-        val_indices = client.list_indices(index5)
+        val_indices = self.client.list_indices(index5)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index6)
+        val_indices = self.client.list_indices(index6)
         self.assertEqual(len(val_indices), 1)
 
-        val_indices = client.list_indices(index7)
+        val_indices = self.client.list_indices(index7)
         self.assertEqual(len(val_indices), 0)
 
-        client.delete_indices(indices)
+        self.client.delete_indices(indices)

--- a/tests/observatory/platform/elastic/test_elastic_environment.py
+++ b/tests/observatory/platform/elastic/test_elastic_environment.py
@@ -46,7 +46,6 @@ class TestElasticEnvironment(unittest.TestCase):
                 self.assertEqual(response.return_code, 0)
 
                 # Check that files are copied
-                self.assertTrue(os.path.isfile(os.path.join(build_path, "elasticsearch.yml")))
                 self.assertTrue(os.path.isfile(os.path.join(build_path, "docker-compose.yml")))
 
                 # Wait until found

--- a/tests/observatory/platform/elastic/test_kibana.py
+++ b/tests/observatory/platform/elastic/test_kibana.py
@@ -42,9 +42,6 @@ class TestKibana(unittest.TestCase):
     def tearDownClass(cls) -> None:
         cls.es.stop()
 
-    def __init__(self, *args, **kwargs):
-        super(TestKibana, self).__init__(*args, **kwargs)
-
     def test_kibana(self):
         """Test initialisation of Kibana class with different arguments"""
         kibana = Kibana(host="host")

--- a/tests/observatory/platform/elastic/test_kibana.py
+++ b/tests/observatory/platform/elastic/test_kibana.py
@@ -26,14 +26,14 @@ class TestParseKibanaUrl(unittest.TestCase):
     def test_parse_kibana_url(self):
         """Parse Kibana URL"""
 
-        url = "https://user.account:password@random-id.us-west1.gcp.cloud.es.io:9243"
+        url = "https://api_key_id:api_key@random-id.us-west1.gcp.cloud.es.io:9243"
         expected_host = "https://random-id.us-west1.gcp.cloud.es.io:9243"
-        expected_username = "user.account"
-        expected_password = "password"
+        expected_key_id = "api_key_id"
+        expected_key = "api_key"
         kibana_host, username, password = parse_kibana_url(url)
         self.assertEqual(expected_host, kibana_host)
-        self.assertEqual(expected_username, username)
-        self.assertEqual(expected_password, password)
+        self.assertEqual(expected_key_id, username)
+        self.assertEqual(expected_key, password)
 
 
 class TestKibana(unittest.TestCase):
@@ -44,13 +44,13 @@ class TestKibana(unittest.TestCase):
 
         kibana_host: str = os.getenv("TEST_KIBANA_HOST")
         assert kibana_host is not None, "TestKibana: please set the TEST_KIBANA_HOST environment variable."
-        self.kibana_host, self.username, self.password = parse_kibana_url(kibana_host)
+        self.kibana_host, self.key_id, self.api_key = parse_kibana_url(kibana_host)
 
     def test_create_delete_space(self):
         """Test the creation and deletion of spaces"""
 
         # Make clients
-        kibana = Kibana(host=self.kibana_host, username=self.username, password=self.password)
+        kibana = Kibana(host=self.kibana_host, api_key_id=self.key_id, api_key=self.api_key)
 
         # Parameters
         space_id = random_id()
@@ -71,7 +71,7 @@ class TestKibana(unittest.TestCase):
         """Test the creation and deletion of index patterns"""
 
         # Make clients
-        kibana = Kibana(host=self.kibana_host, username=self.username, password=self.password)
+        kibana = Kibana(host=self.kibana_host, api_key_id=self.key_id, api_key=self.api_key)
         elastic = Elastic(host=self.elastic_host)
 
         # Parameters

--- a/tests/observatory/platform/elastic/test_kibana.py
+++ b/tests/observatory/platform/elastic/test_kibana.py
@@ -45,6 +45,23 @@ class TestKibana(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestKibana, self).__init__(*args, **kwargs)
 
+    def test_kibana(self):
+        """Test initialisation of Kibana class with different arguments"""
+        kibana = Kibana(host="host")
+        self.assertEqual("host", kibana.host)
+        self.assertDictEqual({"Content-Type": "application/json", "kbn-xsrf": "true"}, kibana.headers)
+
+        kibana = Kibana(username="user", password="password")
+        self.assertDictEqual(
+            {"Content-Type": "application/json", "kbn-xsrf": "true", "Authorization": "Basic dXNlcjpwYXNzd29yZA=="},
+            kibana.headers,
+        )
+
+        kibana = Kibana(api_key_id="id", api_key="key")
+        self.assertDictEqual(
+            {"Content-Type": "application/json", "kbn-xsrf": "true", "Authorization": "ApiKey aWQ6a2V5"}, kibana.headers
+        )
+
     def test_create_delete_space(self):
         """Test the creation and deletion of spaces"""
         # Parameters

--- a/tests/observatory/platform/utils/test_proc_utils.py
+++ b/tests/observatory/platform/utils/test_proc_utils.py
@@ -1,0 +1,88 @@
+# Copyright 2022 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Aniek Roelofs
+
+import subprocess
+from subprocess import Popen
+
+from observatory.platform.utils.proc_utils import wait_for_process, stream_process
+import unittest
+from unittest.mock import patch
+
+
+class TestProcUtils(unittest.TestCase):
+    def test_wait_for_process(self):
+        # Test stdout
+        proc: Popen = subprocess.Popen(
+            ["echo", "foo"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        out, _ = wait_for_process(proc)
+        self.assertEqual("foo\n", out)
+
+        # Test stderr
+        proc: Popen = subprocess.Popen(
+            ["ls", "bar"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        _, err = wait_for_process(proc)
+        self.assertEqual("ls: bar: No such file or directory\n", err)
+
+    @patch("builtins.print")
+    def test_stream_process(self, mock_print):
+        # Test stdout with debug=False
+        proc: Popen = subprocess.Popen(
+            ["echo", "foo"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        out, _ = stream_process(proc, False)
+        self.assertEqual("foo\n", out)
+        mock_print.assert_not_called()
+        mock_print.reset_mock()
+
+        # Test stderr with debug=False
+        proc: Popen = subprocess.Popen(
+            ["ls", "bar"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        _, err = stream_process(proc, False)
+        self.assertEqual("ls: bar: No such file or directory\n", err)
+        mock_print.assert_called_once_with("ls: bar: No such file or directory\n", end="")
+        mock_print.reset_mock()
+
+        # Test stdout with debug=True
+        proc: Popen = subprocess.Popen(
+            ["echo", "foo"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        out, _ = stream_process(proc, True)
+        self.assertEqual("foo\n", out)
+        mock_print.assert_called_once_with("foo\n", end="")
+        mock_print.reset_mock()
+
+        # Test stderr with debug=True
+        proc: Popen = subprocess.Popen(
+            ["ls", "bar"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        _, err = stream_process(proc, True)
+        self.assertEqual("ls: bar: No such file or directory\n", err)
+        mock_print.assert_called_once_with("ls: bar: No such file or directory\n", end="")


### PR DESCRIPTION
As discussed on slack and thanks to your pointers @jdddog:
- Update Elastic Import workflow to use an Airflow connection based on a variable defined in ElasticImportConfig. This makes it possible to use multiple Airflow connections for different Elasticsearch/Kibana instances.
- Update the Elastic and Kibana clients to use an API key instead of username/password.
- Update unit tests to use ElasticEnvironment instead of deployed elastic cluster.

The config.yml file needs to be updated to use the following Airflow connections:
```
elastic_main: https://<api_key_id>:<api_key>@<elastic_address>:<port>
elastic_public: https://<api_key_id>:<api_key>@<elastic_address>:<port>
kibana_main: https://<api_key_id>:<api_key>@<kibana_address>:<port>
kibana_public: https://<api_key_id>:<api_key>@<kibana_address>:<port>
```

The PR's for academic-observatory-workflows and oaebu-workflows will have to be reviewed and merged after this one as well.

EDIT: the github secrets do not have to be updated anymore since all unit tests now use the ElasticEnvironment