### PR TITLE
Update API key documentation and fix AIRFLOW__CORE__SQL_ALCHEMY_CONN

### DIFF
--- a/docs/workflows/elastic_import.md
+++ b/docs/workflows/elastic_import.md
@@ -23,8 +23,8 @@ of the given Kibana spaces. Both servers are accessed using the same API key, se
 In the Kibana dev console, run the below command, being careful to customise the following:
 * index.names: add wildcard prefixes for indexes that this API key should have access to, or give it access
   to all indexes with the wildcard "*".
-* applications.resources: add the specific spaces that the API key should have access to in the form "space:my-space-id",
-  or give the API key access to all spaces with the wildcard "*".
+* applications.resources: add the specific Kibana spaces that the API key should have access to in the form 
+  "space:my-space-id", or give the API key access to all spaces with the wildcard "*".
 
 ```
 POST /_security/api_key 

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -46,7 +46,7 @@ version: '3.8'
 x-environment: &environment
   # Airflow settings
   AIRFLOW__CORE__EXECUTOR: CeleryExecutor
-  AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgres+psycopg2://{{ postgres_user }}:{{ postgres_password }}@{{ postgres_hostname }}:5432/{{ airflow_db_name }}"
+  AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgresql+psycopg2://{{ postgres_user }}:{{ postgres_password }}@{{ postgres_hostname }}:5432/{{ airflow_db_name }}"
   AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW_FERNET_KEY}
   AIRFLOW__CORE__LOAD_EXAMPLES: "False"
   AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: "False"


### PR DESCRIPTION
Changed:
* postgres+psycopg2 to postgresql+psycopg2 as the first option does not work anymore with SQL Alchemy.
* Updated the Elastic and Kibana API key documentation to show you how to create an API key for Airflow using the Kibana Dev Console. I personally prefer to create an API key in this way, because then you don't need to create and manage another user account and password.