### PR TITLE
OpenAlex telescope changes

### DIFF
--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -46,7 +46,7 @@ version: '3.8'
 x-environment: &environment
   # Airflow settings
   AIRFLOW__CORE__EXECUTOR: CeleryExecutor
-  AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgres+psycopg2://{{ postgres_user }}:{{ postgres_password }}@{{ postgres_hostname }}:5432/{{ airflow_db_name }}"
+  AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgresql+psycopg2://{{ postgres_user }}:{{ postgres_password }}@{{ postgres_hostname }}:5432/{{ airflow_db_name }}"
   AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW_FERNET_KEY}
   AIRFLOW__CORE__LOAD_EXAMPLES: "False"
   AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: "False"

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -659,6 +659,23 @@ class ObservatoryTestCase(unittest.TestCase):
                 [], actual_content, msg=f"Rows in actual content that are not in expected content: {actual_content}"
             )
 
+    def assert_table_bytes(self, table_id: str, expected_bytes: int):
+        """Assert whether the given bytes from a BigQuery table matches the expected bytes.
+
+        :param table_id: the BigQuery table id.
+        :param expected_bytes: the expected number of bytes.
+        :return: whether the table exists and the expected bytes match
+        """
+
+        table = None
+        try:
+            table = self.bigquery_client.get_table(table_id)
+        except NotFound:
+            pass
+
+        self.assertIsNotNone(table)
+        self.assertEqual(expected_bytes, table.num_bytes)
+
     def assert_file_integrity(self, file_path: str, expected_hash: str, algorithm: str):
         """Assert that a file exists and it has the correct hash.
 

--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -250,32 +250,6 @@ def prepare_bq_load(
     return project_id, bucket_name, data_location, schema_file_path
 
 
-def get_bq_load_info(
-    dag_id: str, transform_folder: str, transform_files: List[str], batch_load: bool
-) -> List[Tuple[str, str, str]]:
-    """Get (a list of) the transform blob, main table id and partition table id that are used to load data into
-    BigQuery.
-    When the batch_load property of the telescope is set to True, all blobs in the transform folder will be loaded
-    into 1 table at once.
-    When the batch_load property of the telescope is set to False, each blob in the transform folder will be used to
-    create/update an individual table.
-
-    :return: List with tuples of transform_blob, main_table_id and partition_table_id
-    """
-    bq_info = []
-    if batch_load:
-        if transform_files:
-            transform_blob = batch_blob_name(transform_folder)
-            main_table_id, partition_table_id = (dag_id, f"{dag_id}_partitions")
-            bq_info = [(transform_blob, main_table_id, partition_table_id)]
-    else:
-        for transform_path in transform_files:
-            transform_blob = blob_name(transform_path)
-            main_table_id, partition_table_id = table_ids_from_path(transform_path)
-            bq_info.append((transform_blob, main_table_id, partition_table_id))
-    return bq_info
-
-
 def prepare_bq_load_v2(
     schema_folder: str,
     project_id: str,

--- a/observatory-platform/observatory/platform/workflows/stream_telescope.py
+++ b/observatory-platform/observatory/platform/workflows/stream_telescope.py
@@ -184,6 +184,7 @@ class StreamTelescope(Workflow):
         When the batch_load property of the telescope is set to False, each blob in the transform folder will be used to
         create/update an individual table.
 
+        :param release: The release object.
         :return: List with tuples of transform_blob, main_table_id and partition_table_id
         """
         bq_info = []

--- a/observatory-platform/observatory/platform/workflows/stream_telescope.py
+++ b/observatory-platform/observatory/platform/workflows/stream_telescope.py
@@ -15,7 +15,7 @@
 # Author: Aniek Roelofs, James Diprose, Tuan Chien
 
 import logging
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List
 
 import pendulum
 from airflow.exceptions import AirflowSkipException
@@ -24,13 +24,15 @@ from croniter import croniter
 from google.cloud.bigquery import SourceFormat
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.workflow_utils import (
+    batch_blob_name,
+    blob_name,
     bq_append_from_file,
     bq_append_from_partition,
     bq_delete_old,
     bq_load_ingestion_partition,
     delete_old_xcoms,
-    get_bq_load_info,
     is_first_dag_run,
+    table_ids_from_path,
     upload_files_from_list,
 )
 from observatory.platform.workflows.workflow import Release, Workflow
@@ -174,6 +176,29 @@ class StreamTelescope(Workflow):
 
         return start_date, end_date, first_release
 
+    def get_bq_load_info(self, release: StreamRelease) -> List[Tuple[str, str, str]]:
+        """Get (a list of) the transform blob, main table id and partition table id that are used to load data into
+        BigQuery.
+        When the batch_load property of the telescope is set to True, all blobs in the transform folder will be loaded
+        into 1 table at once.
+        When the batch_load property of the telescope is set to False, each blob in the transform folder will be used to
+        create/update an individual table.
+
+        :return: List with tuples of transform_blob, main_table_id and partition_table_id
+        """
+        bq_info = []
+        if self.batch_load:
+            if release.transform_files:
+                transform_blob = batch_blob_name(release.transform_folder)
+                main_table_id, partition_table_id = (self.dag_id, f"{self.dag_id}_partitions")
+                bq_info = [(transform_blob, main_table_id, partition_table_id)]
+        else:
+            for transform_path in release.transform_files:
+                transform_blob = blob_name(transform_path)
+                main_table_id, partition_table_id = table_ids_from_path(transform_path)
+                bq_info.append((transform_blob, main_table_id, partition_table_id))
+        return bq_info
+
     def download(self, release: StreamRelease, **kwargs):
         """Task to download the StreamRelease release.
 
@@ -231,7 +256,7 @@ class StreamTelescope(Workflow):
             # because a first release can be relatively big in size.
             raise AirflowSkipException("Skipped, because first release")
 
-        bq_load_info = get_bq_load_info(self.dag_id, release.transform_folder, release.transform_files, self.batch_load)
+        bq_load_info = self.get_bq_load_info(release)
         for transform_blob, main_table_id, partition_table_id in bq_load_info:
             table_description = self.table_descriptions.get(main_table_id, "")
             bq_load_ingestion_partition(
@@ -262,7 +287,7 @@ class StreamTelescope(Workflow):
 
         logging.info(f"Deleting old data from main table using partition with ingestion date of {release.end_date}")
         bytes_budget = kwargs.get("bytes_budget", None)
-        bq_load_info = get_bq_load_info(self.dag_id, release.transform_folder, release.transform_files, self.batch_load)
+        bq_load_info = self.get_bq_load_info(release)
         for _, main_table_id, partition_table_id in bq_load_info:
             bq_delete_old(
                 release.end_date,
@@ -280,7 +305,7 @@ class StreamTelescope(Workflow):
         :param kwargs: The context passed from the PythonOperator.
         :return: None.
         """
-        bq_load_info = get_bq_load_info(self.dag_id, release.transform_folder, release.transform_files, self.batch_load)
+        bq_load_info = self.get_bq_load_info(release)
 
         if release.first_release:
             for transform_blob, main_table_id, partition_table_id in bq_load_info:

--- a/tests/observatory/platform/workflows/test_stream_telescope.py
+++ b/tests/observatory/platform/workflows/test_stream_telescope.py
@@ -31,7 +31,6 @@ from observatory.platform.utils.workflow_utils import (
     batch_blob_name,
     blob_name,
     create_date_table_id,
-    get_bq_load_info,
     table_ids_from_path,
 )
 from observatory.platform.workflows.stream_telescope import (
@@ -231,12 +230,7 @@ class TestStreamTelescope(ObservatoryTestCase):
                                 self.assert_blob_integrity(env.transform_bucket, blob_name(file), file)
 
                             # Get bq_load_info
-                            bq_load_info = get_bq_load_info(
-                                telescope.dag_id,
-                                release.transform_folder,
-                                release.transform_files,
-                                telescope.batch_load,
-                            )
+                            bq_load_info = telescope.get_bq_load_info(release)
                             if batch_load:
                                 transform_blob = batch_blob_name(release.transform_folder)
                                 main_table_id, partition_table_id = (telescope.dag_id, f"{telescope.dag_id}_partitions")
@@ -413,12 +407,7 @@ class TestStreamTelescope(ObservatoryTestCase):
                             )
 
                             # Test that bq load info for bq load functions is as expected
-                            bq_load_info = get_bq_load_info(
-                                telescope.dag_id,
-                                release.transform_folder,
-                                release.transform_files,
-                                telescope.batch_load,
-                            )
+                            bq_load_info = telescope.get_bq_load_info(release)
                             if batch_load:
                                 transform_blob = batch_blob_name(release.transform_folder)
                                 main_table_id, partition_table_id = (telescope.dag_id, f"{telescope.dag_id}_partitions")


### PR DESCRIPTION
This PR includes changes required for the OpenAlex telescope:

- Include possibility to use transfer manifest file in `aws_to_google_cloud_storage_transfer` function
- Add test method to assert the number of bytes in a table
- Move the `get_bq_load_info` function from utils to inside the StreamTelescope class, so it can be overridden for specific use cases