### PR TITLE
Minor fixes for bugs when deploying with Terraform

### DIFF
--- a/observatory-api/requirements.txt
+++ b/observatory-api/requirements.txt
@@ -10,3 +10,4 @@ python-dateutil>=2.8.2,<3
 certifi>=2021.5.30
 pendulum>=2.1.2,<3
 openapi-spec-validator>=0.3.1,<1
+markupsafe==2.0.1

--- a/observatory-platform/observatory/platform/observatory_config.py
+++ b/observatory-platform/observatory/platform/observatory_config.py
@@ -830,16 +830,16 @@ class ObservatoryConfig:
 
         packages = [
             PythonPackage(
-                name="observatory-api",
-                type=self.observatory.api_package_type,
-                host_package=self.observatory.api_package,
-                docker_package=os.path.basename(self.observatory.api_package),
-            ),
-            PythonPackage(
                 name="observatory-platform",
                 type=self.observatory.package_type,
                 host_package=self.observatory.package,
                 docker_package=os.path.basename(self.observatory.package),
+            ),
+            PythonPackage(
+                name="observatory-api",
+                type=self.observatory.api_package_type,
+                host_package=self.observatory.api_package,
+                docker_package=os.path.basename(self.observatory.api_package),
             ),
         ]
 


### PR DESCRIPTION
- Fix error that pops up when trying to create objects with Observatory API.

Error: `ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.9/site-packages/markupsafe/__init__.py)`.
Described here https://github.com/aws/aws-sam-cli/issues/3661 as well.
The suggested fix of pinning markupsafe to a specific version has fixed the error in my workflows-dev deployment.

- Fix error that pops up in Airflow, because of missing modules from the Observatory API client. Some of the more recently added modules were missing.

Currently, the editable observatory-api package that is specified in the config file will be installed, but later this version is overwritten by the observatory-api from PyPi that is mentioned in requirements.txt from the observatory-platform package.

We need to publish a new release of the Observatory API, but it would also help to have the observatory-api package mentioned in the config file to be dominant over the one mentioned in the requirements file. I think it makes sense to expect that the config file version is actually used. To do this I have just switched the order of the python packages, meaning that the observatory-platform now comes before the observatory-api package in the rendered `Dockerfile.observatory` file
