### PR TITLE
Ensure that the blob name is unique across tables with the same name …

### DIFF
--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -909,7 +909,7 @@ def bq_load_tables(
 
         # Save to JSONL
         for table in tables:
-            blob_name = f"{table.table_name}.jsonl.gz"
+            blob_name = f"{table.dataset_id}-{table.table_name}.jsonl.gz"
             file_path = os.path.join(t, blob_name)
             list_to_jsonl_gz(file_path, table.records)
             files_list.append(file_path)

--- a/tests/observatory/platform/test_terraform_api.py
+++ b/tests/observatory/platform/test_terraform_api.py
@@ -149,7 +149,7 @@ class TestTerraformApi(unittest.TestCase):
 
         # Delete workspace
         response_code = self.terraform_api.delete_workspace(self.organisation, workspace_id)
-        self.assertEqual(response_code, 200)
+        self.assertEqual(response_code, 204)  # must have changed from 200 to 204 in Feb / March 2022
 
         # Try to delete non-existing workspace
         response_code = self.terraform_api.delete_workspace(self.organisation, workspace_id)


### PR DESCRIPTION
In the bq_load_tables function, ensure that the blob name is unique across tables with the same name that are in different datasets.