### PR TITLE
Add functionality to use a schema when creating table from query

### DIFF
--- a/observatory-platform/observatory/platform/utils/gc_utils.py
+++ b/observatory-platform/observatory/platform/utils/gc_utils.py
@@ -506,7 +506,7 @@ def create_bigquery_table_from_query(
     if query_parameters is None:
         query_parameters = []
 
-    func_name = create_bigquery_dataset.__name__
+    func_name = create_bigquery_table_from_query.__name__
     msg = (
         f"project_id={project_id}, dataset_id={dataset_id}, location={location}, table={table_id}, "
         f"schema_file_path(optional)={schema_file_path}"

--- a/observatory-platform/observatory/platform/utils/gc_utils.py
+++ b/observatory-platform/observatory/platform/utils/gc_utils.py
@@ -283,6 +283,7 @@ def create_empty_bigquery_table(
     else:
         table = bigquery.Table(dataset.table(table_id))
 
+    # Note that clustering fields can only be set if a schema is specified
     if clustering_fields:
         table.clustering_fields = clustering_fields
 

--- a/tests/observatory/platform/utils/test_gc_utils.py
+++ b/tests/observatory/platform/utils/test_gc_utils.py
@@ -51,7 +51,6 @@ from observatory.platform.utils.gc_utils import (
     create_bigquery_view,
     create_cloud_storage_bucket,
     create_empty_bigquery_table,
-    delete_bigquery_dataset,
     delete_bucket_dir,
     download_blob_from_cloud_storage,
     download_blobs_from_cloud_storage,


### PR DESCRIPTION
This PR makes it possible for workflows to store the results from a BigQuery SQL query into a destination table using a specified schema.

If a schema is given, it checks if the destination table already exists. If it does not exist yet it will create an empty table with the given schema and then store the results from the query in that table.

When a field that results from the query is missing in the schema, it will give an error.
When a field is not available in the results from the query and it is specified as a required field in the schema, it will also give an error.
However, if the field is specified as nullable it will just fill this field with 'null'.

The `create_bigquery_table_from_query` function uses the "WRITE_TRUNCATE" disposition by default, which means that it overwrites table data if it already exists, this overwrite includes e.g. the descriptions. So if this function is run twice with the same table id, the descriptions will disappear.

The schema file path parameter is optional and does not introduce any breaking changes, all workflows should still work with this changed functionality. I will create a separate PR for the oaebu-workflows and academic-observatory-workflows to use schema's with the queries for which we have schema's.

Summary of changes:
- Add new function to create an empty table with optional schema and clustering fields
- Add parameter to specify schema file path to `create_bigquery_table_from_query` function
- If schema file path is given for `create_bigquery_table_from_query`, create an empty table with the schema first and use this as a destination for the query result
- Removed the 'partition' related parameters for `create_bigquery_table_from_query`, because this is not used by any of the workflows