### PR TITLE
api: add local api server

### DIFF
--- a/observatory-platform/observatory/platform/docker/Dockerfile.observatory.jinja2
+++ b/observatory-platform/observatory/platform/docker/Dockerfile.observatory.jinja2
@@ -104,4 +104,7 @@ COPY entrypoint-airflow.sh /entrypoint-airflow.sh
 RUN chmod +x /entrypoint-root.sh
 RUN chmod +x /entrypoint-airflow.sh
 
+COPY entrypoint-api.sh /entrypoint-api.sh
+RUN chmod +x /entrypoint-api.sh
+
 ENTRYPOINT ["/entrypoint-root.sh"]

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -31,7 +31,8 @@ version: '3.8'
 {%- set google_application_credentials="${HOST_GOOGLE_APPLICATION_CREDENTIALS}" -%}
 {%- set postgres_hostname="postgres" -%}
 {%- set redis_hostname="redis" -%}
-
+{%- set api_server_db="observatory" -%}
+{%- set api_server_port="5001" -%}
 {%- else -%}
 
 {%- set host_data_path="/opt/observatory/data" -%}
@@ -79,6 +80,13 @@ x-environment: &environment
   {%- for conn in config.airflow_connections %}
   {{ conn.conn_name }}: {{ '${' + conn.conn_name + '}' }}
   {%- endfor %}
+
+  # API server
+  API_SERVER_DB: "{{api_server_db}}"
+  BASE_DB_URI: "postgresql://{{postgres_user}}:{{postgres_password}}@{{postgres_hostname}}/postgres"
+  OBSERVATORY_DB_URI: "postgresql://{{postgres_user}}:{{postgres_password}}@{{postgres_hostname}}/{{api_server_db}}"
+  OBSERVATORY_DB_PORT: "{{api_server_port}}"
+
   {%- endif %}
 
   # Variables
@@ -293,6 +301,18 @@ services:
       test: ["CMD", "pg_isready", "-U", "{{ postgres_user }}", "-d", "{{ airflow_db_name }}"]
       interval: 5s
       retries: 5
+
+  apiserver:
+    build: *build
+    environment: *environment
+    volumes: *volumes
+    restart: always
+    <<: *networks
+    depends_on:
+      - postgres
+    entrypoint: /entrypoint-api.sh
+    ports:
+      - {{api_server_port}}:{{api_server_port}}
   {%- endif %}
 
 {% if (config.google_cloud is not none) and (config.google_cloud.credentials is not none) -%}

--- a/observatory-platform/observatory/platform/docker/entrypoint-api.sh
+++ b/observatory-platform/observatory/platform/docker/entrypoint-api.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Tuan Chien
+
+# Create database if it does not exist
+psql ${BASE_DB_URI} -tc "SELECT 1 FROM pg_database WHERE datname = '${API_SERVER_DB}'" | grep -q 1 || psql ${BASE_DB_URI} -c "CREATE DATABASE ${API_SERVER_DB}"
+
+# Launch API server
+sudo --preserve-env=OBSERVATORY_DB_URI --user airflow --set-home --login gunicorn -b 0.0.0.0:${OBSERVATORY_DB_PORT} --timeout 0 observatory.api.server.app:app

--- a/observatory-platform/observatory/platform/platform_builder.py
+++ b/observatory-platform/observatory/platform/platform_builder.py
@@ -101,6 +101,9 @@ class PlatformBuilder(ComposeRunner):
             self.add_file(
                 path=os.path.join(self.docker_module_path, "elasticsearch.yml"), output_file_name="elasticsearch.yml"
             )
+            self.add_file(
+                path=os.path.join(self.docker_module_path, "entrypoint-api.sh"), output_file_name="entrypoint-api.sh"
+            )
 
             # Add all project requirements files for local projects
             if self.config is not None and self.config_is_valid:


### PR DESCRIPTION
- creates an "observatory" database in the postgresql server instance running in docker
- creates a docker container based on the observatory dockerfile that does the database creation (if it doesn't exist), and runs the api server via gunicorn.
- opens up a port (default: 5001) on the localhost to access the api server