### PR TITLE
Fix dag-delete error

### DIFF
--- a/observatory-api/requirements.txt
+++ b/observatory-api/requirements.txt
@@ -3,7 +3,7 @@ Flask>=1.1.4,<2
 connexion[swagger-ui]>=2.7.0,<3
 elasticsearch>=7.13.3,<8
 pyyaml>=5.1,<6
-SQLAlchemy>=1.3.18,<2
+SQLAlchemy==1.3.24 # https://github.com/apache/airflow/issues/21661
 psycopg2-binary>=2.9.1,<3
 urllib3>=1.25.11,<2
 python-dateutil>=2.8.2,<3

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -9,6 +9,7 @@ apache-airflow-providers-slack==4.0.0
 apache-airflow-providers-http==2.0.0
 WTForms<3 # Fix ModuleNotFoundError: No module named 'wtforms.compat' error
 Markdown==3.3.4 # prevent error: INSTALLED_EXTENSIONS = metadata.entry_points(group='markdown.extensions') TypeError: entry_points() got an unexpected keyword argument 'group'
+SQLAlchemy==1.3.24 # https://github.com/apache/airflow/issues/21661
 
 # Google Cloud
 google-crc32c>=1.1.0,<2


### PR DESCRIPTION
Fixes an issue with not being able to delete DAGs in Airflow UI due to incorrect version of SQLAlchemy. We will need to move to installing Airflow with a constraints file in the future as this will fix this problem in a more robust way.

https://github.com/apache/airflow/issues/15354