### PR TITLE
streamtelescope: add diff merge by lex order

### DIFF
--- a/tests/fixtures/workflows/db_merge0.json
+++ b/tests/fixtures/workflows/db_merge0.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:075fe11a1ef96edeec9630bfb2adf4dc7635156eec756e825775ac1f3ef514cd
+size 83

--- a/tests/fixtures/workflows/db_merge1.json
+++ b/tests/fixtures/workflows/db_merge1.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07e47a5dc8fb084f0fe28601afb5b6cc83e6dc1a95b86e98182410c1cc24df53
+size 41


### PR DESCRIPTION
Add stream telescope task that can merge multiple updates into a single update.
It applies updates files in lexicographic order.