### PR TITLE
Create directories that are mounted as volumes with Docker

### DIFF
--- a/observatory-platform/observatory/platform/platform_builder.py
+++ b/observatory-platform/observatory/platform/platform_builder.py
@@ -230,3 +230,22 @@ class PlatformBuilder(ComposeRunner):
             env[conn.conn_name] = conn.value
 
         return env
+
+    def make_files(self):
+        """Create directories that are mounted as volumes as defined in the docker-compose file.
+
+        :return: None.
+        """
+        super(PlatformBuilder, self).make_files()
+        observatory_home = os.path.normpath(self.config.observatory.observatory_home)
+        # Create data directory
+        data_dir = os.path.join(observatory_home, "data")
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Create logs directory
+        logs_dir = os.path.join(observatory_home, "logs")
+        os.makedirs(logs_dir, exist_ok=True)
+
+        # Create postgres directory
+        postgres_dir = os.path.join(observatory_home, "postgres")
+        os.makedirs(postgres_dir, exist_ok=True)


### PR DESCRIPTION
@keegansmith21 and I had some issues when starting the observatory platform and syncing the files in the 'data' directory generated by the workflows from the container to the host.

It turned out that the 'data' directory on the host did not exist yet, so these files can then not be synced. I think it would be good to make sure that all directories that are mounted as volumes exist before starting the observatory platform.
As far as I can tell these are only the 'data', 'logs' and 'postgres' directories.