### PR TITLE
Update to Elastic & Kibana v8

### DIFF
--- a/observatory-api/requirements.cloudrun.txt
+++ b/observatory-api/requirements.cloudrun.txt
@@ -1,7 +1,7 @@
 gunicorn>=20.1.0,<21
 Flask>=1.1.4,<2
 connexion[swagger-ui]>=2.7.0,<3
-elasticsearch>=7.13.3,<8
+elasticsearch>=8.0.0,<9
 pyyaml>=5.1,<6
 SQLAlchemy>=1.3.18,<2
 psycopg2-binary>=2.9.1,<3

--- a/observatory-api/requirements.txt
+++ b/observatory-api/requirements.txt
@@ -1,7 +1,7 @@
 gunicorn>=20.1.0,<21
 Flask>=1.1.4,<2
 connexion[swagger-ui]>=2.7.0,<3
-elasticsearch>=7.13.3,<8
+elasticsearch>=8.0.0,<9
 pyyaml>=5.1,<6
 SQLAlchemy==1.3.24 # https://github.com/apache/airflow/issues/21661
 psycopg2-binary>=2.9.1,<3

--- a/observatory-platform/observatory/platform/docker/Dockerfile.package_install.jinja2
+++ b/observatory-platform/observatory/platform/docker/Dockerfile.package_install.jinja2
@@ -1,4 +1,4 @@
-# Copyright 2020 Curtin University
+{# Copyright 2020 Curtin University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License.#}
 
 # Author: Tuan Chien
 
@@ -24,10 +24,8 @@ USER root
 RUN chmod +x ./requirements.sh
 RUN ./requirements.sh
 USER ${INSTALL_USER}
-
-# Install editable package: {{ package.name }}
-COPY ./requirements.{{ package.name }}.txt requirements.txt
-RUN pip3 install -r requirements.txt --user
+# The Python dependencies for editable packages are installed when the container starts
+# as the packages are volume mounted
 {% endif %}
 
 {% elif package.type == 'sdist' %}
@@ -51,7 +49,6 @@ RUN pip3 install {{ package.docker_package }} --user
 {% elif package.type == 'pypi' %}
 
 # Install PyPI package: {{ package.name }}
-
 # Extract sdist and install requirements.sh
 {% if install_deps %}
 RUN pip3 download {{ package.docker_package }} --no-binary :all: --no-deps

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -265,13 +265,15 @@ services:
     restart: always
     volumes:
       - "{{ host_data_path }}/elastic:/usr/share/elasticsearch/data"
-      - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
     ports:
       - ${HOST_ELASTIC_PORT}:9200
     networks:
       - {{ config.observatory.docker_network_name }}
     environment:
+      - cluster.name="observatory-cluster"
       - discovery.type=single-node
+      - network.host=0.0.0.0
+      - xpack.security.enabled=false
 
   kibana:
     image: "docker.elastic.co/kibana/kibana:8.2.2"
@@ -280,6 +282,8 @@ services:
       - ${HOST_KIBANA_PORT}:5601
     networks:
       - {{ config.observatory.docker_network_name }}
+    environment:
+       - xpack.security.enabled=false
   {%- endif %}
 
   postgres:

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -261,7 +261,7 @@ services:
   {% if config.backend.type.value == 'local' -%}
   {% if config.observatory.enable_elk -%}
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.13.3"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.2.2"
     restart: always
     volumes:
       - "{{ host_data_path }}/elastic:/usr/share/elasticsearch/data"
@@ -274,7 +274,7 @@ services:
       - discovery.type=single-node
 
   kibana:
-    image: "docker.elastic.co/kibana/kibana:7.13.3"
+    image: "docker.elastic.co/kibana/kibana:8.2.2"
     restart: always
     ports:
       - ${HOST_KIBANA_PORT}:5601

--- a/observatory-platform/observatory/platform/docker/elasticsearch.yml
+++ b/observatory-platform/observatory/platform/docker/elasticsearch.yml
@@ -1,3 +1,0 @@
-cluster.name: "observatory-cluster"
-network.host: 0.0.0.0
-discovery.zen.minimum_master_nodes: 1

--- a/observatory-platform/observatory/platform/docker/entrypoint-airflow.sh.jinja2
+++ b/observatory-platform/observatory/platform/docker/entrypoint-airflow.sh.jinja2
@@ -24,10 +24,8 @@
 {% for package in config.python_packages %}
 {% if package.type == 'editable' -%}
 cd /opt/{{ package.name }}
-pip3 install -r requirements.txt
-
 export PBR_VERSION=0.0.1
-pip3 install --no-deps -e . --user
+pip3 install -e . --user
 unset PBR_VERSION
 {% endif %}
 {% endfor %}

--- a/observatory-platform/observatory/platform/docker/entrypoint-api.sh.jinja2
+++ b/observatory-platform/observatory/platform/docker/entrypoint-api.sh.jinja2
@@ -24,10 +24,8 @@
 {% if package.name == 'observatory-api' %}
 {% if package.type == 'editable' -%}
 cd /opt/{{ package.name }}
-pip3 install -r requirements.txt
-
 export PBR_VERSION=0.0.1
-pip3 install --no-deps -e . --user
+pip3 install -e . --user
 unset PBR_VERSION
 {% endif %}
 {% endif %}

--- a/observatory-platform/observatory/platform/docker/platform_runner.py
+++ b/observatory-platform/observatory/platform/docker/platform_runner.py
@@ -74,9 +74,6 @@ class PlatformRunner(ComposeRunner):
         self.add_file(
             path=os.path.join(self.docker_module_path, "entrypoint-root.sh"), output_file_name="entrypoint-root.sh"
         )
-        self.add_file(
-            path=os.path.join(self.docker_module_path, "elasticsearch.yml"), output_file_name="elasticsearch.yml"
-        )
         self.add_template(path=os.path.join(self.docker_module_path, "seed_db.sh.jinja2"), config=self.config)
 
         # Add all project requirements files for local projects

--- a/observatory-platform/observatory/platform/docker/platform_runner.py
+++ b/observatory-platform/observatory/platform/docker/platform_runner.py
@@ -87,12 +87,6 @@ class PlatformRunner(ComposeRunner):
                     path=os.path.join(package.host_package, "requirements.sh"),
                     output_file_name=f"requirements.{package.name}.sh",
                 )
-
-                # Add project requirements files for local projects
-                self.add_file(
-                    path=os.path.join(package.host_package, "requirements.txt"),
-                    output_file_name=f"requirements.{package.name}.txt",
-                )
             elif package.type == "sdist":
                 # Add sdist package file
                 self.add_file(path=package.host_package, output_file_name=package.docker_package)

--- a/observatory-platform/observatory/platform/docker/seed_db.sh.jinja2
+++ b/observatory-platform/observatory/platform/docker/seed_db.sh.jinja2
@@ -9,10 +9,8 @@ set -x
 {% if package.name != 'observatory-platform' %}
 {% if package.type == 'editable' -%}
 cd /opt/{{ package.name }}
-pip3 install -r requirements.txt
-
 export PBR_VERSION=0.0.1
-pip3 install --no-deps -e . --user
+pip3 install {{ "--no-deps" if package.name != 'observatory-api' }} -e . --user
 unset PBR_VERSION
 {% endif %}
 {% endif %}

--- a/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
+++ b/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
@@ -8,7 +8,6 @@ services:
       - discovery.type=single-node
       - ELASTIC_PASSWORD={{ password }}
       - cluster.name="test-es-cluster"
-      - discovery.type=single-node
       - network.host=0.0.0.0
       - xpack.security.enabled=false
 

--- a/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
+++ b/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
@@ -2,13 +2,14 @@ services:
   elasticsearch:
     image: "docker.elastic.co/elasticsearch/elasticsearch:8.2.2"
     restart: always
-    volumes:
-      - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
     ports:
       - {{ elastic_port }}:9200
     environment:
       - discovery.type=single-node
       - ELASTIC_PASSWORD={{ password }}
+      - cluster.name="test-es-cluster"
+      - network.host=0.0.0.0
+      - xpack.security.enabled=false
 
   kibana:
     image: "docker.elastic.co/kibana/kibana:8.2.2"
@@ -18,3 +19,4 @@ services:
     environment:
       - ELASTICSEARCH_USERNAME=kibana_system
       - ELASTICSEARCH_PASSWORD={{ password }}
+      - xpack.security.enabled=false

--- a/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
+++ b/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
@@ -8,6 +8,7 @@ services:
       - discovery.type=single-node
       - ELASTIC_PASSWORD={{ password }}
       - cluster.name="test-es-cluster"
+      - discovery.type=single-node
       - network.host=0.0.0.0
       - xpack.security.enabled=false
 

--- a/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
+++ b/observatory-platform/observatory/platform/elastic/docker-compose.yml.jinja2
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.16.2"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.2.2"
     restart: always
     volumes:
       - "./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
@@ -11,7 +11,7 @@ services:
       - ELASTIC_PASSWORD={{ password }}
 
   kibana:
-    image: "docker.elastic.co/kibana/kibana:7.16.2"
+    image: "docker.elastic.co/kibana/kibana:8.2.2"
     restart: always
     ports:
       - {{ kibana_port }}:5601

--- a/observatory-platform/observatory/platform/elastic/elastic.py
+++ b/observatory-platform/observatory/platform/elastic/elastic.py
@@ -164,7 +164,12 @@ class Elastic:
         self.thread_count = thread_count
         self.chunk_size = chunk_size
         self.timeout = timeout
-        self.es = Elasticsearch(hosts=[self.host], timeout=timeout, api_key=(api_key_id, api_key))
+
+        es_api_key = None
+        if api_key_id is not None and api_key is not None:
+            es_api_key = (api_key_id, api_key)
+
+        self.es = Elasticsearch(hosts=[self.host], timeout=timeout, api_key=es_api_key)
 
     def query(self, index: str, query: Dict = None):
         if query is None:
@@ -184,7 +189,7 @@ class Elastic:
 
         try:
             self.es.indices.delete(index=index_id)
-        except elasticsearch.exceptions.TransportError as e:
+        except elasticsearch.NotFoundError as e:
             logging.warning(f"Index not found: {e}")
 
     def delete_indices(self, indices: List[str]):
@@ -205,7 +210,7 @@ class Elastic:
 
         index_ids = []
         try:
-            indexes: Dict = self.es.indices.get(alias_id)
+            indexes: Dict = self.es.indices.get(index=alias_id)
             for key, val in indexes.items():
                 index_ids.append(key)
         except elasticsearch.exceptions.NotFoundError:

--- a/observatory-platform/observatory/platform/elastic/elastic_environment.py
+++ b/observatory-platform/observatory/platform/elastic/elastic_environment.py
@@ -19,7 +19,6 @@ import os
 import time
 from typing import Dict
 
-import elastic_transport
 import requests
 from elasticsearch import Elasticsearch
 
@@ -84,7 +83,7 @@ class ElasticEnvironment(ComposeRunner):
         process_output = super().start()
         if self.wait:
             self.wait_until_started()
-
+        time.sleep(20)
         return process_output
 
     def kibana_ping(self):
@@ -98,7 +97,7 @@ class ElasticEnvironment(ComposeRunner):
             # before Kibana is actually ready.
             response = requests.get(f"{self.kibana_uri}/api/spaces/space")
             return response.status_code == self.HTTP_OK
-        except (ConnectionResetError, requests.exceptions.ConnectionError, elastic_transport.ConnectionError):
+        except (ConnectionResetError, requests.exceptions.ConnectionError):
             pass
         return False
 

--- a/observatory-platform/observatory/platform/elastic/elasticsearch.yml
+++ b/observatory-platform/observatory/platform/elastic/elasticsearch.yml
@@ -1,3 +1,0 @@
-cluster.name: "test-es-cluster"
-network.host: 0.0.0.0
-discovery.zen.minimum_master_nodes: 1

--- a/observatory-platform/observatory/platform/observatory_config.py
+++ b/observatory-platform/observatory/platform/observatory_config.py
@@ -843,18 +843,20 @@ class ObservatoryConfig:
         :return: the list of Python packages.
         """
 
+        # observatory-api should be installed first so that observatory-platform install doesn't try to install
+        # observatory-api from PyPI
         packages = [
-            PythonPackage(
-                name="observatory-platform",
-                type=self.observatory.package_type,
-                host_package=self.observatory.package,
-                docker_package=os.path.basename(self.observatory.package),
-            ),
             PythonPackage(
                 name="observatory-api",
                 type=self.observatory.api_package_type,
                 host_package=self.observatory.api_package,
                 docker_package=os.path.basename(self.observatory.api_package),
+            ),
+            PythonPackage(
+                name="observatory-platform",
+                type=self.observatory.package_type,
+                host_package=self.observatory.package,
+                docker_package=os.path.basename(self.observatory.package),
             ),
         ]
 

--- a/observatory-platform/observatory/platform/workflows/elastic_import_workflow.py
+++ b/observatory-platform/observatory/platform/workflows/elastic_import_workflow.py
@@ -517,7 +517,7 @@ class ElasticImportRelease(SnapshotRelease):
         # Update all aliases at once
         success = False
         try:
-            result = client.es.indices.update_aliases({"actions": actions})
+            result = client.es.indices.update_aliases(actions=actions)
             success = result.get("acknowledged", False)
         except elasticsearch.exceptions.NotFoundError:
             pass

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -20,7 +20,7 @@ google-auth-oauthlib>=0.4.5,<1
 google-cloud-secret-manager<2.0.0,>=0.2.0 # for Google Cloud Secret Manager backend
 
 # Elasticsearch
-elasticsearch>=7.13.3,<8
+elasticsearch>=8.0.0,<9
 
 # Docker
 docker-compose>=1.29.2,<2

--- a/tests/observatory/api/client/test_observatory_api.py
+++ b/tests/observatory/api/client/test_observatory_api.py
@@ -783,7 +783,7 @@ class TestObservatoryApi(unittest.TestCase):
             self.assertEqual('"Elasticsearch environment variable for host or api key is empty"\n', e.exception.body)
 
             # Test successful query
-            mock_create_connection.return_value = Elasticsearch()
+            mock_create_connection.return_value = Elasticsearch("http://localhost:9200")
             res = copy.deepcopy(RES_EXAMPLE)
             mock_es_scroll.return_value = res
 

--- a/tests/observatory/api/server/test_elastic.py
+++ b/tests/observatory/api/server/test_elastic.py
@@ -78,18 +78,23 @@ class TestElastic(unittest.TestCase):
 
         :return:
         """
-        # test elasticsearch instance is returned
+
+        # Test that invalid address raises error
+        with self.assertRaises(ValueError):
+            create_es_connection("address", "api_key")
+
+        # Test elasticsearch instance is returned
         mock_elasticsearch_ping.return_value = True
-        es = create_es_connection("address", "api_key")
+        es = create_es_connection("http://localhost:9200", "api_key")
         self.assertIsInstance(es, Elasticsearch)
 
         # test connection error is raised
         mock_elasticsearch_ping.return_value = False
         with self.assertRaises(ConnectionError):
-            create_es_connection("address", "api_key")
+            create_es_connection("http://localhost:9200", "api_key")
 
         # test None is returned when address or api_key is empty
-        es = create_es_connection("address", "")
+        es = create_es_connection("http://localhost:9200", "")
         self.assertIsNone(es)
 
         es = create_es_connection(None, "api_key")
@@ -262,5 +267,5 @@ class TestElastic(unittest.TestCase):
         alias = "subset-agg"
         mock_es_indices.return_value = [{"index": f"{alias}-{dates[0]}"}, {"index": f"{alias}-{dates[1]}"}]
 
-        available_dates = list_available_index_dates(Elasticsearch(), alias)
+        available_dates = list_available_index_dates(Elasticsearch("http://localhost:9200"), alias)
         self.assertEqual(dates, available_dates)

--- a/tests/observatory/platform/cli/test_cli_functional.py
+++ b/tests/observatory/platform/cli/test_cli_functional.py
@@ -228,7 +228,7 @@ class TestCliFunctional(unittest.TestCase):
 
     @patch("observatory.platform.cli.cli.ObservatoryConfig.load")
     def test_run_platform_editable(self, mock_config_load):
-        """Test that the platform runs when built from an editable project. API installed from PyPI."""
+        """Test that the platform runs when built from an editable project."""
 
         runner = CliRunner()
         with runner.isolated_filesystem() as t:
@@ -264,7 +264,7 @@ class TestCliFunctional(unittest.TestCase):
 
     @patch("observatory.platform.cli.cli.ObservatoryConfig.load")
     def test_dag_load_workflows_project_editable(self, mock_config_load):
-        """Test that the DAGs load when build from an editable workflows project. API installed from PyPI."""
+        """Test that the DAGs load when build from an editable workflows project."""
 
         runner = CliRunner()
         with runner.isolated_filesystem() as t:
@@ -349,7 +349,7 @@ class TestCliFunctional(unittest.TestCase):
 
     @patch("observatory.platform.cli.cli.ObservatoryConfig.load")
     def test_run_platform_sdist(self, mock_config_load):
-        """Test that the platform runs when built from a source distribution. API package installed from PyPI."""
+        """Test that the platform runs when built from a source distribution."""
 
         runner = CliRunner()
         with runner.isolated_filesystem() as t:
@@ -389,7 +389,7 @@ class TestCliFunctional(unittest.TestCase):
 
     @patch("observatory.platform.cli.cli.ObservatoryConfig.load")
     def test_dag_load_workflows_project_sdist(self, mock_config_load):
-        """Test that DAGs load from an sdist workflows project. API package installed from PyPI."""
+        """Test that DAGs load from an sdist workflows project."""
 
         runner = CliRunner()
         with runner.isolated_filesystem() as t:

--- a/tests/observatory/platform/cli/test_cli_functional.py
+++ b/tests/observatory/platform/cli/test_cli_functional.py
@@ -118,8 +118,8 @@ class TestCliFunctional(unittest.TestCase):
         self.start_cmd = ["platform", "start", "--debug", "--config-path"]
         self.stop_cmd = ["platform", "stop", "--debug", "--config-path"]
         self.workflows_package_name = "my-workflows-project"
-        self.dag_check_timeout = 180
-        self.port_wait_timeout = 180
+        self.dag_check_timeout = 360
+        self.port_wait_timeout = 360
         self.config_file_name = "config.yaml"
 
     def make_editable_observatory_config(self, temp_dir: str) -> ObservatoryConfig:

--- a/tests/observatory/platform/docker/test_platform_runner.py
+++ b/tests/observatory/platform/docker/test_platform_runner.py
@@ -167,7 +167,6 @@ class TestPlatformRunner(unittest.TestCase):
             build_file_names = [
                 "docker-compose.observatory.yml",
                 "Dockerfile.observatory",
-                "elasticsearch.yml",
                 "entrypoint-airflow.sh",
                 "entrypoint-root.sh",
             ]

--- a/tests/observatory/platform/docker/test_platform_runner.py
+++ b/tests/observatory/platform/docker/test_platform_runner.py
@@ -170,7 +170,6 @@ class TestPlatformRunner(unittest.TestCase):
                 "elasticsearch.yml",
                 "entrypoint-airflow.sh",
                 "entrypoint-root.sh",
-                "requirements.observatory-platform.txt",
             ]
             for file_name in build_file_names:
                 path = os.path.join(cmd.build_path, file_name)

--- a/tests/observatory/platform/elastic/test_kibana.py
+++ b/tests/observatory/platform/elastic/test_kibana.py
@@ -17,11 +17,13 @@
 import os
 import unittest
 
+from click.testing import CliRunner
+
 from observatory.platform.elastic.elastic import Elastic
 from observatory.platform.elastic.elastic_environment import ElasticEnvironment
 from observatory.platform.elastic.kibana import Kibana, ObjectType
+from observatory.platform.utils.test_utils import find_free_port
 from observatory.platform.utils.test_utils import random_id
-from click.testing import CliRunner
 
 
 class TestKibana(unittest.TestCase):
@@ -32,7 +34,11 @@ class TestKibana(unittest.TestCase):
         with CliRunner().isolated_filesystem() as temp_dir:
             # Start an Elastic environment
             elastic_build_path = os.path.join(temp_dir, "elastic")
-            cls.es = ElasticEnvironment(build_path=elastic_build_path)
+            elastic_port = find_free_port()
+            kibana_port = find_free_port()
+            cls.es = ElasticEnvironment(
+                build_path=elastic_build_path, elastic_port=elastic_port, kibana_port=kibana_port
+            )
             cls.es.start()
 
             cls.elastic = Elastic(host=cls.es.elastic_uri)

--- a/tests/observatory/platform/terraform/test_terraform_builder.py
+++ b/tests/observatory/platform/terraform/test_terraform_builder.py
@@ -151,6 +151,7 @@ class TestTerraformBuilder(unittest.TestCase):
             packages = ["observatory-api", "observatory-platform"]
             for package in packages:
                 path = os.path.join(cmd.build_path, "packages", package)
+                print(f"Check exists: {path}")
                 self.assertTrue(os.path.exists(path))
 
             # Test that the expected Docker files have been written
@@ -160,11 +161,10 @@ class TestTerraformBuilder(unittest.TestCase):
                 "elasticsearch.yml",
                 "entrypoint-airflow.sh",
                 "entrypoint-root.sh",
-                "requirements.observatory-platform.txt",
-                "requirements.observatory-api.txt",
             ]
             for file_name in build_file_names:
                 path = os.path.join(cmd.build_path, "docker", file_name)
+                print(f"Checking that file exists: {path}")
                 self.assertTrue(os.path.isfile(path))
                 self.assertTrue(os.stat(path).st_size > 0)
 

--- a/tests/observatory/platform/terraform/test_terraform_builder.py
+++ b/tests/observatory/platform/terraform/test_terraform_builder.py
@@ -158,7 +158,6 @@ class TestTerraformBuilder(unittest.TestCase):
             build_file_names = [
                 "docker-compose.observatory.yml",
                 "Dockerfile.observatory",
-                "elasticsearch.yml",
                 "entrypoint-airflow.sh",
                 "entrypoint-root.sh",
             ]


### PR DESCRIPTION
This PR updates the Elasticsearch client library to v8 in observatory platform and the Elasticsearch and Kibana Docker containers to 8.2.2.

To get this working, when Python packages and their dependencies are installed properly in editable mode, they need to be installed with their dependencies when the container starts rather than at build time, as Docker volume mounts are not available at build time. 

Trying to only install the dependencies at build time causes problems, which is why I have reverted this. For instance, the editable observatory-api will not be installed before the observatory-platform dependencies are installed, which means that the observatory-api will be installed from PyPI when it should be installed as an editable package, and this causes version conflicts.