### PR TITLE
api: cascade delete for Workflow and Dataset

### DIFF
--- a/observatory-api/observatory/api/server/orm.py
+++ b/observatory-api/observatory/api/server/orm.py
@@ -299,7 +299,13 @@ class Workflow(Base):
     modified = Column(DateTime())
     organisation_id = Column(Integer, ForeignKey(f"{Organisation.__tablename__}.id"), nullable=True)
     workflow_type_id = Column(Integer, ForeignKey(f"{WorkflowType.__tablename__}.id"), nullable=False)
-    datasets = relationship("Dataset", backref=__tablename__)
+    datasets = relationship(
+        "Dataset",
+        backref=__tablename__,
+        cascade="all, delete-orphan",
+        single_parent=True,
+        passive_deletes=True,
+    )
 
     def __init__(
         self,
@@ -549,9 +555,15 @@ class Dataset(Base):
     created = Column(DateTime())
     modified = Column(DateTime())
 
-    workflow_id = Column(Integer, ForeignKey(f"{Workflow.__tablename__}.id"), nullable=False)
+    workflow_id = Column(Integer, ForeignKey(f"{Workflow.__tablename__}.id", ondelete="CASCADE"), nullable=False)
     dataset_type_id = Column(Integer, ForeignKey(f"{DatasetType.__tablename__}.id"), nullable=False)
-    releases = relationship("DatasetRelease", backref=__tablename__)
+    releases = relationship(
+        "DatasetRelease",
+        backref=__tablename__,
+        cascade="all, delete-orphan",
+        single_parent=True,
+        passive_deletes=True,
+    )
 
     def __init__(
         self,
@@ -642,7 +654,7 @@ class DatasetRelease(Base):
     id = Column(Integer, primary_key=True)
     start_date = Column(DateTime())
     end_date = Column(DateTime())
-    dataset_id = Column(Integer, ForeignKey(f"{Dataset.__tablename__}.id"), nullable=False)
+    dataset_id = Column(Integer, ForeignKey(f"{Dataset.__tablename__}.id", ondelete="CASCADE"), nullable=False)
     created = Column(DateTime())
     modified = Column(DateTime())
 


### PR DESCRIPTION
Instead of refusing to delete Workflow and Dataset objects with dependents, delete the dependent objects as well.

This requires a database change to be performed if upgrading an existing db:

alter table dataset 
drop constraint dataset_workflow_id_fkey,
add constraint dataset_workflow_id_fkey foreign key (workflow_id) references workflow(id) on delete cascade;

alter table dataset_release
drop constraint dataset_release_dataset_id_fkey,
add constraint dataset_release_dataset_id_fkey foreign key (dataset_id) references dataset(id) on delete cascade;
