### PR TITLE
jsonl comparison fix

### DIFF
--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -69,6 +69,7 @@ import threading
 import time
 import unittest
 import uuid
+import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -653,13 +654,13 @@ class ObservatoryTestCase(unittest.TestCase):
         actual_content = None
         try:
             rows = self.bigquery_client.list_rows(table_id)
-            actual_content = [dict(row) for row in rows]
+            actual_content = json.loads(json.dumps([dict(row) for row in rows], default=str))
         except NotFound:
             pass
 
         self.assertIsNotNone(rows)
         if expected_content is not None:
-            for row in expected_content:
+            for row in json.loads(json.dumps(expected_content, default=str)):
                 self.assertIn(row, actual_content)
                 actual_content.remove(row)
             self.assertListEqual(

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -660,7 +660,7 @@ class ObservatoryTestCase(unittest.TestCase):
 
         self.assertIsNotNone(rows)
         if expected_content is not None:
-            for row in json.loads(json.dumps(expected_content, default=str)):
+            for row in expected_content:
                 self.assertIn(row, actual_content)
                 actual_content.remove(row)
             self.assertListEqual(

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -543,11 +543,11 @@ class TestObservatoryTestCase(unittest.TestCase):
             test_case = ObservatoryTestCase()
             table_id = f"{self.project_id}.{dataset_id}.{table_name}"
             expected_content = [
-                {"first_name": "Gisella", "last_name": "Derya", "dob": datetime(1997, 7, 1).date()},
-                {"first_name": "Adelaida", "last_name": "Melis", "dob": datetime(1980, 9, 3).date()},
-                {"first_name": "Melanie", "last_name": "Magomedkhan", "dob": datetime(1990, 3, 1).date()},
-                {"first_name": "Octavia", "last_name": "Tomasa", "dob": datetime(1970, 1, 8).date()},
-                {"first_name": "Ansgar", "last_name": "Zorion", "dob": datetime(2001, 2, 1).date()},
+                {"first_name": "Gisella", "last_name": "Derya", "dob": str(datetime(1997, 7, 1).date())},
+                {"first_name": "Adelaida", "last_name": "Melis", "dob": str(datetime(1980, 9, 3).date())},
+                {"first_name": "Melanie", "last_name": "Magomedkhan", "dob": str(datetime(1990, 3, 1).date())},
+                {"first_name": "Octavia", "last_name": "Tomasa", "dob": str(datetime(1970, 1, 8).date())},
+                {"first_name": "Ansgar", "last_name": "Zorion", "dob": str(datetime(2001, 2, 1).date())},
             ]
             test_case.assert_table_content(table_id, expected_content)
 
@@ -564,10 +564,10 @@ class TestObservatoryTestCase(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 table_id = f"{dataset_id}.{table_name}"
                 expected_content = [
-                    {"first_name": "Gisella", "last_name": "Derya", "dob": datetime(1997, 7, 1).date()},
-                    {"first_name": "Adelaida", "last_name": "Melis", "dob": datetime(1980, 9, 3).date()},
-                    {"first_name": "Octavia", "last_name": "Tomasa", "dob": datetime(1970, 1, 8).date()},
-                    {"first_name": "Ansgar", "last_name": "Zorion", "dob": datetime(2001, 2, 1).date()},
+                    {"first_name": "Gisella", "last_name": "Derya", "dob": str(datetime(1997, 7, 1).date())},
+                    {"first_name": "Adelaida", "last_name": "Melis", "dob": str(datetime(1980, 9, 3).date())},
+                    {"first_name": "Octavia", "last_name": "Tomasa", "dob": str(datetime(1970, 1, 8).date())},
+                    {"first_name": "Ansgar", "last_name": "Zorion", "dob": str(datetime(2001, 2, 1).date())},
                 ]
                 test_case.assert_table_content(table_id, expected_content)
 
@@ -575,12 +575,12 @@ class TestObservatoryTestCase(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 table_id = f"{self.project_id}.{dataset_id}.{table_name}"
                 expected_content = [
-                    {"first_name": "Gisella", "last_name": "Derya", "dob": datetime(1997, 7, 1).date()},
-                    {"first_name": "Adelaida", "last_name": "Melis", "dob": datetime(1980, 9, 3).date()},
-                    {"first_name": "Melanie", "last_name": "Magomedkhan", "dob": datetime(1990, 3, 1).date()},
-                    {"first_name": "Octavia", "last_name": "Tomasa", "dob": datetime(1970, 1, 8).date()},
-                    {"first_name": "Ansgar", "last_name": "Zorion", "dob": datetime(2001, 2, 1).date()},
-                    {"first_name": "Extra", "last_name": "Row", "dob": datetime(2001, 2, 1).date()},
+                    {"first_name": "Gisella", "last_name": "Derya", "dob": str(datetime(1997, 7, 1).date())},
+                    {"first_name": "Adelaida", "last_name": "Melis", "dob": str(datetime(1980, 9, 3).date())},
+                    {"first_name": "Melanie", "last_name": "Magomedkhan", "dob": str(datetime(1990, 3, 1).date())},
+                    {"first_name": "Octavia", "last_name": "Tomasa", "dob": str(datetime(1970, 1, 8).date())},
+                    {"first_name": "Ansgar", "last_name": "Zorion", "dob": str(datetime(2001, 2, 1).date())},
+                    {"first_name": "Extra", "last_name": "Row", "dob": str(datetime(2001, 2, 1).date())},
                 ]
                 test_case.assert_table_content(table_id, expected_content)
 


### PR DESCRIPTION
Currently, a json file can be compared to a bigquery table. An issue arises because bigquery will pull some fields as objects if done through the Python client vs exporting the table through the bigquery console as json. This PR resolves the issue by dumping both jsons to strings and then reloading them before making assertions.

This blocks The-Academic-Observatory/oaebu-workflows#102