### PR TITLE
Updated docker compose process to pipe its stderr to stdout

### DIFF
--- a/observatory-platform/observatory/platform/docker/compose_runner.py
+++ b/observatory-platform/observatory/platform/docker/compose_runner.py
@@ -121,7 +121,7 @@ class ComposeRunner(Builder):
         proc: Popen = subprocess.Popen(
             self.COMPOSE_ARGS_PREFIX + [self.compose_file_name] + args,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             env=env,
             cwd=self.build_path,
         )

--- a/observatory-platform/observatory/platform/utils/proc_utils.py
+++ b/observatory-platform/observatory/platform/utils/proc_utils.py
@@ -44,15 +44,17 @@ def stream_process(proc: Popen, debug: bool) -> Tuple[str, str]:
     output_concat = ""
     error_concat = ""
     while True:
-        for line in proc.stdout:
-            output = line.decode("utf-8")
-            if debug:
-                print(output, end="")
-            output_concat += output
-        for line in proc.stderr:
-            error = line.decode("utf-8")
-            print(error, end="")
-            error_concat += error
+        if proc.stdout:
+            for line in proc.stdout:
+                output = line.decode("utf-8")
+                if debug:
+                    print(output, end="")
+                output_concat += output
+        if proc.stderr:
+            for line in proc.stderr:
+                error = line.decode("utf-8")
+                print(error, end="")
+                error_concat += error
         if proc.poll() is not None:
             break
     return output_concat, error_concat


### PR DESCRIPTION
Docker compose subprocess appears to hang on occasion. Part of the reason is that the stdout stream of compose is never filled and its stderr is never printed. This update should fix the printing issue. I haven't had `observatory platform start` hang since implementing the change, but i'll wait until i'm more confident it isn't still broken before requesting a merge.