### PR TITLE
Added prefix functionality to ObservatoryEnvironment class

### DIFF
--- a/observatory-platform/observatory/platform/utils/gc_utils.py
+++ b/observatory-platform/observatory/platform/utils/gc_utils.py
@@ -22,6 +22,7 @@ import multiprocessing
 import os
 import re
 import time
+import datetime
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from copy import deepcopy
 from enum import Enum
@@ -1232,3 +1233,68 @@ def delete_bucket_dir(*, bucket_name: str, prefix: str):
 
     for blob in blobs:
         blob.delete()
+
+
+def list_all_buckets():
+    """List of all Google Cloud buckets.
+
+    :return: list of buckets that the service account as access to under the project.
+    """
+
+    # Client to read Google Cloud Storage
+    storage_client = storage.Client()
+    buckets = storage_client.list_buckets()
+
+    # Make list of all names of the storage buckets
+    bucket_list = []
+    for bucket in buckets:
+        bucket_list.append(bucket.name)
+
+    return bucket_list
+
+
+def list_all_datasets():
+    """List of all BigQuery datasets.
+
+    :return: list of datasets that the service account as access to under the project.
+    """
+
+    client = bigquery.Client()
+    datasets = list(client.list_datasets())
+
+    dataset_list = []
+    for dataset in datasets:
+        dataset_list.append(dataset.dataset_id)
+
+    return dataset_list
+
+
+def get_age_of_bucket_in_days(project_id: str, bucket_name: str):
+    """Determines the age of a bucket in days from time of created to present
+    :param project_id: project_name
+    :param bucket_name: Name of bucket
+    :result age_in_days: Age of the bucket in days"""
+
+    storage_client = storage.Client(project=project_id)
+    bucket = storage_client.get_bucket(bucket_name)
+
+    # Timezone of the bucket is in UTC. Have to change local timezone to UTC to get correct age.
+    days_old = (datetime.datetime.now(datetime.timezone.utc) - bucket.time_created).days
+
+    return days_old
+
+
+def get_age_of_dataset_in_days(project_id: str, dataset_id: str):
+
+    """Determines the age of a dataset in days from time of created to present
+    :param project_id: project_name
+    :param bucket_name: Name of bucket
+    :result age_in_days: Age of the bucket in days"""
+
+    client = bigquery.Client(project=project_id)
+    dataset = client.get_dataset(dataset_id)
+
+    # Timezone of the dataset is in UTC. Have to change local timezone to UTC to get correct age.
+    days_old = (datetime.datetime.now(datetime.timezone.utc) - dataset.created).days
+
+    return days_old

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -263,7 +263,8 @@ class ObservatoryEnvironment:
 
         The bucket will be created when create() is called and deleted when the Observatory
         environment is closed.
-
+    
+        :param prefix: an optional additional prefix for the bucket.
         :return: returns the bucket name.
         """
 

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -194,6 +194,18 @@ def make_prefix(test_name: str, org_name: str):
         + ("".join(re.findall("[A-Z]+", org_name))).lower()
         )
 
+    # no capitals in the org_part and "_" separating the name. Used for function names.
+    elif not re.search("[A-Z]+", org_name) and re.search("[\_]+", org_name):
+
+        reg = re.compile(r"(?:(?<=\_)|^)(?:[a-z]|\d+)", re.I)
+        org_part = ''.join(reg.findall(org_name))
+
+        prefix = (
+        ("".join(re.findall("[A-Z]+", test_name))).lower()
+        + "_"
+        + org_part
+        )
+
     elif org_name != "":
 
         # For cases where the organisation name is too long and will cause 

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -189,7 +189,7 @@ class ObservatoryEnvironment:
         elastic_port: int = 9200,
         kibana_port: int = 5601,
         prefix: str = "obsenv_tests",
-        age_to_delete: int = 2,
+        age_to_delete: int = 12,
     ):
         """Constructor for an Observatory environment.
 
@@ -263,7 +263,7 @@ class ObservatoryEnvironment:
 
         The bucket will be created when create() is called and deleted when the Observatory
         environment is closed.
-    
+
         :param prefix: an optional additional prefix for the bucket.
         :return: returns the bucket name.
         """

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -330,7 +330,6 @@ class ObservatoryEnvironment:
         else:
             bucket_name = random_id()
 
-        logging.info(f"Created bucket name: {bucket_name}")
         self.buckets.append(bucket_name)
         return bucket_name
 
@@ -343,6 +342,7 @@ class ObservatoryEnvironment:
 
         self.assert_gcp_dependencies()
         self.storage_client.create_bucket(bucket_id, location=self.data_location)
+        logging.info(f"Created bucket with name: {bucket_id}")
 
     def _create_dataset(self, dataset_id: str) -> None:
         """Create a BigQuery dataset.
@@ -355,6 +355,7 @@ class ObservatoryEnvironment:
         dataset = bigquery.Dataset(f"{self.project_id}.{dataset_id}")
         dataset.location = self.data_location
         self.bigquery_client.create_dataset(dataset, exists_ok=True)
+        logging.info(f"Created dataset with name: {dataset_id}")
 
     def _delete_bucket(self, bucket_id: str) -> None:
         """Delete a Google Cloud Storage Bucket.
@@ -422,7 +423,6 @@ class ObservatoryEnvironment:
             dataset_id = f"{prefix}_{random_id()}"
         else:
             dataset_id = random_id()
-        logging.info(f"Created dataset name: {dataset_id}")
         self.datasets.append(dataset_id)
         return dataset_id
 

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -75,7 +75,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from multiprocessing import Process
-from typing import Dict, List
+from typing import Dict, List, Optional
 from unittest.mock import patch
 
 import croniter
@@ -188,7 +188,7 @@ class ObservatoryEnvironment:
         enable_elastic: bool = False,
         elastic_port: int = 9200,
         kibana_port: int = 5601,
-        prefix: str = "obsenv_tests",
+        prefix: Optional[str] = "obsenv_tests",
         age_to_delete: int = 12,
     ):
         """Constructor for an Observatory environment.
@@ -258,7 +258,7 @@ class ObservatoryEnvironment:
 
         assert self.create_gcp_env, "Please specify the Google Cloud project_id and data_location"
 
-    def add_bucket(self, prefix: str = "") -> str:
+    def add_bucket(self, prefix: Optional[str] = None) -> str:
         """Add a Google Cloud Storage Bucket to the Observatory environment.
 
         The bucket will be created when create() is called and deleted when the Observatory
@@ -269,14 +269,13 @@ class ObservatoryEnvironment:
         """
 
         self.assert_gcp_dependencies()
-        if (self.prefix != "") and (prefix != ""):
-            bucket_name = f"{self.prefix}_{prefix}_{random_id()}"
-        elif self.prefix != "" and (prefix == ""):
-            bucket_name = f"{self.prefix}_{random_id()}"
-        elif (self.prefix == "") and (prefix != ""):
-            bucket_name = f"{prefix}_{random_id()}"
-        else:
-            bucket_name = random_id()
+        parts = []
+        if self.prefix:
+            parts.append(self.prefix)
+        if prefix:
+            parts.append(prefix)
+        parts.append(random_id())
+        bucket_name = "_".join(parts)
 
         if len(bucket_name) > 63:
             raise Exception(f"Bucket name cannot be longer than 63 characters: {bucket_name}")
@@ -327,7 +326,7 @@ class ObservatoryEnvironment:
                 f"Bucket {bucket_id} not found. Did you mean to call _delete_bucket on the same bucket twice?"
             )
 
-    def add_dataset(self, prefix: str = "") -> str:
+    def add_dataset(self, prefix: Optional[str] = None) -> str:
         """Add a BigQuery dataset to the Observatory environment.
 
         The BigQuery dataset will be deleted when the Observatory environment is closed.
@@ -337,14 +336,13 @@ class ObservatoryEnvironment:
         """
 
         self.assert_gcp_dependencies()
-        if (self.prefix != "") and (prefix != ""):
-            dataset_id = f"{self.prefix}_{prefix}_{random_id()}"
-        elif self.prefix != "" and (prefix == ""):
-            dataset_id = f"{self.prefix}_{random_id()}"
-        elif (self.prefix == "") and (prefix != ""):
-            dataset_id = f"{prefix}_{random_id()}"
-        else:
-            dataset_id = random_id()
+        parts = []
+        if self.prefix:
+            parts.append(self.prefix)
+        if prefix:
+            parts.append(prefix)
+        parts.append(random_id())
+        dataset_id = "_".join(parts)
         self.datasets.append(dataset_id)
         return dataset_id
 

--- a/tests/observatory/platform/utils/test_gc_utils.py
+++ b/tests/observatory/platform/utils/test_gc_utils.py
@@ -997,22 +997,21 @@ class TestGoogleCloudUtils(unittest.TestCase):
         
         try: 
 
-            # Get list of all datasets
-            dataset_list = list_all_datasets()
-
             # Create test datasets
             for test_dataset in test_datasets:
                 create_bigquery_dataset(self.gc_project_id, test_dataset, self.gc_bucket_location)
-                
+
+            # Ensure that datasets have been created.
+            dataset_list = list_all_datasets()
+            self.assertTrue( set(dataset_list).issuperset( set(test_datasets)) )
+
             # Remove datasets that have shared prefix and age of 0 days.
             delete_old_datasets_with_prefix(self.gc_project_id, prefix, age_to_delete = 0)
 
-            # Get list of all datasets again after the two test ones have been deleted.
+            # Check that datasets have been deleted.
             dataset_list_post = list_all_datasets()
-
-            # Check that buckets with unique prefix are not present.
-            self.assertEqual(dataset_list_post, dataset_list)
-
+            self.assertFalse( set(dataset_list_post).issuperset( set(test_datasets)) )
+                   
         finally:
             # Delete testing datasets
             for test_dataset in test_datasets:
@@ -1030,22 +1029,22 @@ class TestGoogleCloudUtils(unittest.TestCase):
 
         try: 
 
-            # Get list of all buckets
-            bucket_list = list_all_buckets()
-
             # Create test buckets
             for test_bucket in test_buckets:
                 success_create = create_cloud_storage_bucket(test_bucket, self.gc_bucket_location, self.gc_project_id)
                 self.assertTrue(success_create)
 
+            # Esnure buckets have been created.
+            bucket_list = list_all_buckets()
+            self.assertTrue( set(bucket_list).issuperset( set(test_buckets)) )
+
             # Remove datasets that have shared prefix and age of 0 days.
             delete_old_buckets_with_prefix(self.gc_project_id, prefix, age_to_delete = 0)
 
-            # Get list of all buckets again after the two test ones have been deleted.
-            bucket_list_post = list_all_buckets()
-
             # Check that buckets with unique prefix are not present.
-            self.assertEqual(bucket_list_post, bucket_list)
+            bucket_list_post = list_all_buckets()
+            self.assertFalse( set(bucket_list_post).issuperset( set(test_buckets)) )
+           
             success = True
 
         finally:

--- a/tests/observatory/platform/utils/test_gc_utils.py
+++ b/tests/observatory/platform/utils/test_gc_utils.py
@@ -66,8 +66,8 @@ from observatory.platform.utils.gc_utils import (
     table_name_from_blob,
     upload_file_to_cloud_storage,
     upload_files_to_cloud_storage,
-    list_all_datasets,
-    list_all_buckets,
+    list_datasets_with_prefix,
+    list_buckets_with_prefix,
     delete_old_datasets_with_prefix,
     delete_old_buckets_with_prefix,
 )
@@ -185,8 +185,8 @@ class TestGoogleCloudUtils(unittest.TestCase):
 
         # Save time and only have this run once.
         if not __class__.__init__already:
-            delete_old_datasets_with_prefix(self.prefix, age_to_delete=2)
-            delete_old_buckets_with_prefix(self.prefix, age_to_delete=2)
+            delete_old_datasets_with_prefix(self.prefix, age_to_delete=12)
+            delete_old_buckets_with_prefix(self.prefix, age_to_delete=12)
             __class__.__init__already = True
 
     def test_create_bigquery_dataset(self):
@@ -908,7 +908,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
             finally:
                 pass
 
-    def test_list_all_datasets(self):
+    def test_list_datasets_with_prefix(self):
 
         client = bigquery.Client()
         dataset_id = self.prefix + "_" + random_id()
@@ -918,7 +918,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
             create_bigquery_dataset(self.gc_project_id, dataset_id, self.gc_bucket_location)
 
             # Get list of datasets under project
-            dataset_list = list_all_datasets()
+            dataset_list = list_datasets_with_prefix()
             dataset_names = [dataset.dataset_id for dataset in dataset_list]
 
             self.assertTrue(set(dataset_names).issuperset({dataset_id}))
@@ -927,7 +927,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
             # Delete testing dataset when finished
             client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
 
-    def test_list_all_buckets(self):
+    def test_list_buckets_with_prefix(self):
 
         client = storage.Client()
         bucket_id = self.prefix + "_" + random_id()
@@ -938,7 +938,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
             self.assertTrue(success)
 
             # Get list of bucket objects under project
-            bucket_list = list_all_buckets()
+            bucket_list = list_buckets_with_prefix()
             bucket_names = [bucket.name for bucket in bucket_list]
 
             # Check that it is in the list of all other buckets
@@ -966,7 +966,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
                 )
 
             # Ensure that datasets have been created.
-            dataset_list = list_all_datasets()
+            dataset_list = list_datasets_with_prefix(prefix)
             dataset_names = [dataset.dataset_id for dataset in dataset_list]
             self.assertTrue(set(dataset_names).issuperset(set(test_datasets)))
 
@@ -974,7 +974,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
             delete_old_datasets_with_prefix(prefix, age_to_delete=0)
 
             # Check that datasets have been deleted.
-            dataset_list_post = list_all_datasets()
+            dataset_list_post = list_datasets_with_prefix(prefix)
             dataset_names_post = [dataset.dataset_id for dataset in dataset_list_post]
             self.assertFalse(set(dataset_names_post).issuperset(set(test_datasets)))
 
@@ -1000,7 +1000,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
 
         try:
             # Esnure buckets have been created.
-            bucket_list = list_all_buckets()
+            bucket_list = list_buckets_with_prefix(prefix)
             bucket_names = [bucket.name for bucket in bucket_list]
             self.assertTrue(set(bucket_names).issuperset(set(test_buckets)))
 
@@ -1008,7 +1008,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
             delete_old_buckets_with_prefix(prefix, age_to_delete=0)
 
             # Check that buckets with unique prefix are not present.
-            bucket_list_post = list_all_buckets()
+            bucket_list_post = list_buckets_with_prefix(prefix)
             bucket_names_post = [bucket.name for bucket in bucket_list_post]
             self.assertFalse(set(bucket_names_post).issuperset(set(test_buckets)))
 

--- a/tests/observatory/platform/utils/test_gc_utils.py
+++ b/tests/observatory/platform/utils/test_gc_utils.py
@@ -992,7 +992,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
         client = bigquery.Client()
 
         # Create unique prefix just for this test
-        prefix = self.prefix + "_tdodwp_"
+        prefix = self.prefix + "_tdodwp_" + random_id()[:16] + "_"
         test_datasets = [prefix + random_id() for i in range(2) ]
         
         try: 
@@ -1022,7 +1022,7 @@ class TestGoogleCloudUtils(unittest.TestCase):
         client = storage.Client()
 
         # Create unique prefix just for this test
-        prefix = self.prefix + "_tdobwp_"
+        prefix = self.prefix + "_tdobwp_" + random_id()[:16] + "_"
         test_buckets = [prefix + random_id() for i in range(2) ]
 
         success = False

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -153,7 +153,7 @@ class TestObservatoryEnvironment(unittest.TestCase):
         env._delete_bucket(bucket_id)
 
         # No Google Cloud variables raises error
-        bucket_id = "ObsEnv_tests_" + random_id()
+        bucket_id = "obsenv_tests_" + random_id()
         with self.assertRaises(AssertionError):
             ObservatoryEnvironment()._create_bucket(bucket_id)
         with self.assertRaises(AssertionError):

--- a/tests/observatory/platform/utils/test_test_utils.py
+++ b/tests/observatory/platform/utils/test_test_utils.py
@@ -116,11 +116,10 @@ class TestObservatoryEnvironment(unittest.TestCase):
         self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
 
-        self.prefix = make_prefix(__class__.__name__, "")
-
     def test_add_bucket(self):
         """Test the add_bucket method"""
 
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
 
         # The download and transform buckets are added in the constructor
@@ -139,9 +138,9 @@ class TestObservatoryEnvironment(unittest.TestCase):
     def test_create_delete_bucket(self):
         """Test _create_bucket and _delete_bucket"""
 
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
         env.delete_old_test_buckets(age_to_delete=7)
-        env.delete_old_test_datasets(age_to_delete=7)
 
         bucket_id = self.prefix + "_" + random_id()
 
@@ -167,10 +166,11 @@ class TestObservatoryEnvironment(unittest.TestCase):
     def test_add_delete_dataset(self):
         """Test add_dataset and _delete_dataset"""
 
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
+
         # Create dataset
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
-        env.delete_old_test_buckets(age_to_delete=7)
-        env.delete_old_test_datasets()
+        env.delete_old_test_datasets(age_to_delete=7)
 
         dataset_id = env.add_dataset()
         create_bigquery_dataset(self.project_id, dataset_id, self.data_location)
@@ -196,6 +196,7 @@ class TestObservatoryEnvironment(unittest.TestCase):
         
         """ Tests delete_old_test_buckets. Used to remove leftover buckets from stopped tests."""
 
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
 
         bucket_list =[ self.prefix + "_" + random_id() for i in range(2) ]
@@ -216,6 +217,7 @@ class TestObservatoryEnvironment(unittest.TestCase):
     
     def test_delete_old_test_datasets(self):
 
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix=self.prefix)
 
         dataset_list = [ env.add_dataset() for i in range(2) ]
@@ -246,6 +248,7 @@ class TestObservatoryEnvironment(unittest.TestCase):
         dag = telescope.make_dag()
 
         # Test that previous tasks have to be finished to run next task
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
         
         env.delete_old_test_buckets(age_to_delete=7)
@@ -304,11 +307,11 @@ class TestObservatoryEnvironment(unittest.TestCase):
     def test_task_logging(self):
         """Test task logging"""
 
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
+
         expected_state = "success"
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
         env.delete_old_test_buckets(age_to_delete=7)
-        env.delete_old_test_datasets(age_to_delete=7)
-
 
         # Setup Telescope
         execution_date = pendulum.datetime(year=2020, month=11, day=1)
@@ -354,10 +357,10 @@ class TestObservatoryEnvironment(unittest.TestCase):
     def test_create_dagrun(self):
         """Tests create_dag_run"""
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
 
+        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
         env.delete_old_test_buckets(age_to_delete=7)
-        env.delete_old_test_datasets(age_to_delete=7)
 
         # Setup Telescope
         first_execution_date = pendulum.datetime(year=2020, month=11, day=1, tz="UTC")
@@ -436,8 +439,10 @@ class TestObservatoryEnvironment(unittest.TestCase):
 
     def test_create_dag_run_timedelta(self):
 
-        self.prefix = make_prefix(__class__.__name__, "TCDRT")
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
+        env.delete_old_test_buckets(age_to_delete=7)
+
         telescope = TelescopeTest(schedule_interval=timedelta(days=1))
         dag = telescope.make_dag()
         execution_date = pendulum.datetime(2021, 1, 1)
@@ -455,8 +460,6 @@ class TestObservatoryTestCase(unittest.TestCase):
         super(TestObservatoryTestCase, self).__init__(*args, **kwargs)
         self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
-
-        self.prefix = make_prefix(__class__.__name__,"")
 
     def test_assert_dag_structure(self):
         """Test assert_dag_structure"""
@@ -476,6 +479,8 @@ class TestObservatoryTestCase(unittest.TestCase):
 
     def test_assert_dag_load(self):
         """Test assert_dag_load"""
+
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
 
         test_case = ObservatoryTestCase()
         env = ObservatoryEnvironment(prefix=self.prefix)
@@ -512,7 +517,11 @@ class TestObservatoryTestCase(unittest.TestCase):
     def test_assert_blob_integrity(self):
         """Test assert_blob_integrity"""
 
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
+
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
+        env.delete_old_test_buckets(age_to_delete=7)
+
         with env.create():
             # Upload file to download bucket and check gzip-crc
             file_name = "people.csv"
@@ -531,7 +540,7 @@ class TestObservatoryTestCase(unittest.TestCase):
     def test_assert_table_integrity(self):
         """Test assert_table_integrity"""
 
-        self.prefix = make_prefix(__class__.__name__,"TATI")
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
 
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
         env.delete_old_test_buckets(age_to_delete = 7)
@@ -586,7 +595,7 @@ class TestObservatoryTestCase(unittest.TestCase):
         :return: None.
         """
 
-        self.prefix = make_prefix(__class__.__name__,"TATC")
+        self.prefix = make_prefix(self.__class__.__name__,self._testMethodName)
         env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
 
         env.delete_old_test_buckets(age_to_delete = 7)

--- a/tests/observatory/platform/workflows/test_elastic_import_workflow.py
+++ b/tests/observatory/platform/workflows/test_elastic_import_workflow.py
@@ -37,7 +37,6 @@ from observatory.platform.utils.test_utils import (
     ObservatoryTestCase,
     Table,
     bq_load_tables,
-    make_prefix,
     test_fixtures_path,
     find_free_port,
 )
@@ -169,9 +168,6 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
         self.table_name = "ao_author"
 
-
-        self.prefix = make_prefix(__class__.__name__,"OTC")
-
     def test_ctor(self):
         workflow_default_index_keep_info = ElasticImportWorkflow(
             dag_id="elastic_import",
@@ -287,11 +283,7 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
             enable_elastic=True,
             elastic_port=self.elastic_port,
             kibana_port=self.kibana_port,
-            prefix = self.prefix
         )
-
-        env.delete_old_test_buckets(age_to_delete=7)
-        env.delete_old_test_datasets(age_to_delete=7)
 
         dataset_id = env.add_dataset(prefix="data_export")
         with env.create() as t:

--- a/tests/observatory/platform/workflows/test_elastic_import_workflow.py
+++ b/tests/observatory/platform/workflows/test_elastic_import_workflow.py
@@ -290,7 +290,7 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
             prefix = self.prefix
         )
 
-        env.delete_old_test_buckets(age_to_detele=7)
+        env.delete_old_test_buckets(age_to_delete=7)
         env.delete_old_test_datasets(age_to_delete=7)
 
         dataset_id = env.add_dataset(prefix="data_export")

--- a/tests/observatory/platform/workflows/test_elastic_import_workflow.py
+++ b/tests/observatory/platform/workflows/test_elastic_import_workflow.py
@@ -37,6 +37,7 @@ from observatory.platform.utils.test_utils import (
     ObservatoryTestCase,
     Table,
     bq_load_tables,
+    make_prefix,
     test_fixtures_path,
     find_free_port,
 )
@@ -168,6 +169,9 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
         self.table_name = "ao_author"
 
+
+        self.prefix = make_prefix(__class__.__name__,"OTC")
+
     def test_ctor(self):
         workflow_default_index_keep_info = ElasticImportWorkflow(
             dag_id="elastic_import",
@@ -283,7 +287,12 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
             enable_elastic=True,
             elastic_port=self.elastic_port,
             kibana_port=self.kibana_port,
+            prefix = self.prefix
         )
+
+        env.delete_old_test_buckets(age_to_detele=7)
+        env.delete_old_test_datasets(age_to_delete=7)
+
         dataset_id = env.add_dataset(prefix="data_export")
         with env.create() as t:
             # Create settings

--- a/tests/observatory/platform/workflows/test_stream_telescope.py
+++ b/tests/observatory/platform/workflows/test_stream_telescope.py
@@ -40,6 +40,7 @@ from observatory.platform.utils.release_utils import get_dataset_releases, get_l
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
+    make_prefix,
     test_fixtures_path,
     find_free_port,
 )
@@ -207,6 +208,8 @@ class TestStreamTelescope(ObservatoryTestCase):
         self.org_name = "Curtin University"
         self.workflow = 1
 
+        self.prefix = make_prefix(__class__.__name__, self.org_name)
+
     def setup_api(self):
         org = Organisation(name=self.org_name)
         result = self.api.put_organisation(org)
@@ -261,8 +264,12 @@ class TestStreamTelescope(ObservatoryTestCase):
             with self.subTest(batch_load=batch_load):
                 # Setup Observatory environment
                 env = ObservatoryEnvironment(
-                    self.project_id, self.data_location, api_host=self.host, api_port=self.port
+                    self.project_id, self.data_location, api_host=self.host, api_port=self.port, prefix = self.prefix
                 )
+
+                env.delete_old_test_buckets(age_to_delete=7)
+                env.delete_old_test_datasets(age_to_delete=7)
+
                 dataset_id = env.add_dataset()
 
                 telescope = MyTestStreamTelescope(dataset_id=dataset_id, batch_load=batch_load, workflow_id=1)
@@ -456,14 +463,20 @@ class TestStreamTelescope(ObservatoryTestCase):
 
         m_makeapi.return_value = self.api
 
+        self.prefix = make_prefix(__class__.__name__, "TTFC")
+
         # Setup Telescopes, first one without batch_load and second one with batch_load
         batch_load_settings = [False, True]
         for batch_load in batch_load_settings:
             with self.subTest(batch_load=batch_load):
                 # Setup Observatory environment
                 env = ObservatoryEnvironment(
-                    self.project_id, self.data_location, api_host=self.host, api_port=self.port
+                    self.project_id, self.data_location, api_host=self.host, api_port=self.port, prefix = self.prefix
                 )
+
+                env.delete_old_test_buckets(age_to_delete=7)
+                env.delete_old_test_datasets(age_to_delete=7)
+
                 dataset_id = env.add_dataset()
 
                 telescope = MyTestStreamTelescope(dataset_id=dataset_id, batch_load=batch_load)
@@ -740,8 +753,13 @@ class TestStreamTelescopeTasks(ObservatoryTestCase):
     def test_get_release_info(self, m_makeapi):
         m_makeapi.return_value = self.api
 
+        self.prefix = make_prefix(__class__.__name__, "TGRI")
+
         start_date = pendulum.datetime(2020, 8, 1)
-        env = ObservatoryEnvironment(api_host=self.host, api_port=self.port)
+        env = ObservatoryEnvironment(api_host=self.host, api_port=self.port, prefix = self.prefix)
+        env.delete_old_test_buckets(age_to_delete=7)
+        env.delete_old_test_datasets(age_to_delete=7)
+
         with env.create():
             self.setup_api()
             first_execution_date = pendulum.datetime(2021, 9, 2)

--- a/tests/observatory/platform/workflows/test_stream_telescope.py
+++ b/tests/observatory/platform/workflows/test_stream_telescope.py
@@ -40,7 +40,6 @@ from observatory.platform.utils.release_utils import get_dataset_releases, get_l
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
-    make_prefix,
     test_fixtures_path,
     find_free_port,
 )
@@ -208,8 +207,6 @@ class TestStreamTelescope(ObservatoryTestCase):
         self.org_name = "Curtin University"
         self.workflow = 1
 
-        self.prefix = make_prefix(__class__.__name__, self.org_name)
-
     def setup_api(self):
         org = Organisation(name=self.org_name)
         result = self.api.put_organisation(org)
@@ -264,11 +261,8 @@ class TestStreamTelescope(ObservatoryTestCase):
             with self.subTest(batch_load=batch_load):
                 # Setup Observatory environment
                 env = ObservatoryEnvironment(
-                    self.project_id, self.data_location, api_host=self.host, api_port=self.port, prefix = self.prefix
+                    self.project_id, self.data_location, api_host=self.host, api_port=self.port
                 )
-
-                env.delete_old_test_buckets(age_to_delete=7)
-                env.delete_old_test_datasets(age_to_delete=7)
 
                 dataset_id = env.add_dataset()
 
@@ -469,11 +463,8 @@ class TestStreamTelescope(ObservatoryTestCase):
             with self.subTest(batch_load=batch_load):
                 # Setup Observatory environment
                 env = ObservatoryEnvironment(
-                    self.project_id, self.data_location, api_host=self.host, api_port=self.port, prefix = self.prefix
+                    self.project_id, self.data_location, api_host=self.host, api_port=self.port
                 )
-
-                env.delete_old_test_buckets(age_to_delete=7)
-                env.delete_old_test_datasets(age_to_delete=7)
 
                 dataset_id = env.add_dataset()
 
@@ -710,8 +701,6 @@ class TestStreamTelescopeTasks(ObservatoryTestCase):
         self.org_name = "Curtin University"
         self.workflow = 1
 
-        self.prefix = make_prefix(__class__.__name__, self.org_name)
-
     def setup_api(self):
         org = Organisation(name=self.org_name)
         result = self.api.put_organisation(org)
@@ -754,9 +743,7 @@ class TestStreamTelescopeTasks(ObservatoryTestCase):
         m_makeapi.return_value = self.api
 
         start_date = pendulum.datetime(2020, 8, 1)
-        env = ObservatoryEnvironment(api_host=self.host, api_port=self.port, prefix = self.prefix)
-        env.delete_old_test_buckets(age_to_delete=7)
-        env.delete_old_test_datasets(age_to_delete=7)
+        env = ObservatoryEnvironment(api_host=self.host, api_port=self.port)
 
         with env.create():
             self.setup_api()

--- a/tests/observatory/platform/workflows/test_stream_telescope.py
+++ b/tests/observatory/platform/workflows/test_stream_telescope.py
@@ -463,8 +463,6 @@ class TestStreamTelescope(ObservatoryTestCase):
 
         m_makeapi.return_value = self.api
 
-        self.prefix = make_prefix(__class__.__name__, "TTFC")
-
         # Setup Telescopes, first one without batch_load and second one with batch_load
         batch_load_settings = [False, True]
         for batch_load in batch_load_settings:
@@ -712,6 +710,8 @@ class TestStreamTelescopeTasks(ObservatoryTestCase):
         self.org_name = "Curtin University"
         self.workflow = 1
 
+        self.prefix = make_prefix(__class__.__name__, self.org_name)
+
     def setup_api(self):
         org = Organisation(name=self.org_name)
         result = self.api.put_organisation(org)
@@ -752,8 +752,6 @@ class TestStreamTelescopeTasks(ObservatoryTestCase):
     @patch("observatory.platform.utils.release_utils.make_observatory_api")
     def test_get_release_info(self, m_makeapi):
         m_makeapi.return_value = self.api
-
-        self.prefix = make_prefix(__class__.__name__, "TGRI")
 
         start_date = pendulum.datetime(2020, 8, 1)
         env = ObservatoryEnvironment(api_host=self.host, api_port=self.port, prefix = self.prefix)

--- a/tests/observatory/platform/workflows/test_workflow.py
+++ b/tests/observatory/platform/workflows/test_workflow.py
@@ -30,7 +30,11 @@ from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
 from airflow.sensors.external_task import ExternalTaskSensor
 from observatory.platform.observatory_config import Environment
 from observatory.platform.utils.airflow_utils import AirflowVars
-from observatory.platform.utils.test_utils import ObservatoryEnvironment, ObservatoryTestCase, find_free_port, make_prefix
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    find_free_port,
+)
 from observatory.platform.workflows.workflow import Release, Workflow, make_task_id
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_type import DatasetType
@@ -105,8 +109,6 @@ class TestWorkflow(ObservatoryTestCase):
         self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
         self.org_name = "Curtin University"
         self.workflow_id = 1
-
-        self.prefix = make_prefix(__class__.__name__, self.org_name)
 
     def setup_api(self):
         org = Organisation(name=self.org_name)
@@ -304,10 +306,7 @@ class TestWorkflow(ObservatoryTestCase):
         m_makeapi.return_value = self.api
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port, prefix = self.prefix)
-
-        env.delete_old_test_buckets(age_to_delete=7)
-        env.delete_old_test_datasets(age_to_delete=7)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
 
         # Create the Observatory environment and run tests
         with env.create(task_logging=True):
@@ -351,10 +350,7 @@ class TestWorkflow(ObservatoryTestCase):
         # mock_send_slack_msg.return_value = Mock(spec=SlackWebhookHook)
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location, prefix = self.prefix)
-
-        env.delete_old_test_buckets(age_to_delete=7)
-        env.delete_old_test_datasets(age_to_delete=7)
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
 
         # Setup Telescope with 0 retries and missing airflow variable, so it will fail the task
         execution_date = pendulum.datetime(2020, 1, 1)


### PR DESCRIPTION
When unit tests run and are stopped part way through, they can leave behind unwanted buckets and datasets in Google Cloud and BigQuery. 

Functions have been added to remove unnecessary old test buckets and datasets that can be run at the start of each test that are older than 7 days from the Google Storage and BigQuery that share a common prefix. Each prefix is unique to the test and organisation name and will not remove buckets or datasets that are being used by other tests. 

Each unit test still needs to be modified to add this pre-run clean up step. 