### PR TITLE
INF-547: Random_id generator to use hostname of machine

### DIFF
--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -121,6 +121,7 @@ from observatory.platform.utils.workflow_utils import find_schema
 from pendulum import DateTime
 from sftpserver.stub_sftp import StubServer, StubSFTPServer
 import freezegun
+import socket
 
 
 def random_id():
@@ -128,7 +129,7 @@ def random_id():
 
     :return: a random string id.
     """
-    return str(uuid.uuid4()).replace("-", "")
+    return str(uuid.uuid5(uuid.uuid4(), socket.gethostname())).replace("-", "")
 
 
 def test_fixtures_path(*subdirs) -> str:

--- a/observatory-platform/observatory/platform/utils/test_utils.py
+++ b/observatory-platform/observatory/platform/utils/test_utils.py
@@ -127,6 +127,11 @@ import socket
 def random_id():
     """Generate a random id for bucket name.
 
+    When code is pushed to a branch and a pull request is open, Github Actions runs the unit tests workflow
+    twice, one for the push and one for the pull request. However, the uuid4 function, which calls os.urandom(16),
+    generates the same sequence of values for each workflow run. We have also used the hostname of the machine
+    in the construction of the random id to ensure sure that the ids are different on both workflow runs.
+
     :return: a random string id.
     """
     return str(uuid.uuid5(uuid.uuid4(), socket.gethostname())).replace("-", "")


### PR DESCRIPTION
Discovered that unit tests fail due to the Github action VMs being able to generate the same random_id used for Google buckets and datasets for separate push and pull request unit tests. This can cause the two tests to interfere with each other and unexpectedly delete buckets and or datasets that are still in use which causes one of the two tests to fail. 

I have added a tad more randomness to the randon_id by effectively using the hostname of the github VM as a seed for the ID generation. Changed the random_id from being generated from uuid4 to uuid5 using a uuidv4 and the hostname of the VM.