### PR TITLE
INF-484: Validate logos are in SVG or JPG

### DIFF
--- a/observatory-platform/observatory/platform/utils/workflow_utils.py
+++ b/observatory-platform/observatory/platform/utils/workflow_utils.py
@@ -1078,8 +1078,8 @@ def delete_old_xcoms(
 
 def check_image_integrity(image_path: str, image_type: str):
 
-    """ Function to check if images exist and or currupted. Check performed by verifying and 
-    rotation/transposing, which will fail if they are courrpt. 
+    """ Function to check if images are in an accepted type, if they exist and if they are corrupt. 
+    Check performed by verifying and rotating/transposing, which will fail if they are courrpt. 
 
     PIL can take multiple different file formats, just not SVGs. SVGs are converted 
     to a PNG as required.
@@ -1093,14 +1093,18 @@ def check_image_integrity(image_path: str, image_type: str):
     # Parameter needed for PIL library to allow large images.
     PIL.Image.MAX_IMAGE_PIXELS = 933120000
 
-    if image_type != "fmt":
-        if image_type == "svg":
+    accepted_image_types = ['svg', 'jpg', 'jpeg', 'png'] 
+    if image_type in accepted_image_types:
+        if image_type == 'svg':
             # Convert SVG to PNG
             cairosvg.svg2png(url=image_path, write_to='output.png')
             valid_file = pil_check("output.png")
             os.remove("output.png")
         else:
-            valid_file = pil_check(image_path)
+            valid_file = pil_check(image_path)   
+    else:
+        valid_file = False
+        raise AirflowException(f'Image is neither a {accepted_image_types} : {image_path}')
 
     return valid_file
 

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -55,6 +55,10 @@ validators
 xmltodict
 pandas
 
+# Verifying logos/images
+image==1.5.33
+CairoSVG==2.5.2
+
 # Test utils
 freezegun>=1.1.0,<2
 httpretty>=1.0.0,<2

--- a/tests/observatory/platform/utils/test_workflow_utils.py
+++ b/tests/observatory/platform/utils/test_workflow_utils.py
@@ -934,9 +934,9 @@ class TestWorkflowUtils(unittest.TestCase):
             # Verify conversion
             img = PIL.Image.open('output.png')
             expected_image_array = [ [ [0, 68, 51, 234], [0, 68, 52,  64], [0,  0, 0,    0], [0,  0,  0,   0] ],
-                                    [ [0, 68, 51,  60], [0, 68, 51, 233], [0, 70, 50,  66], [0,  0,  0,   0] ],
-                                    [ [0,  0,  0,   0], [0, 68, 51,  60], [0, 60, 51, 233], [0, 70, 50,  66] ],
-                                    [ [0,  0,  0,   0], [0,  0,  0,   0], [0, 68, 52,  64], [0, 68, 51, 234] ] ]
+                                     [ [0, 68, 51,  60], [0, 68, 51, 233], [0, 70, 50,  66], [0,  0,  0,   0] ],
+                                     [ [0,  0,  0,   0], [0, 68, 51,  60], [0, 60, 51, 233], [0, 70, 50,  66] ],
+                                     [ [0,  0,  0,   0], [0,  0,  0,   0], [0, 68, 52,  64], [0, 68, 51, 234] ] ]
             self.assertEquals(asarray(expected_image_array).all(), asarray(img).all())
 
             # Check image integrity (mock is known to be good)
@@ -944,8 +944,11 @@ class TestWorkflowUtils(unittest.TestCase):
             self.assertTrue(success)
 
         finally:
-            os.remove('output.png')
-            
+            # Delete file created by test.
+            try:
+                os.remove('output.png')
+            except:
+                raise Exception('Unable to delete output.png from test.')
 
     def test_normalized_schedule_interval(self):
         """Test normalized_schedule_interval"""


### PR DESCRIPTION
Added function and necessary unit test to check if an image is in an accepted format, being either a svg, jpg, jpeg, or png. 
Also does a verification step and raises an Airflow exception is the image is corrupt.

To add to oa_web_workflow to check that the logos exist and if they were downloaded correctly. 