### PR TITLE
INF-588: HTTP Request Updates

### DIFF
--- a/observatory-platform/observatory/platform/utils/url_utils.py
+++ b/observatory-platform/observatory/platform/utils/url_utils.py
@@ -34,7 +34,7 @@ from tenacity.wait import wait_base
 def retry_get_url(
     url: str,
     num_retries=3,
-    wait: wait_base = wait_exponential_jitter(multipliter=5, max=300),
+    wait: wait_base = wait_exponential_jitter(initial=5, max=300),
     squelch_url: bool = False,
     **kwargs,
 ):

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -55,6 +55,7 @@ timeout-decorator
 validators
 xmltodict
 pandas
+tenacity
 
 # Test utils
 freezegun>=1.1.0,<2


### PR DESCRIPTION
Updates to URL Utilities

- Removed functions that are not in use anywhere
- Created a new function for retrying GET requests using tenacity

I know that we have the retry_session() function, but there are some things that it (and urllib3) can't do. With the tenacity function, we can:
- specify any 400/500 response as an error
- log each repeat request as they are placed

This does not make the retry_session() function obsolete, as it is able to force a small selection of response codes to retry. It can also do more than GET requests.