### PR TITLE
INF-597: Terraform config files not updating and Flower docker container not building successfully. 

### DIFF
--- a/observatory-platform/observatory/platform/terraform/build.sh
+++ b/observatory-platform/observatory/platform/terraform/build.sh
@@ -3,6 +3,8 @@
 # Documentation recommends to sleep for 30 seconds first:
 sleep 30
 
+echo " ----- Install Docker (using apt-get) ----- "
+
 # Install Docker
 sudo apt-get update
 sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
@@ -12,10 +14,14 @@ sudo apt-get update
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io
 sudo service docker restart
 
+echo " ----- Make the airflow user and add it to the docker group ----- "
+
 # Make the airflow user and add it to the docker group
 sudo useradd --home-dir /home/airflow --shell /bin/bash --create-home airflow
 sudo usermod -aG docker airflow
 sudo newgrp docker
+
+echo " ----- Install Docker Compose v1.29.2 and Berlas v0.5.0 ----- "
 
 # Install Docker Compose
 sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64" -o /usr/local/bin/docker-compose
@@ -25,12 +31,16 @@ sudo chmod +x /usr/local/bin/docker-compose
 sudo curl -L "https://storage.googleapis.com/berglas/0.5.0/linux_amd64/berglas" -o /usr/local/bin/berglas
 sudo chmod +x /usr/local/bin/berglas
 
+echo " ----- Install Google Compute Monitoring agent ----- "
+
 # Install Google Compute Monitoring agent
 curl -sSO https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
 sudo bash add-monitoring-agent-repo.sh
 sudo apt-get update
 sudo apt-get install -y 'stackdriver-agent=6.*'
 sudo service stackdriver-agent start
+
+echo " ----- Make airflow and docker directories, move packages, and clean up files ----- "
 
 # Make directories
 sudo mkdir -p /opt/airflow/logs
@@ -47,8 +57,9 @@ sudo cp -r /tmp/opt/observatory/build/docker/* /opt/observatory/build/docker
 # Remove tmp
 sudo rm -r /tmp
 
-# Own all /opt directories
+# Own all /opt directories and packer home folder
 sudo chown -R airflow /opt/
+sudo chown -R airflow /home/packer/
 
 # Set working directory and environment variables for building docker containers
 cd /opt/observatory/build/docker
@@ -58,6 +69,8 @@ export HOST_FLOWER_UI_PORT=5555
 export HOST_AIRFLOW_UI_PORT=8080
 export HOST_ELASTIC_PORT=9200
 export HOST_KIBANA_PORT=5601
+
+echo " ----- Building docker containers with docker-compose, running as airflow user ----- "
 
 # Pull and build Docker containers
 PRESERVE_ENV="HOST_USER_ID,HOST_REDIS_PORT,HOST_FLOWER_UI_PORT,HOST_AIRFLOW_UI_PORT,HOST_ELASTIC_PORT,HOST_KIBANA_PORT"

--- a/observatory-platform/observatory/platform/terraform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform/terraform_builder.py
@@ -31,8 +31,8 @@ from observatory.platform.utils.jinja2_utils import render_template
 from observatory.platform.utils.proc_utils import stream_process
 
 
-def copy_dir(source_path: str, destination_path: str, ignore, update: int = 0):
-    distutils.dir_util.copy_tree(source_path, destination_path, update=update)
+def copy_dir(source_path: str, destination_path: str):
+    distutils.dir_util.copy_tree(source_path, destination_path)
 
 
 class TerraformBuilder:
@@ -89,21 +89,19 @@ class TerraformBuilder:
             shutil.rmtree(self.packages_build_path)
         os.makedirs(self.packages_build_path)
 
-        ignore = shutil.ignore_patterns("__pycache__", "*.eggs", "*.egg-info")
-
         # Copy local packages
         for package in self.config.python_packages:
             if package.type == "editable":
                 destination_path = os.path.join(self.packages_build_path, package.name)
-                copy_dir(package.host_package, destination_path, ignore)
+                copy_dir(package.host_package, destination_path)
 
         # Clear terraform/terraform path
         if os.path.exists(self.terraform_build_path):
             shutil.rmtree(self.terraform_build_path)
         os.makedirs(self.terraform_build_path)
 
-        # Copy terraform files into build/terraform: ignore jinja2 templates
-        copy_dir(self.terraform_path, self.terraform_build_path, ignore=shutil.ignore_patterns("*.jinja2", "__pycache__"))
+        # Copy terraform files into build/terraform
+        copy_dir(self.terraform_path, self.terraform_build_path)
 
         # Make startup scripts
         self.make_startup_script(True, "startup-main.tpl")

--- a/observatory-platform/observatory/platform/terraform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform/terraform_builder.py
@@ -31,8 +31,8 @@ from observatory.platform.utils.jinja2_utils import render_template
 from observatory.platform.utils.proc_utils import stream_process
 
 
-def copy_dir(source_path: str, destination_path: str, ignore):
-    distutils.dir_util.copy_tree(source_path, destination_path)
+def copy_dir(source_path: str, destination_path: str, ignore, update: int = 0):
+    distutils.dir_util.copy_tree(source_path, destination_path, update=update)
 
 
 class TerraformBuilder:
@@ -97,8 +97,13 @@ class TerraformBuilder:
                 destination_path = os.path.join(self.packages_build_path, package.name)
                 copy_dir(package.host_package, destination_path, ignore)
 
+        # Clear terraform/terraform path
+        if os.path.exists(self.terraform_build_path):
+            shutil.rmtree(self.terraform_build_path)
+        os.makedirs(self.terraform_build_path)
+
         # Copy terraform files into build/terraform: ignore jinja2 templates
-        copy_dir(self.terraform_path, self.terraform_build_path, shutil.ignore_patterns("*.jinja2", "__pycache__"))
+        copy_dir(self.terraform_path, self.terraform_build_path, ignore=shutil.ignore_patterns("*.jinja2", "__pycache__"))
 
         # Make startup scripts
         self.make_startup_script(True, "startup-main.tpl")


### PR DESCRIPTION
1. When using the `observatory terraform build-image config.yaml` command, it was not copying/overwriting terraform config files to the observatory home directory and thus when deploying a new version of the platform to the cloud, it was using the old terraform config. I have now forced the platform to delete the old terraform config files before copying the new ones across from the codebase.

3. After updating the terraform files a strange permissions issue with docker arose, causing the flower container to fail when building the main VM. Have added the appropriate permissions to the /home/packer folder for the airflow user so the Flower container can build successfully. 

Waiting on results from the unit tests.