### PR TITLE
Upgrade to Docker Compose V2

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,7 @@ Observatory Platform supports Python 3.8, Ubuntu Linux 20.04 and MacOS 10.14, on
 * Python 3.8
 * Pip
 * Docker
+* Docker Compose V2
 * virtualenv
 * curl
 

--- a/install.sh
+++ b/install.sh
@@ -268,7 +268,7 @@ function install_ubuntu_system_deps() {
     echo "Installing docker"
     echo "-----------------"
 
-    sudo apt-get install -y docker.io
+    sudo apt-get install -y docker.io docker-compose-plugin
 
     echo "Adding $(id -nu) to the docker group"
     sudo usermod -aG docker $(id -nu)

--- a/observatory-platform/observatory/platform/cli/cli.py
+++ b/observatory-platform/observatory/platform/cli/cli.py
@@ -15,8 +15,6 @@
 # Author: James Diprose, Aniek Roelofs, Tuan Chien
 
 import os
-import subprocess
-import sys
 from typing import ClassVar
 
 import click
@@ -35,7 +33,6 @@ from observatory.platform.utils.config_utils import observatory_home
 from observatory.platform.utils.config_utils import (
     terraform_credentials_path as default_terraform_credentials_path,
 )
-from observatory.platform.utils.proc_utils import stream_process
 
 PLATFORM_NAME = "Observatory Platform"
 TERRAFORM_NAME = "Observatory Terraform"
@@ -160,9 +157,9 @@ def platform_check_dependencies(platform_cmd: PlatformCommand, min_line_chars: i
     else:
         print(indent("- not installed, please install https://docs.docker.com/get-docker/", INDENT2))
 
-    print(indent("Docker Compose:", INDENT1))
-    if platform_cmd.docker_compose_path is not None:
-        print(indent(f"- path: {platform_cmd.docker_compose_path}", INDENT2))
+    print(indent("Docker Compose V2:", INDENT1))
+    if platform_cmd.docker_compose:
+        print(indent(f"- installed", INDENT2))
     else:
         print(indent("- not installed, please install https://docs.docker.com/compose/install/", INDENT2))
 

--- a/observatory-platform/observatory/platform/docker/compose_runner.py
+++ b/observatory-platform/observatory/platform/docker/compose_runner.py
@@ -39,7 +39,7 @@ class ProcessOutput:
 
 
 class ComposeRunner(Builder):
-    COMPOSE_ARGS_PREFIX = ["docker-compose", "-f"]
+    COMPOSE_ARGS_PREFIX = ["docker", "compose", "-f"]
     COMPOSE_BUILD_ARGS = ["build"]
     COMPOSE_START_ARGS = ["up", "-d"]
     COMPOSE_STOP_ARGS = ["down"]

--- a/observatory-platform/observatory/platform/docker/platform_runner.py
+++ b/observatory-platform/observatory/platform/docker/platform_runner.py
@@ -95,7 +95,7 @@ class PlatformRunner(ComposeRunner):
         :return: whether the environment for building the Observatory Platform is valid.
         """
 
-        return all([self.docker_exe_path is not None, self.docker_compose_path is not None, self.is_docker_running])
+        return all([self.docker_exe_path is not None, self.docker_compose, self.is_docker_running])
 
     @property
     def docker_module_path(self) -> str:
@@ -116,13 +116,14 @@ class PlatformRunner(ComposeRunner):
         return shutil.which("docker")
 
     @property
-    def docker_compose_path(self) -> str:
-        """The path to the Docker Compose executable.
+    def docker_compose(self) -> bool:
+        """Whether Docker Compose is installed.
 
-        :return: the path or None.
+        :return: true or false.
         """
 
-        return shutil.which("docker-compose")
+        stream = os.popen("docker info")
+        return "compose: Docker Compose" in stream.read()
 
     @property
     def is_docker_running(self) -> bool:

--- a/observatory-platform/observatory/platform/terraform/build.sh
+++ b/observatory-platform/observatory/platform/terraform/build.sh
@@ -1,39 +1,27 @@
 #!/usr/bin/env bash
 
-# Documentation recommends to sleep for 30 seconds first:
+echo " ----- Sleeping for 30 seconds as per Packer documentation ----- "
 sleep 30
 
-echo " ----- Install Docker (using apt-get) ----- "
-
-# Install Docker
+echo " ----- Install Docker and Docker Compose V2 (using apt-get) ----- "
+sudo apt-get -y install ca-certificates curl gnupg lsb-release
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
-sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
-sudo apt-get update
-sudo apt-get -y install docker-ce docker-ce-cli containerd.io
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 sudo service docker restart
 
 echo " ----- Make the airflow user and add it to the docker group ----- "
-
-# Make the airflow user and add it to the docker group
 sudo useradd --home-dir /home/airflow --shell /bin/bash --create-home airflow
 sudo usermod -aG docker airflow
 sudo newgrp docker
 
-echo " ----- Install Docker Compose v1.29.2 and Berlas v0.5.0 ----- "
-
-# Install Docker Compose
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
-
-# Install berglas v0.5.3
-sudo curl -L "https://storage.googleapis.com/berglas/0.5.0/linux_amd64/berglas" -o /usr/local/bin/berglas
+echo " ----- Install Berglas v1.0.1 ----- "
+sudo curl -L "https://storage.googleapis.com/berglas/1.0.1/linux_amd64/berglas" -o /usr/local/bin/berglas
 sudo chmod +x /usr/local/bin/berglas
 
 echo " ----- Install Google Compute Monitoring agent ----- "
-
-# Install Google Compute Monitoring agent
 curl -sSO https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
 sudo bash add-monitoring-agent-repo.sh
 sudo apt-get update
@@ -41,8 +29,6 @@ sudo apt-get install -y 'stackdriver-agent=6.*'
 sudo service stackdriver-agent start
 
 echo " ----- Make airflow and docker directories, move packages, and clean up files ----- "
-
-# Make directories
 sudo mkdir -p /opt/airflow/logs
 sudo mkdir /opt/airflow/dags
 sudo mkdir -p /opt/observatory/data
@@ -71,8 +57,6 @@ export HOST_ELASTIC_PORT=9200
 export HOST_KIBANA_PORT=5601
 
 echo " ----- Building docker containers with docker-compose, running as airflow user ----- "
-
-# Pull and build Docker containers
 PRESERVE_ENV="HOST_USER_ID,HOST_REDIS_PORT,HOST_FLOWER_UI_PORT,HOST_AIRFLOW_UI_PORT,HOST_ELASTIC_PORT,HOST_KIBANA_PORT"
-sudo -u airflow --preserve-env=${PRESERVE_ENV} bash -c "docker-compose -f docker-compose.observatory.yml pull"
-sudo -u airflow --preserve-env=${PRESERVE_ENV} bash -c "docker-compose -f docker-compose.observatory.yml build"
+sudo -u airflow --preserve-env=${PRESERVE_ENV} bash -c "docker compose -f docker-compose.observatory.yml pull"
+sudo -u airflow --preserve-env=${PRESERVE_ENV} bash -c "docker compose -f docker-compose.observatory.yml build"

--- a/observatory-platform/observatory/platform/terraform/build.sh
+++ b/observatory-platform/observatory/platform/terraform/build.sh
@@ -18,7 +18,8 @@ sudo usermod -aG docker airflow
 sudo newgrp docker
 
 echo " ----- Install Berglas v1.0.1 ----- "
-sudo curl -L "https://storage.googleapis.com/berglas/1.0.1/linux_amd64/berglas" -o /usr/local/bin/berglas
+# See here for a list of releases: https://github.com/GoogleCloudPlatform/berglas/releases
+curl -L "https://github.com/GoogleCloudPlatform/berglas/releases/download/v1.0.1/berglas_1.0.1_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin berglas
 sudo chmod +x /usr/local/bin/berglas
 
 echo " ----- Install Google Compute Monitoring agent ----- "

--- a/observatory-platform/observatory/platform/terraform/observatory-image.json
+++ b/observatory-platform/observatory/platform/terraform/observatory-image.json
@@ -11,7 +11,7 @@
       "account_file": "{{user `credentials_file`}}",
       "project_id": "{{user `project_id`}}",
       "ssh_username": "packer",
-      "source_image_family": "ubuntu-1804-lts",
+      "source_image_family": "ubuntu-2204-lts",
       "machine_type": "n1-standard-1",
       "zone": "{{user `zone`}}",
       "image_name": "observatory-image-{{user `environment`}}"

--- a/observatory-platform/observatory/platform/terraform/startup.tpl.jinja2
+++ b/observatory-platform/observatory/platform/terraform/startup.tpl.jinja2
@@ -56,7 +56,7 @@ sudo -u airflow bash -c "berglas access sm://${project_id}/google_application_cr
 cd /opt/observatory/build/docker
 
 # Pull, build and start Docker containers
-{% set docker_compose_cmd="docker-compose -f docker-compose.observatory.yml"%}
+{% set docker_compose_cmd="docker compose -f docker-compose.observatory.yml"%}
 sudo -u airflow --preserve-env=$PRESERVE_ENV bash -c "{{ docker_compose_cmd }} pull {{ docker_containers }}"
 sudo -u airflow --preserve-env=$PRESERVE_ENV bash -c "{{ docker_compose_cmd }} build {{ docker_containers }}"
 sudo -u airflow -H --preserve-env=$PRESERVE_ENV bash -c "berglas exec -- {{ docker_compose_cmd }} up -d {{ docker_containers }}"

--- a/observatory-platform/observatory/platform/terraform/versions.tf
+++ b/observatory-platform/observatory/platform/terraform/versions.tf
@@ -2,13 +2,16 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "~> 4.53.1"
     }
     random = {
       source = "hashicorp/random"
+      version = "~> 3.4.3"
     }
     template = {
       source = "hashicorp/template"
+      version = "~> 2.2.0"
     }
   }
-  required_version = ">= 0.13.5"
+  required_version = "~> 1.0.5"
 }

--- a/observatory-platform/observatory/platform/terraform/vm/main.tf
+++ b/observatory-platform/observatory/platform/terraform/vm/main.tf
@@ -8,6 +8,7 @@ resource "google_compute_address" "vm_private_ip" {
 resource "google_compute_instance" "vm_instance" {
   name = var.name
   machine_type = var.machine_type
+  tags = ["allow-ssh"]
   allow_stopping_for_update = true
 
   boot_disk {

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -24,7 +24,7 @@ google-api-core==1.33.2 # fix TypeError: _blocking_poll() got an unexpected keyw
 elasticsearch>=8.0.0,<9
 
 # Docker
-docker-compose>=1.29.2,<2
+docker>6,<7
 
 # Command line interface, config files and templates
 click>=7.1.2,<8

--- a/tests/observatory/platform/cli/test_cli.py
+++ b/tests/observatory/platform/cli/test_cli.py
@@ -212,7 +212,7 @@ class MockPlatformCommand(Mock):
         is_environment_valid: bool,
         docker_exe_path: str,
         is_docker_running: bool,
-        docker_compose_path: str,
+        docker_compose: bool,
         build_return_code: int,
         start_return_code: int,
         stop_return_code: int,
@@ -225,7 +225,7 @@ class MockPlatformCommand(Mock):
         self.is_environment_valid = is_environment_valid
         self.docker_exe_path = docker_exe_path
         self.is_docker_running = is_docker_running
-        self.docker_compose_path = docker_compose_path
+        self.docker_compose = docker_compose
         self.host_uid = HOST_UID
         self.debug = DEBUG
         self.dags_path = dags_path
@@ -269,7 +269,7 @@ class TestObservatoryPlatform(unittest.TestCase):
             is_environment_valid = True
             docker_exe_path = "/path/to/docker"
             is_docker_running = True
-            docker_compose_path = "/path/to/docker-compose"
+            docker_compose = True
             config = MockConfig(is_valid=True)
             mock_config.return_value = config
             build_return_code = 0
@@ -282,7 +282,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 is_environment_valid=is_environment_valid,
                 docker_exe_path=docker_exe_path,
                 is_docker_running=is_docker_running,
-                docker_compose_path=docker_compose_path,
+                docker_compose=docker_compose,
                 build_return_code=build_return_code,
                 start_return_code=start_return_code,
                 stop_return_code=stop_return_code,
@@ -312,7 +312,7 @@ class TestObservatoryPlatform(unittest.TestCase):
             is_environment_valid = False
             docker_exe_path = None
             is_docker_running = False
-            docker_compose_path = None
+            docker_compose = False
             config = None
             build_return_code = 0
             start_return_code = 0
@@ -324,7 +324,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 is_environment_valid=is_environment_valid,
                 docker_exe_path=docker_exe_path,
                 is_docker_running=is_docker_running,
-                docker_compose_path=docker_compose_path,
+                docker_compose=docker_compose,
                 build_return_code=build_return_code,
                 start_return_code=start_return_code,
                 stop_return_code=stop_return_code,
@@ -355,7 +355,7 @@ class TestObservatoryPlatform(unittest.TestCase):
             is_environment_valid = False
             docker_exe_path = None
             is_docker_running = False
-            docker_compose_path = None
+            docker_compose = False
             config = MockConfig(is_valid=True)
             mock_config.return_value = config
             build_return_code = 0
@@ -368,7 +368,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 is_environment_valid=is_environment_valid,
                 docker_exe_path=docker_exe_path,
                 is_docker_running=is_docker_running,
-                docker_compose_path=docker_compose_path,
+                docker_compose=docker_compose,
                 build_return_code=build_return_code,
                 start_return_code=start_return_code,
                 stop_return_code=stop_return_code,
@@ -404,7 +404,7 @@ class TestObservatoryPlatform(unittest.TestCase):
             is_environment_valid = False
             docker_exe_path = "/path/to/docker"
             is_docker_running = False
-            docker_compose_path = "/path/to/docker-compose"
+            docker_compose = True
             config = MockConfig(is_valid=True)
             mock_config.return_value = config
             build_return_code = 0
@@ -417,7 +417,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 is_environment_valid=is_environment_valid,
                 docker_exe_path=docker_exe_path,
                 is_docker_running=is_docker_running,
-                docker_compose_path=docker_compose_path,
+                docker_compose=docker_compose,
                 build_return_code=build_return_code,
                 start_return_code=start_return_code,
                 stop_return_code=stop_return_code,
@@ -450,7 +450,7 @@ class TestObservatoryPlatform(unittest.TestCase):
             is_environment_valid = False
             docker_exe_path = "/path/to/docker"
             is_docker_running = False
-            docker_compose_path = "/path/to/docker-compose"
+            docker_compose = True
             validation_error = ValidationError("google_cloud.credentials", "required field")
             config = MockConfig(is_valid=False, errors=[validation_error])
             mock_config.return_value = config
@@ -464,7 +464,7 @@ class TestObservatoryPlatform(unittest.TestCase):
                 is_environment_valid=is_environment_valid,
                 docker_exe_path=docker_exe_path,
                 is_docker_running=is_docker_running,
-                docker_compose_path=docker_compose_path,
+                docker_compose=docker_compose,
                 build_return_code=build_return_code,
                 start_return_code=start_return_code,
                 stop_return_code=stop_return_code,

--- a/tests/observatory/platform/docker/test_platform_runner.py
+++ b/tests/observatory/platform/docker/test_platform_runner.py
@@ -121,15 +121,13 @@ class TestPlatformRunner(unittest.TestCase):
             self.assertIsNotNone(result)
             self.assertTrue(result.endswith("docker"))
 
-    def test_docker_compose_path(self):
+    def test_docker_compose(self):
         """Test that the path to the Docker Compose executable is found"""
 
         with CliRunner().isolated_filesystem() as t:
             cfg = self.get_config(t)
             cmd = PlatformRunner(config=cfg)
-            result = cmd.docker_compose_path
-            self.assertIsNotNone(result)
-            self.assertTrue(result.endswith("docker-compose"))
+            self.assertTrue(cmd.docker_compose)
 
     @patch("observatory.platform.docker.platform_runner.docker.from_env")
     def test_is_docker_running_true(self, mock_from_env):

--- a/tests/observatory/platform/elastic/test_elastic_environment.py
+++ b/tests/observatory/platform/elastic/test_elastic_environment.py
@@ -20,12 +20,15 @@ import unittest
 from click.testing import CliRunner
 
 from observatory.platform.elastic.elastic_environment import ElasticEnvironment
+from observatory.platform.utils.test_utils import (
+    find_free_port,
+)
 
 
 class TestElasticEnvironment(unittest.TestCase):
     def setUp(self) -> None:
-        self.elastic_port = 9201
-        self.kibana_port = 5602
+        self.elastic_port = find_free_port()
+        self.kibana_port = find_free_port()
         self.wait_time_secs = 120
 
     def test_elastic_environment(self):


### PR DESCRIPTION
Upgrade Docker Compose to V2 as V1 won’t be supported from the end of June 2023 and will be removed from all Docker Desktop versions.

I've also updated a number of related things:
* Updated docs with Docker Compose V2 changes and Ubuntu install script.
* For VMs:
  * Updated VM image to Ubuntu 22.04 (Ubuntu 18.04 is end of life).
  * Updated Berglas to v1.0.1.
* Terraform:
  * Tidied up the firewall rules, which had to be updated after hashicorp/google updated.
  * Add versions restraints to the terraform/versions.tf so that the Terraform providers don't update to a new version without us doing it, which causes problems.

I've tested deploying the system to the cloud.