### PR TITLE
Fix: Only delete non hidden files in terraform directory. 

### DIFF
--- a/observatory-platform/observatory/platform/terraform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform/terraform_builder.py
@@ -100,10 +100,10 @@ class TerraformBuilder:
             terraform_files = os.listdir(self.terraform_build_path)
             terraform_files_to_delete = [file for file in terraform_files if not file.startswith(".")]
             for file in terraform_files_to_delete:
-                if os.path.isfile(f"{self.terraform_build_path}/{file}"):
-                    os.remove(f"{self.terraform_build_path}/{file}")
+                if os.path.isfile(os.path.join(self.terraform_build_path, file)):
+                    os.remove(os.path.join(self.terraform_build_path, file))
                 else:
-                    shutil.rmtree(f"{self.terraform_build_path}/{file}")
+                    shutil.rmtree(os.path.join(self.terraform_build_path, file))
         else:
             os.makedirs(self.terraform_build_path)
 

--- a/observatory-platform/observatory/platform/terraform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform/terraform_builder.py
@@ -95,10 +95,17 @@ class TerraformBuilder:
                 destination_path = os.path.join(self.packages_build_path, package.name)
                 copy_dir(package.host_package, destination_path)
 
-        # Clear terraform/terraform path
+        # Clear terraform/terraform path, but keep the .terraform folder and other hidden files necessary for terraform.
         if os.path.exists(self.terraform_build_path):
-            shutil.rmtree(self.terraform_build_path)
-        os.makedirs(self.terraform_build_path)
+            terraform_files = os.listdir(self.terraform_build_path)
+            terraform_files_to_delete = [file for file in terraform_files if not file.startswith(".")]
+            for file in terraform_files_to_delete:
+                if os.path.isfile(f"{self.terraform_build_path}/{file}"):
+                    os.remove(f"{self.terraform_build_path}/{file}")
+                else:
+                    shutil.rmtree(f"{self.terraform_build_path}/{file}")
+        else:
+            os.makedirs(self.terraform_build_path)
 
         # Copy terraform files into build/terraform
         copy_dir(self.terraform_path, self.terraform_build_path)


### PR DESCRIPTION
@jdddog Requested this fix for the merged pull request INF-597: Terraform config files not updating and Flower docker container not building successfully. 

The .terraform folder in the /build/terraform/terraform directory is needed to be kept and not deleted each time the terraform part of the platform initialises. 

I have changed it so instead of deleting the path /build/terraform/terraform, it will now only delete all of the non hidden files in that directory, keeping the necessary .terraform folder and .terraform.lock.hcl file. 