### PR TITLE
Fix/Change apiserver container docker network

### DIFF
--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -245,7 +245,8 @@ services:
       - OBSERVATORY_API_PORT=5002
     volumes: *volumes
     restart: always
-    <<: *networks
+    networks:
+      - {{ config.observatory.docker_network_name }}
     {% if config.backend.type.value == 'local' %} 
     depends_on:
       postgres:


### PR DESCRIPTION
Connecting to the apiserver container by hostname was not working because the docker network details were incorrect when deployed to the cloud. This change is required so that container can report back as 'healthy' and so Airflow can use it for all of the workflows.