### PR TITLE
INF-609: Add limits to Bigquery for per user per day and project per day. 

### DIFF
--- a/observatory-platform/observatory/platform/terraform/versions.tf
+++ b/observatory-platform/observatory/platform/terraform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "~> 4.53.1"
+      version = "~> 4.58.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
Adding safety limits for Bigquery usage for per user per day and per day for the entire Google project that the observatory platform is deployed to. 

Current limits are set to 10 TiB ( 10,485,760 Megabytes ) for the per user per day and 15 Tib ( 15,728,640 Megabytes ) per day for the whole project. 

We can easily increase these limits if required. 