### PR TITLE
Fix api and workers network settings

### DIFF
--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -54,7 +54,6 @@ x-environment: &environment
 
   # Variables
   AIRFLOW_VAR_DATA_PATH: "/opt/observatory/data"
-  AIRFLOW_VAR_DAGS_MODULE_NAMES: {{ config.dags_module_names  }}
   {%- for var in config.make_airflow_variables() %}
   {%- if config.backend.type.value == 'local' %}
   {{ var.env_var_name }}: '{{ var.value }}'
@@ -211,6 +210,8 @@ services:
     environment: *environment
     volumes: *volumes
     restart: always
+    ports:
+      - 8793:8793
     <<: *networks
     depends_on:
       - scheduler
@@ -225,6 +226,8 @@ services:
     environment: *environment
     volumes: *volumes
     restart: always
+    ports:
+      - 8793:8793
     <<: *networks
     {% if (config.google_cloud is not none) and (config.google_cloud.credentials is not none) -%}
     secrets:
@@ -245,8 +248,9 @@ services:
       - OBSERVATORY_API_PORT=5002
     volumes: *volumes
     restart: always
-    networks:
-      - {{ config.observatory.docker_network_name }}
+    ports:
+      - ${HOST_API_SERVER_PORT}:5002
+    <<: *networks
     {% if config.backend.type.value == 'local' %} 
     depends_on:
       postgres:
@@ -257,8 +261,6 @@ services:
       interval: 30s
       retries: 20
     command: apiserver
-    ports:
-      - ${HOST_API_SERVER_PORT}:5002
     entrypoint: /entrypoint-api.sh
 
 {% if config.backend.type.value == 'local' %} 

--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -210,8 +210,6 @@ services:
     environment: *environment
     volumes: *volumes
     restart: always
-    ports:
-      - 8793:8793
     <<: *networks
     depends_on:
       - scheduler
@@ -226,8 +224,6 @@ services:
     environment: *environment
     volumes: *volumes
     restart: always
-    ports:
-      - 8793:8793
     <<: *networks
     {% if (config.google_cloud is not none) and (config.google_cloud.credentials is not none) -%}
     secrets:
@@ -250,7 +246,8 @@ services:
     restart: always
     ports:
       - ${HOST_API_SERVER_PORT}:5002
-    <<: *networks
+    networks:
+      - {{ config.observatory.docker_network_name }}
     {% if config.backend.type.value == 'local' %} 
     depends_on:
       postgres:

--- a/observatory-platform/observatory/platform/observatory_config.py
+++ b/observatory-platform/observatory/platform/observatory_config.py
@@ -712,7 +712,7 @@ class ObservatoryConfig:
             self.airflow_variables = []
 
         self.airflow_connections = airflow_connections
-        if airflow_variables is None:
+        if airflow_connections is None:
             self.airflow_connections = []
 
         self.workflows_projects = workflows_projects
@@ -816,6 +816,13 @@ class ObservatoryConfig:
         if self.terraform is not None:
             if self.terraform.organization is not None:
                 variables.append(AirflowVariable(AirflowVars.TERRAFORM_ORGANIZATION, self.terraform.organization))
+
+        # Add dags module names
+        variables.append(
+            AirflowVariable(
+                AirflowVars.DAGS_MODULE_NAMES, json.dumps([proj.dags_module for proj in self.workflows_projects])
+            )
+        )
 
         # Add user defined variables to list
         variables += self.airflow_variables

--- a/observatory-platform/observatory/platform/terraform/startup.tpl.jinja2
+++ b/observatory-platform/observatory/platform/terraform/startup.tpl.jinja2
@@ -37,7 +37,7 @@ export AIRFLOW_UI_USER_PASSWORD="sm://${project_id}/airflow_ui_user_password"
 export AIRFLOW_UI_USER_EMAIL="sm://${project_id}/airflow_ui_user_email"
 {% set docker_containers="redis flower webserver scheduler worker_local airflow_init apiserver"%}
 {%- else %}
-{% set docker_containers="worker_remote apiserver"%}
+{% set docker_containers="worker_remote"%}
 {%- endif %}
 
 # Export environment variables for all Airflow variables

--- a/observatory-platform/observatory/platform/terraform/vm/main.tf
+++ b/observatory-platform/observatory/platform/terraform/vm/main.tf
@@ -9,7 +9,7 @@ resource "google_compute_address" "vm_private_ip" {
 resource "google_compute_instance" "vm_instance" {
   name = var.name
   machine_type = var.machine_type
-  tags = ["allow-ssh"]
+  tags = ["allow-ssh", "allow-internal-airflow"]
   allow_stopping_for_update = true
 
   boot_disk {


### PR DESCRIPTION
Fixes the issues with Airflow webserver not being able to access logs and API server not being accessible.

Made following changes:
* Reverted workers and apiserver to use host mode. API and worker containers are now accessed using the host name of the VM.
* In Terraform:
  * Open ports 5002 (API) and 8793 (Airflow worker) within VPC network for both VMs. 
  * Only run apiserver on airflow-main-vm.
  * Use hostname of airflow-main-vm for redis_hostname instead of IP address.
* observatory_api connection should now be: http://:@airflow-main-vm:5002