### PR TITLE
Terraform deploy may 2023 fixes

### DIFF
--- a/observatory-platform/observatory/platform/bigquery.py
+++ b/observatory-platform/observatory/platform/bigquery.py
@@ -43,7 +43,7 @@ from observatory.platform.utils.jinja2_utils import (
 
 # BigQuery single query byte limit.
 # Daily limit is set in Terraform
-BIGQUERY_SINGLE_QUERY_BYTE_LIMIT = int(1.5 * 2**40)  # 1.5 TiB
+BIGQUERY_SINGLE_QUERY_BYTE_LIMIT = int(2 * 2**40)  # 2 TiB
 
 
 def assert_table_id(table_id: str):

--- a/observatory-platform/observatory/platform/bigquery.py
+++ b/observatory-platform/observatory/platform/bigquery.py
@@ -43,7 +43,7 @@ from observatory.platform.utils.jinja2_utils import (
 
 # BigQuery single query byte limit.
 # Daily limit is set in Terraform
-BIGQUERY_SINGLE_QUERY_BYTE_LIMIT = 1024 * 1024 * 1024 * 1024 * 1  # 1 TiB
+BIGQUERY_SINGLE_QUERY_BYTE_LIMIT = int(1.5 * 2**40)  # 1.5 TiB
 
 
 def assert_table_id(table_id: str):

--- a/observatory-platform/observatory/platform/bigquery.py
+++ b/observatory-platform/observatory/platform/bigquery.py
@@ -26,7 +26,6 @@ from typing import Dict, Tuple, Union, List, Optional
 
 import jsonlines
 import pendulum
-from deepdiff import DeepDiff
 from google.api_core.exceptions import BadRequest, Conflict
 from google.cloud import bigquery
 from google.cloud.bigquery import LoadJob, LoadJobConfig, QueryJob, SourceFormat, CopyJobConfig, CopyJob
@@ -56,50 +55,6 @@ def assert_table_id(table_id: str):
 
     n_parts = len(table_id.split("."))
     assert n_parts == 3, f"bq_table_id_parts: table_id={table_id} requires 3 parts but only has {n_parts}"
-
-
-def compare_lists_of_dicts(expected: List[Dict], actual: List[Dict], primary_key: str) -> bool:
-    """Compare two lists of dictionaries, using a primary_key as the basis for the top level comparisons.
-
-    :param expected: the expected data.
-    :param actual: the actual data.
-    :param primary_key: the primary key.
-    :return: whether the expected and actual match.
-    """
-
-    expected_dict = {item[primary_key]: item for item in expected}
-    actual_dict = {item[primary_key]: item for item in actual}
-
-    if set(expected_dict.keys()) != set(actual_dict.keys()):
-        logging.error("Primary keys don't match:")
-        logging.error(f"Only in expected: {set(expected_dict.keys()) - set(actual_dict.keys())}")
-        logging.error(f"Only in actual: {set(actual_dict.keys()) - set(expected_dict.keys())}")
-        return False
-
-    all_matched = True
-    for key in expected_dict:
-        diff = DeepDiff(expected_dict[key], actual_dict[key], ignore_order=True)
-        logging.info(f"primary_key: {key}")
-        for diff_type, changes in diff.items():
-            all_matched = False
-            if diff_type == "values_changed":
-                for key_path, change in changes.items():
-                    logging.error(
-                        f"(expected) != (actual) {key_path}: {change['old_value']} (expected) != (actual) {change['new_value']}"
-                    )
-            elif diff_type == "dictionary_item_added":
-                for change in changes:
-                    logging.error(f"dictionary_item_added: {change}")
-            elif diff_type == "dictionary_item_removed":
-                for change in changes:
-                    logging.error(f"dictionary_item_removed: {change}")
-            elif diff_type == "type_changes":
-                for key_path, change in changes.items():
-                    logging.error(
-                        f"(expected) != (actual) {key_path}: {change['old_type']} (expected) != (actual) {change['new_type']}"
-                    )
-
-    return all_matched
 
 
 def bq_table_id(project_id: str, dataset_id: str, table_id: str) -> str:
@@ -964,9 +919,11 @@ def bq_upsert_records(
     main_columns = bq_select_columns(table_id=main_table_id)
     upsert_columns = bq_select_columns(table_id=upsert_table_id)
 
-    # Assert that the column names and data types in main_table and upsert_table are the same
-    columns_match = compare_lists_of_dicts(main_columns, upsert_columns, "column_name")
-    assert columns_match, f"bq_upsert_records: columns in {main_table_id} do not match {upsert_table_id}"
+    # Assert that the column names and data types in main_table and upsert_table are the same and in the same order
+    # Must be in same order for upsert to work
+    assert (
+        main_columns == upsert_columns
+    ), f"bq_upsert_records: columns in {main_table_id} do not match {upsert_table_id} or are not in the same order"
 
     # Check that primary_key is in both tables
     # The data_type of primary_key must match because of the above assert

--- a/observatory-platform/observatory/platform/bigquery.py
+++ b/observatory-platform/observatory/platform/bigquery.py
@@ -36,6 +36,7 @@ from google.cloud.exceptions import Conflict, NotFound
 from natsort import natsorted
 
 from observatory.platform.config import sql_templates_path
+from observatory.platform.observatory_environment import compare_lists_of_dicts
 from observatory.platform.utils.jinja2_utils import (
     make_sql_jinja2_filename,
     render_template,
@@ -920,9 +921,8 @@ def bq_upsert_records(
     upsert_columns = bq_select_columns(table_id=upsert_table_id)
 
     # Assert that the column names and data types in main_table and upsert_table are the same
-    assert (
-        main_columns == upsert_columns
-    ), f"bq_upsert_records: columns in {main_table_id} do not match {upsert_table_id}"
+    columns_match = compare_lists_of_dicts(main_columns, upsert_columns, "column_name")
+    assert columns_match, f"bq_upsert_records: columns in {main_table_id} do not match {upsert_table_id}"
 
     # Check that primary_key is in both tables
     # The data_type of primary_key must match because of the above assert

--- a/observatory-platform/observatory/platform/observatory_environment.py
+++ b/observatory-platform/observatory/platform/observatory_environment.py
@@ -67,7 +67,6 @@ import shutil
 import socket
 import socketserver
 import threading
-import time
 import unittest
 import uuid
 from dataclasses import dataclass
@@ -83,6 +82,7 @@ import httpretty
 import paramiko
 import pendulum
 import requests
+import time
 from airflow import DAG, settings
 from airflow.exceptions import AirflowException
 from airflow.models import DagBag
@@ -99,6 +99,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from dateutil.relativedelta import relativedelta
+from deepdiff import DeepDiff
 from google.cloud import bigquery, storage
 from google.cloud.exceptions import NotFound
 from pendulum import DateTime
@@ -112,7 +113,6 @@ from observatory.platform.bigquery import (
     bq_table_id,
     SourceFormat,
     bq_delete_old_datasets_with_prefix,
-    compare_lists_of_dicts,
 )
 from observatory.platform.config import module_file_path, AirflowVars, AirflowConns
 from observatory.platform.elastic.elastic_environment import ElasticEnvironment
@@ -637,6 +637,50 @@ def load_and_parse_json(file_path: str, date_fields: Set[str] = None):
     with open(file_path, mode="r") as f:
         rows = json.load(f, object_hook=parse_datetime)
     return rows
+
+
+def compare_lists_of_dicts(expected: List[Dict], actual: List[Dict], primary_key: str) -> bool:
+    """Compare two lists of dictionaries, using a primary_key as the basis for the top level comparisons.
+
+    :param expected: the expected data.
+    :param actual: the actual data.
+    :param primary_key: the primary key.
+    :return: whether the expected and actual match.
+    """
+
+    expected_dict = {item[primary_key]: item for item in expected}
+    actual_dict = {item[primary_key]: item for item in actual}
+
+    if set(expected_dict.keys()) != set(actual_dict.keys()):
+        logging.error("Primary keys don't match:")
+        logging.error(f"Only in expected: {set(expected_dict.keys()) - set(actual_dict.keys())}")
+        logging.error(f"Only in actual: {set(actual_dict.keys()) - set(expected_dict.keys())}")
+        return False
+
+    all_matched = True
+    for key in expected_dict:
+        diff = DeepDiff(expected_dict[key], actual_dict[key], ignore_order=True)
+        logging.info(f"primary_key: {key}")
+        for diff_type, changes in diff.items():
+            all_matched = False
+            if diff_type == "values_changed":
+                for key_path, change in changes.items():
+                    logging.error(
+                        f"(expected) != (actual) {key_path}: {change['old_value']} (expected) != (actual) {change['new_value']}"
+                    )
+            elif diff_type == "dictionary_item_added":
+                for change in changes:
+                    logging.error(f"dictionary_item_added: {change}")
+            elif diff_type == "dictionary_item_removed":
+                for change in changes:
+                    logging.error(f"dictionary_item_removed: {change}")
+            elif diff_type == "type_changes":
+                for key_path, change in changes.items():
+                    logging.error(
+                        f"(expected) != (actual) {key_path}: {change['old_type']} (expected) != (actual) {change['new_type']}"
+                    )
+
+    return all_matched
 
 
 class ObservatoryTestCase(unittest.TestCase):

--- a/observatory-platform/observatory/platform/terraform/main.tf
+++ b/observatory-platform/observatory/platform/terraform/main.tf
@@ -321,7 +321,7 @@ resource "google_storage_bucket_iam_member" "observatory_airflow_bucket_observat
 
 # Necessary to define the network so that the VMs can talk to the Cloud SQL database.
 locals {
-  network_name       = "observatory-network"
+  network_name       = "ao-network"
 }
 
 resource "google_compute_network" "observatory_network" {
@@ -381,19 +381,6 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   depends_on              = [google_project_service.services]
 }
 
-resource "random_id" "database_protector" {
-  count       = var.environment == "production" ? 1 : 0
-  byte_length = 8
-  keepers     = {
-    observatory_db_instance = google_sql_database_instance.observatory_db_instance.id
-    airflow_db              = google_sql_database.airflow_db.id
-    users                   = google_sql_user.observatory_user.id
-  }
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "random_id" "airflow_db_name_suffix" {
   byte_length = 4
 }
@@ -417,6 +404,7 @@ resource "google_sql_database_instance" "observatory_db_instance" {
       location           = var.google_cloud.data_location
       start_time         = var.cloud_sql_database.backup_start_time
     }
+    deletion_protection_enabled = true # Stops the machine being deleted at the GCP platform level
   }
 }
 

--- a/observatory-platform/observatory/platform/terraform/outputs.tf
+++ b/observatory-platform/observatory/platform/terraform/outputs.tf
@@ -18,11 +18,13 @@ output "airflow_worker_vm_ip_address" {
 output "airflow_main_vm_external_ip" {
   value       = try(google_compute_address.airflow_main_vm_static_external_ip, null)
   description = "The external IP address of the Airflow Main VM."
+  sensitive = true
 }
 
 output "airflow_worker_vm_external_ip" {
   value       = try(google_compute_address.airflow_worker_vm_static_external_ip, null)
   description = "The external IP address of the Airflow Worker VM."
+  sensitive = true
 }
 
 output "airflow_main_vm_script" {

--- a/observatory-platform/observatory/platform/workflows/elastic_import_workflow.py
+++ b/observatory-platform/observatory/platform/workflows/elastic_import_workflow.py
@@ -314,6 +314,9 @@ class ElasticImportWorkflow(Workflow):
         :param tags: List of dag tags.
         """
 
+        if tags is None:
+            tags = []
+
         super().__init__(
             dag_id=dag_id,
             start_date=start_date,

--- a/tests/observatory/platform/cli/test_cli_functional.py
+++ b/tests/observatory/platform/cli/test_cli_functional.py
@@ -207,7 +207,7 @@ class TestCliFunctional(unittest.TestCase):
             test_fixtures_path("cli", self.workflows_package_name), os.path.join(temp_dir, self.workflows_package_name)
         )
 
-    def assert_dags_loaded(self, expected_dag_ids: Set, config: ObservatoryConfig, dag_check_timeout: int = 30):
+    def assert_dags_loaded(self, expected_dag_ids: Set, config: ObservatoryConfig, dag_check_timeout: int = 180):
         """Assert that DAGs loaded into Airflow.
 
         :param expected_dag_ids: the expected DAG ids.

--- a/tests/observatory/platform/workflows/test_elastic_import_workflow.py
+++ b/tests/observatory/platform/workflows/test_elastic_import_workflow.py
@@ -393,7 +393,7 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
 
             # Run Dummy Dags
             execution_date = pendulum.datetime(year=2021, month=5, day=16)
-            snapshot_date = pendulum.datetime(year=2021, month=5, day=22)
+            snapshot_date = pendulum.datetime(year=2021, month=5, day=23)
             expected_state = "success"
             doi_dag = make_dummy_dag(dag_id_sensor, execution_date)
             with env.create_dag_run(doi_dag, execution_date):

--- a/tests/observatory/platform/workflows/test_elastic_import_workflow.py
+++ b/tests/observatory/platform/workflows/test_elastic_import_workflow.py
@@ -475,15 +475,15 @@ class TestElasticImportWorkflow(ObservatoryTestCase):
 
                 # Test delete_stale_indices task
                 # Artificially load extra indices for ao-author
-                elastic.create_index("ao-author-20210523")
                 elastic.create_index("ao-author-20210524")
                 elastic.create_index("ao-author-20210525")
+                elastic.create_index("ao-author-20210526")
                 ti = env.run_task(workflow.delete_stale_indices.__name__)
                 self.assertEqual(expected_state, ti.state)
                 indices_after_cleanup = set(elastic.list_indices("ao-author-*"))
                 self.assertEqual(len(indices_after_cleanup), 2)
+                self.assertTrue("ao-author-20210526" in indices_after_cleanup)
                 self.assertTrue("ao-author-20210525" in indices_after_cleanup)
-                self.assertTrue("ao-author-20210524" in indices_after_cleanup)
 
                 # Test list create_kibana_index_patterns info task
                 expected_index_pattern_id = expected_alias_id


### PR DESCRIPTION
- Increase BigQuery single query limit
- Terraform: remove database protector, set deletion_protection_enabled = true to stops the database being deleted at the GCP platform level, and set external IPs as sensitive.
-  For ElasticImportWorkflow use data interval end for snapshot date.