### PR TITLE
Feature/Match on multiple keys for upserts and deletes in Bigquery. 

### DIFF
--- a/observatory-platform/observatory/platform/bigquery.py
+++ b/observatory-platform/observatory/platform/bigquery.py
@@ -938,6 +938,8 @@ def bq_upsert_records(
             key in main_column_names and key in upsert_column_names
         ), f"bq_upsert_records: key={key} not in {main_table_id} or {upsert_table_id}"
 
+    main_top_level_cols = [col for col in main_column_names if len(col.split(".")) == 1]
+
     # Run query to upsert records
     template_path = os.path.join(sql_templates_path(), "upsert_records.sql.jinja2")
     query = render_template(
@@ -945,7 +947,7 @@ def bq_upsert_records(
         upsert_table_id=upsert_table_id,
         main_table_id=main_table_id,
         keys=keys,
-        columns=main_column_names,
+        columns=main_top_level_cols,
     )
     bq_run_query(query, bytes_budget=bytes_budget)
 

--- a/observatory-platform/observatory/platform/bigquery.py
+++ b/observatory-platform/observatory/platform/bigquery.py
@@ -933,7 +933,6 @@ def bq_upsert_records(
 
     # If just a string, turn into a list for the jinja template render.
     keys = [primary_key] if isinstance(primary_key, str) else primary_key
-    logging.info(f"Keys to upsert on: {keys}")
     for key in keys:
         assert (
             key in main_column_names and key in upsert_column_names
@@ -965,8 +964,8 @@ def bq_delete_records(
 
     :param main_table_id: the fully qualified table identifier for the main BigQuery table where records will be deleted from.
     :param delete_table_id: the fully qualified table identifier for the BigQuery table containing the records to delete.
-    :param main_table_primary_key: the primary key to use in the main table.
-    :param delete_table_primary_key: the primary key to use in the delete table.
+    :param main_table_primary_key: A single key or a list of keys to use in the main table.
+    :param delete_table_primary_key: A single key or a list of keys to use in the delete table. Must match main_table_primary_key length.
     :param main_table_primary_key_prefix: an optional prefix to add to the primary key main table cells.
     :param delete_table_primary_key_prefix: an optional prefix to add to the primary key delete table cells.
     :param bytes_budget: the bytes budget.
@@ -1017,5 +1016,4 @@ def bq_delete_records(
         delete_table_primary_key_prefix=delete_table_primary_key_prefix,
         zip=zip,
     )
-    print(query)
     bq_run_query(query, bytes_budget=bytes_budget)

--- a/observatory-platform/observatory/platform/sql/delete_records.sql.jinja2
+++ b/observatory-platform/observatory/platform/sql/delete_records.sql.jinja2
@@ -17,13 +17,9 @@
 
 MERGE `{{ main_table_id }}` main_table
 USING `{{ delete_table_id }}` delete_table
-{% if main_table_keys|length == 1 %}
-ON CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[0] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[0] }})
-{% else %}
-ON ( CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[0] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[0] }}) AND
-{% for (main_table_key, delete_table_key) in zip(main_table_keys[1:-1], delete_table_keys[1:-1]) %}
-   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_key }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_key }}) AND
-{% endfor %}
-   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[-1] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[-1] }}) )
-{% endif %}
+ON (
+{%- for (main_table_key, delete_table_key) in zip(main_table_keys, delete_table_keys) %}
+   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_key }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_key }}){% if not loop.last %} AND{% endif %}
+{%- endfor %}
+)
 WHEN MATCHED THEN DELETE;

--- a/observatory-platform/observatory/platform/sql/delete_records.sql.jinja2
+++ b/observatory-platform/observatory/platform/sql/delete_records.sql.jinja2
@@ -22,7 +22,7 @@ ON CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[0
 {% else %}
 ON ( CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[0] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[0] }}) AND
 {% for (main_table_key, delete_table_key) in zip(main_table_keys[1:-1], delete_table_keys[1:-1]) %}
-   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_key }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys }})
+   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_key }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys }}) AND
 {% endfor %}
    CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[-1] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[-1] }}) )
 {% endif %}

--- a/observatory-platform/observatory/platform/sql/delete_records.sql.jinja2
+++ b/observatory-platform/observatory/platform/sql/delete_records.sql.jinja2
@@ -17,5 +17,13 @@
 
 MERGE `{{ main_table_id }}` main_table
 USING `{{ delete_table_id }}` delete_table
-ON CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_primary_key }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_primary_key }})
+{% if main_table_keys|length == 1 %}
+ON CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[0] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[0] }})
+{% else %}
+ON ( CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[0] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[0] }}) AND
+{% for (main_table_key, delete_table_key) in zip(main_table_keys[1:-1], delete_table_keys[1:-1]) %}
+   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_key }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys }})
+{% endfor %}
+   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[-1] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[-1] }}) )
+{% endif %}
 WHEN MATCHED THEN DELETE;

--- a/observatory-platform/observatory/platform/sql/delete_records.sql.jinja2
+++ b/observatory-platform/observatory/platform/sql/delete_records.sql.jinja2
@@ -22,7 +22,7 @@ ON CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[0
 {% else %}
 ON ( CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[0] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[0] }}) AND
 {% for (main_table_key, delete_table_key) in zip(main_table_keys[1:-1], delete_table_keys[1:-1]) %}
-   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_key }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys }}) AND
+   CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_key }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_key }}) AND
 {% endfor %}
    CONCAT('{{ main_table_primary_key_prefix }}', main_table.{{ main_table_keys[-1] }}) = CONCAT('{{ delete_table_primary_key_prefix }}', delete_table.{{ delete_table_keys[-1] }}) )
 {% endif %}

--- a/observatory-platform/observatory/platform/sql/select_columns.sql.jinja2
+++ b/observatory-platform/observatory/platform/sql/select_columns.sql.jinja2
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.#}
 
-SELECT column_name, data_type
-FROM {{ project_id }}.{{ dataset_id }}.INFORMATION_SCHEMA.COLUMNS
+SELECT field_path as column_name, data_type
+FROM {{ project_id }}.{{ dataset_id }}.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS
 WHERE table_name = '{{ table_id }}'

--- a/observatory-platform/observatory/platform/sql/upsert_records.sql.jinja2
+++ b/observatory-platform/observatory/platform/sql/upsert_records.sql.jinja2
@@ -14,19 +14,15 @@
 
 MERGE `{{ main_table_id }}` main_table
 USING `{{ upsert_table_id }}` upsert_table
-{% if keys|length == 1 %}
-ON main_table.{{ keys[0] }} = upsert_table.{{ keys[0] }} 
-{% else %}
-ON ( main_table.{{ keys[0] }} = upsert_table.{{ keys[0] }} AND
-{% for key in keys[1:-1] %}
-   main_table.{{ key }} = upsert_table.{{ key }} AND
-{% endfor %}
-   main_table.{{ keys[-1] }} = upsert_table.{{ keys[-1] }} )
-{% endif %}
+ON (
+  {%- for key in keys %}
+  main_table.{{ key }}=upsert_table.{{ key }}{% if not loop.last %} AND{% endif %}
+  {%- endfor %}
+)
 WHEN MATCHED THEN
   UPDATE SET
-    {% for col in columns %}
+    {%- for col in columns %}
     main_table.{{ col }}=upsert_table.{{ col }}{% if not loop.last %},{% endif %}
-    {% endfor %}
+    {%- endfor %}
 WHEN NOT MATCHED THEN
   INSERT ROW

--- a/observatory-platform/observatory/platform/sql/upsert_records.sql.jinja2
+++ b/observatory-platform/observatory/platform/sql/upsert_records.sql.jinja2
@@ -19,7 +19,7 @@ ON main_table.{{ keys[0] }} = upsert_table.{{ keys[0] }}
 {% else %}
 ON ( main_table.{{ keys[0] }} = upsert_table.{{ keys[0] }} AND
 {% for key in keys[1:-1] %}
-   main_table.{{ key }} = upsert_table.{{ key }},
+   main_table.{{ key }} = upsert_table.{{ key }} AND
 {% endfor %}
    main_table.{{ keys[-1] }} = upsert_table.{{ keys[-1] }} )
 {% endif %}

--- a/observatory-platform/observatory/platform/sql/upsert_records.sql.jinja2
+++ b/observatory-platform/observatory/platform/sql/upsert_records.sql.jinja2
@@ -14,7 +14,15 @@
 
 MERGE `{{ main_table_id }}` main_table
 USING `{{ upsert_table_id }}` upsert_table
-ON main_table.{{ primary_key }} = upsert_table.{{ primary_key }}
+{% if keys|length == 1 %}
+ON main_table.{{ keys[0] }} = upsert_table.{{ keys[0] }} 
+{% else %}
+ON ( main_table.{{ keys[0] }} = upsert_table.{{ keys[0] }} AND
+{% for key in keys[1:-1] %}
+   main_table.{{ key }} = upsert_table.{{ key }},
+{% endfor %}
+   main_table.{{ keys[-1] }} = upsert_table.{{ keys[-1] }} )
+{% endif %}
 WHEN MATCHED THEN
   UPDATE SET
     {% for col in columns %}


### PR DESCRIPTION
Add functionality to use either a singular key or a list of keys to match on for upserts and deletes in Biguqery. I have added this as a union of a string and list so we do not have to modify every workflow that uses these two functions. 

There's probably a much cleaner way of changing the jinja sql scripts for this. 
Please review and suggest other ways if possible.