### PR TITLE
Added multi-uri table load

### DIFF
--- a/tests/fixtures/utils/people_extra.jsonl
+++ b/tests/fixtures/utils/people_extra.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8444a1ee06e774757e94bb78ad8e8e027a4ba57c3adbe14122340e2a31e82c6c
+size 59

--- a/tests/fixtures/utils/people_new.jsonl
+++ b/tests/fixtures/utils/people_new.jsonl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be66e671c2103d67b4b8a82dbcc509a5e35c5345ab0e1712d319415e0239b522
-size 332


### PR DESCRIPTION
I noticed that the table load functionality (on google's end) allows for glob pattern matched URIs. However the list_blobs() functionality (again on google's end) does not! This poses an issue when you want to check that the table load URIs match what you expect when you use list_blobs(). So to get around this, we can just manually supply a list of URIs so that we're certain of the blobs being loaded.