### PR TITLE
Fix/Logs disappear when tasks are in "up for retry" state

### DIFF
--- a/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
+++ b/observatory-platform/observatory/platform/docker/docker-compose.observatory.yml.jinja2
@@ -109,6 +109,8 @@ x-build: &build
 
 services:
   redis:
+    container_name: redis
+    hostname: redis
     image: redis:latest
     restart: always
     ports:
@@ -122,6 +124,8 @@ services:
       retries: 50
 
   flower:
+    container_name: flower
+    hostname: flower
     image: apache/airflow:{{ airflow_version }}-python{{ python_version }}
     environment: *environment
     restart: always
@@ -145,7 +149,10 @@ services:
         condition: service_completed_successfully
 
   webserver:
+    container_name: webserver
+    hostname: webserver 
     image: apache/airflow:{{ airflow_version }}-python{{ python_version }}
+    volumes: *volumes
     environment: *environment
     restart: always
     networks:
@@ -168,6 +175,8 @@ services:
         condition: service_completed_successfully
 
   airflow_init:
+    container_name: airflow_init
+    hostname: airflow_init
     image: apache/airflow:{{ airflow_version }}-python{{ python_version }}
     environment:
       <<: *environment
@@ -180,7 +189,9 @@ services:
     command: version
     depends_on: *depends-on
 
-  scheduler:
+  scheduler:  
+    container_name: scheduler
+    hostname: scheduler
     build: *build
     environment: *environment
     volumes: *volumes
@@ -198,6 +209,8 @@ services:
         condition: service_completed_successfully
 
   worker_local:
+    container_name: worker_local
+    hostname: worker_local
     build: *build
     environment: *environment
     volumes: *volumes
@@ -214,6 +227,8 @@ services:
         condition: service_completed_successfully
 
   worker_remote:
+    container_name: worker_remote
+    hostname: worker_remote
     build: *build
     environment: *environment
     volumes: *volumes
@@ -232,6 +247,8 @@ services:
     {% endif %}
 
   apiserver:
+    container_name: apiserver
+    hostname: apiserver
     build:
       context: .
       dockerfile: Dockerfile.apiserver
@@ -262,6 +279,8 @@ services:
 
 {% if config.backend.type.value == 'local' %}
   postgres:
+    container_name: postgres
+    hostname: postgres
     image: postgres:12.2
     environment:
       - POSTGRES_DB=airflow

--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -46,7 +46,7 @@ pyftpdlib>=1.5.7,<2
 natsort>=7.1.1,<8
 backoff>=2,<3
 timeout-decorator
-validators
+validators<=0.20.0
 xmltodict
 pandas
 tenacity


### PR DESCRIPTION
With the upgrade to Airflow 2.6, logs will disappear in the web UI when a task's status is in the "up for retry" stat,e however when they are in the "failed" or "success" state the logs are available. This is due to the Airflow web UI only finding the logs on the local and remote celery workers through the docker network and there is no open connection for the webserver container to find the logs when in the "up for retry" state. 

This PR forces the common data and logs volumes to be mapped to the webserver container. This allows the web UI to find the logs locally instead of sourcing them from the worker containers in the docker network.

I have also added user-friendly container and host names to the containers for easy debugging down track. 