### PR TITLE
Make dag_run_id nullable in openapi.yaml

### DIFF
--- a/docs/api/DatasetRelease.md
+++ b/docs/api/DatasetRelease.md
@@ -37,7 +37,7 @@
 </tr>
 <tr>
     <td><strong>dag_run_id</strong></td>
-    <td><strong>str</strong></td>
+    <td><strong>str, none_type</strong></td>
     <td></td>
     <td>[optional] </td>
 </tr>

--- a/docs/api/ObservatoryApi.md
+++ b/docs/api/ObservatoryApi.md
@@ -154,11 +154,6 @@ void (empty response body)
     <td>DatasetRelease deleted</td>
     <td> - </td>
 </tr>
-<tr>
-    <td><strong>401</strong></td>
-    <td>API key is missing or invalid</td>
-    <td> * WWW_Authenticate -  <br> </td>
-</tr>
 
 </tbody>
 </table></div>
@@ -276,11 +271,6 @@ with observatory.api.client.ApiClient(configuration) as api_client:
     <td><strong>400</strong></td>
     <td>bad input parameter</td>
     <td> - </td>
-</tr>
-<tr>
-    <td><strong>401</strong></td>
-    <td>API key is missing or invalid</td>
-    <td> * WWW_Authenticate -  <br> </td>
 </tr>
 
 </tbody>
@@ -405,11 +395,6 @@ with observatory.api.client.ApiClient(configuration) as api_client:
     <td><strong>400</strong></td>
     <td>bad input parameter</td>
     <td> - </td>
-</tr>
-<tr>
-    <td><strong>401</strong></td>
-    <td>API key is missing or invalid</td>
-    <td> * WWW_Authenticate -  <br> </td>
 </tr>
 
 </tbody>
@@ -537,11 +522,6 @@ with observatory.api.client.ApiClient(configuration) as api_client:
     <td><strong>201</strong></td>
     <td>DatasetRelease created, returning the created object with an id</td>
     <td> - </td>
-</tr>
-<tr>
-    <td><strong>401</strong></td>
-    <td>API key is missing or invalid</td>
-    <td> * WWW_Authenticate -  <br> </td>
 </tr>
 
 </tbody>
@@ -674,11 +654,6 @@ with observatory.api.client.ApiClient(configuration) as api_client:
     <td><strong>201</strong></td>
     <td>DatasetRelease created, returning the created object with an id</td>
     <td> - </td>
-</tr>
-<tr>
-    <td><strong>401</strong></td>
-    <td>API key is missing or invalid</td>
-    <td> * WWW_Authenticate -  <br> </td>
 </tr>
 
 </tbody>

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -56,9 +56,6 @@ paths:
             $ref: '#/definitions/DatasetRelease'
         400:
           description: bad input parameter
-        401:
-          description: API key is missing or invalid
-          $ref: '#/responses/UnauthorizedError'
     post:
       tags:
       - Observatory
@@ -82,9 +79,6 @@ paths:
           description: DatasetRelease created, returning the created object with an id
           schema:
             $ref: '#/definitions/DatasetRelease'
-        401:
-          description: API key is missing or invalid
-          $ref: '#/responses/UnauthorizedError'
     put:
       tags:
       - Observatory
@@ -113,9 +107,6 @@ paths:
           description: DatasetRelease created, returning the created object with an id
           schema:
             $ref: '#/definitions/DatasetRelease'
-        401:
-          description: API key is missing or invalid
-          $ref: '#/responses/UnauthorizedError'
     delete:
       tags:
       - Observatory
@@ -136,9 +127,6 @@ paths:
       responses:
         200:
           description: DatasetRelease deleted
-        401:
-          description: API key is missing or invalid
-          $ref: '#/responses/UnauthorizedError'
 
   /v1/dataset_releases:
     get:
@@ -170,9 +158,6 @@ paths:
               $ref: '#/definitions/DatasetRelease'
         400:
           description: bad input parameter
-        401:
-          description: API key is missing or invalid
-          $ref: '#/responses/UnauthorizedError'
 
 definitions:
   DatasetRelease:
@@ -189,6 +174,7 @@ definitions:
       dag_run_id:
         type: string
         example: "YYYY-MM-DDTHH:mm:ss.ssssss"
+        x-nullable: true
       data_interval_start:
         type: string
         format: date-time
@@ -241,10 +227,3 @@ definitions:
         minLength: 1
         maxLength: 512
         x-nullable: true
-
-responses:
-  UnauthorizedError:
-    description: API key is missing or invalid
-    headers:
-      WWW_Authenticate:
-        type: string

--- a/observatory-api/observatory/api/client/model/dataset_release.py
+++ b/observatory-api/observatory/api/client/model/dataset_release.py
@@ -79,7 +79,7 @@ class DatasetRelease(ModelNormal):
             'id': (int,),  # noqa: E501, F821
             'dag_id': (str,),  # noqa: E501, F821
             'dataset_id': (str,),  # noqa: E501, F821
-            'dag_run_id': (str,),  # noqa: E501, F821
+            'dag_run_id': (str, none_type,),  # noqa: E501, F821
             'data_interval_start': (datetime, none_type,),  # noqa: E501, F821
             'data_interval_end': (datetime, none_type,),  # noqa: E501, F821
             'snapshot_date': (datetime, none_type,),  # noqa: E501, F821
@@ -162,7 +162,7 @@ class DatasetRelease(ModelNormal):
             id (int): [optional]  # noqa: E501
             dag_id (str): [optional]  # noqa: E501
             dataset_id (str): [optional]  # noqa: E501
-            dag_run_id (str): [optional]  # noqa: E501
+            dag_run_id (str, none_type): [optional]  # noqa: E501
             data_interval_start (datetime, none_type): [optional]  # noqa: E501
             data_interval_end (datetime, none_type): [optional]  # noqa: E501
             snapshot_date (datetime, none_type): [optional]  # noqa: E501
@@ -262,7 +262,7 @@ class DatasetRelease(ModelNormal):
             id (int): [optional]  # noqa: E501
             dag_id (str): [optional]  # noqa: E501
             dataset_id (str): [optional]  # noqa: E501
-            dag_run_id (str): [optional]  # noqa: E501
+            dag_run_id (str, none_type): [optional]  # noqa: E501
             data_interval_start (datetime, none_type): [optional]  # noqa: E501
             data_interval_end (datetime, none_type): [optional]  # noqa: E501
             snapshot_date (datetime, none_type): [optional]  # noqa: E501

--- a/observatory-api/observatory/api/server/openapi.yaml.jinja2
+++ b/observatory-api/observatory/api/server/openapi.yaml.jinja2
@@ -189,6 +189,7 @@ definitions:
       dag_run_id:
         type: string
         example: "YYYY-MM-DDTHH:mm:ss.ssssss"
+        x-nullable: true
       data_interval_start:
         type: string
         format: date-time


### PR DESCRIPTION
A fix for the error:

```python
observatory.api.client.exceptions.ApiTypeError: Invalid type for variable 'dag_run_id'. Required value type is str and passed type was NoneType at ['received_data'][0]['dag_run_id']
```