### PR TITLE
Upgrade Terraform and Packer

### DIFF
--- a/docs/tutorials/deploy_terraform.md
+++ b/docs/tutorials/deploy_terraform.md
@@ -17,7 +17,7 @@ If you wish to manually install the dependencies yourself, see the details below
 ### Linux
 Install Packer:
 ```bash
-sudo curl -L "https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_linux_amd64.zip" -o /usr/local/bin/packer
+sudo curl -L "https://releases.hashicorp.com/packer/1.9.2/packer_1.9.2_linux_amd64.zip" -o /usr/local/bin/packer
 # When asked to replace, answer 'y'
 unzip /usr/local/bin/packer -d /usr/local/bin/
 sudo chmod +x /usr/local/bin/packer
@@ -34,7 +34,7 @@ sudo chmod +x /usr/local/bin/google-cloud-sdk
 
 Install Terraform:
 ```bash
-sudo curl -L "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_linux_amd64.zip" -o /usr/local/bin/terraform
+sudo curl -L "https://releases.hashicorp.com/terraform/1.5.5/terraform_1.5.5_linux_amd64.zip" -o /usr/local/bin/terraform
 # When asked to replace, answer 'y'
 sudo unzip /usr/local/bin/terraform -d /usr/local/bin/
 sudo chmod +x /usr/local/bin/terraform
@@ -43,7 +43,7 @@ sudo chmod +x /usr/local/bin/terraform
 ### Mac
 Install Packer:
 ```bash
-sudo curl -L "https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_darwin_amd64.zip" -o /usr/local/bin/packer
+sudo curl -L "https://releases.hashicorp.com/packer/1.9.2/packer_1.9.2_darwin_amd64.zip" -o /usr/local/bin/packer
 # When asked to replace, answer 'y'
 unzip /usr/local/bin/packer -d /usr/local/bin/
 sudo chmod +x /usr/local/bin/packer
@@ -61,7 +61,7 @@ sudo chmod +x /usr/local/bin/google-cloud-sdk
 
 Install Terraform:
 ```bash
-sudo curl -L "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_darwin_amd64.zip" -o /usr/local/bin/terraform
+sudo curl -L "https://releases.hashicorp.com/terraform/1.5.5/terraform_1.5.5_darwin_amd64.zip" -o /usr/local/bin/terraform
 # When asked to replace, answer 'y'
 unzip /usr/local/bin/terraform -d /usr/local/bin/
 sudo chmod +x /usr/local/bin/terraform

--- a/install.sh
+++ b/install.sh
@@ -207,8 +207,8 @@ function install_google_cloud_sdk() {
 function install_terraform_deps() {
     ## Package versions to install
 
-    terraform_version="1.0.5"
-    packer_version="1.6.0"
+    terraform_version="1.5.5"
+    packer_version="1.9.2"
     google_cloud_sdk_version="330.0.0"
 
     terraform_arch=$arch

--- a/observatory-platform/observatory/platform/terraform/versions.tf
+++ b/observatory-platform/observatory/platform/terraform/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 2.2.0"
     }
   }
-  required_version = "~> 1.0.5"
+  required_version = "~> 1.5.5"
 }


### PR DESCRIPTION
PR to upgrade to Terraform v1.5.5 and Packer v1.9.2.

I have done a test deployment to my project and the platform deploys successfully. 
Thankfully all of the terraform scripts work without needing to be changed. I have also updated the documentation to suit the updated package versions. We will need to go onto Terraform Cloud and update the remote version of Terraform to match.