### PR TITLE
Feature/Add functionality to bq_load_from_memory function

### DIFF
--- a/observatory-platform/observatory/platform/bigquery.py
+++ b/observatory-platform/observatory/platform/bigquery.py
@@ -424,7 +424,7 @@ def bq_load_from_memory(
     partition_field: Union[None, str] = None,
     partition_type: bigquery.TimePartitioningType = bigquery.TimePartitioningType.DAY,
     require_partition_filter=False,
-    write_disposition: str = bigquery.WriteDisposition.WRITE_EMPTY,
+    write_disposition: str = bigquery.WriteDisposition.WRITE_TRUNCATE,
     table_description: str = "",
     cluster: bool = False,
     clustering_fields=None,

--- a/tests/observatory/platform/test_bigquery.py
+++ b/tests/observatory/platform/test_bigquery.py
@@ -604,7 +604,17 @@ class TestBigQuery(unittest.TestCase):
         with bq_dataset_test_env(
             project_id=self.gc_project_id, location=self.gc_location, prefix=self.prefix
         ) as dataset_id:
-            # Test loading from memory
+            # Test loading from memory - without a schema
+            table_id = bq_table_id(self.gc_project_id, dataset_id, random_id())
+            result = bq_load_from_memory(
+                records=test_data,
+                table_id=table_id,
+                schema_file_path=None,
+            )
+            self.assertTrue(result)
+            self.assertTrue(bq_table_exists(table_id=table_id))
+
+            # Test loading from memory - with a schema
             table_id = bq_table_id(self.gc_project_id, dataset_id, random_id())
             result = bq_load_from_memory(
                 records=test_data,


### PR DESCRIPTION
This PR is to add more input options to this function similar to `bq_load_table`. This will be used in future workflows and they need to be able to select the different types of write dispositions. 
The only workflow that uses this function is the doi workflow. I have made it so the default values for the new inputs won't change anything and should run the same as before.

It was also missing a unit test so I have added one based off of `test_bq_load_table`. 

