### PR TITLE
Feature/Create buckets with roles for unit tests

### DIFF
--- a/observatory-platform/observatory/platform/observatory_environment.py
+++ b/observatory-platform/observatory/platform/observatory_environment.py
@@ -232,6 +232,7 @@ class ObservatoryEnvironment:
         prefix: Optional[str] = "obsenv_tests",
         age_to_delete: int = 12,
         workflows: List[Workflow] = None,
+        gcs_bucket_roles: Union[Set[str], str] = None,
     ):
         """Constructor for an Observatory environment.
 
@@ -267,8 +268,8 @@ class ObservatoryEnvironment:
         self.workflows = workflows
 
         if self.create_gcp_env:
-            self.download_bucket = self.add_bucket()
-            self.transform_bucket = self.add_bucket()
+            self.download_bucket = self.add_bucket(roles=gcs_bucket_roles)
+            self.transform_bucket = self.add_bucket(roles=gcs_bucket_roles)
             self.storage_client = storage.Client()
             self.bigquery_client = bigquery.Client()
         else:

--- a/tests/observatory/platform/test_observatory_environment.py
+++ b/tests/observatory/platform/test_observatory_environment.py
@@ -119,13 +119,15 @@ class TestObservatoryEnvironment(unittest.TestCase):
         env = ObservatoryEnvironment(self.project_id, self.data_location)
 
         # The download and transform buckets are added in the constructor
-        self.assertEqual(2, len(env.buckets))
-        self.assertEqual(env.download_bucket, env.buckets[0])
-        self.assertEqual(env.transform_bucket, env.buckets[1])
+        buckets = list(env.buckets.keys())
+        self.assertEqual(2, len(buckets))
+        self.assertEqual(env.download_bucket, buckets[0])
+        self.assertEqual(env.transform_bucket, buckets[1])
 
         # Test that calling add bucket adds a new bucket to the buckets list
         name = env.add_bucket()
-        self.assertEqual(name, env.buckets[-1])
+        buckets = list(env.buckets.keys())
+        self.assertEqual(name, buckets[-1])
 
         # No Google Cloud variables raises error
         with self.assertRaises(AssertionError):
@@ -149,6 +151,14 @@ class TestObservatoryEnvironment(unittest.TestCase):
 
         # Test double delete is handled gracefully
         env._delete_bucket(bucket_id)
+
+        # Test create a bucket with a set of roles
+        roles = {"roles/storage.objectViewer", "roles/storage.legacyBucketWriter"}
+        env._create_bucket(bucket_id, roles=roles)
+        bucket = env.storage_client.bucket(bucket_id)
+        bucket_policy = bucket.get_iam_policy()
+        for role in roles:
+            self.assertTrue({"role": role, "members": {"allUsers"}} in bucket_policy)
 
         # No Google Cloud variables raises error
         bucket_id = "obsenv_tests_" + random_id()


### PR DESCRIPTION
For some workflows, usage of Google storage buckets require explicit roles and permissions. For example, OpenAlex requires the following permissions for transferring data between AWS and GCS:
- roles/storage.objectViewer
- roles/storage.legacyBucketWriter

These roles are now needed to be explicitly added to buckets, otherwise unit tests will fail due to permission issues. This PR adds the ability to create Google storage buckets with specific roles for usage in unit tests. 

Buckets are now added to the ObservatoryEnvironment class as a data dictionary where the keys are the bucket_ids and the values are a set of roles required. I have added the roles in such a way that it should not interfere with existing unit tests for the academic observatory workflows.