### PR TITLE
Fix/Install Packer plugins when building the observatory image

### DIFF
--- a/observatory-platform/observatory/platform/terraform/terraform_builder.py
+++ b/observatory-platform/observatory/platform/terraform/terraform_builder.py
@@ -175,7 +175,7 @@ class TerraformBuilder:
     def install_packer_plugins(self) -> Tuple[str, str, int]:
         """Install the necessary plugins for packer."""
 
-        # Install the Packer plugins by doing an init on the observatory image config
+        # Install the Packer plugins by doing an init on the observatory image config file
         args = ["packer", "init", "observatory-image.json.pkr.hcl"]
 
         if self.debug:

--- a/tests/observatory/platform/terraform/test_terraform_builder.py
+++ b/tests/observatory/platform/terraform/test_terraform_builder.py
@@ -167,12 +167,12 @@ class TestTerraformBuilder(unittest.TestCase):
             cfg = self.get_terraform_config(t)
             cmd = TerraformBuilder(config=cfg)
 
-            # Build the image
+            # Install the packer plugins
             output, error, return_code = cmd.install_packer_plugins()
 
             print(output, error, return_code)
 
-            # Assert that the image built
+            # Assert the install was successful
             expected_return_code = 0
             self.assertEqual(expected_return_code, return_code)
 

--- a/tests/observatory/platform/terraform/test_terraform_builder.py
+++ b/tests/observatory/platform/terraform/test_terraform_builder.py
@@ -155,6 +155,29 @@ class TestTerraformBuilder(unittest.TestCase):
 
     @patch("subprocess.Popen")
     @patch("observatory.platform.terraform.terraform_builder.stream_process")
+    def install_packer_plugins(self, mock_stream_process, mock_subprocess):
+        """Test installing the necessary plugins for Packer."""
+
+        # Check that the environment variables are set properly for the default config
+        with CliRunner().isolated_filesystem() as t:
+            mock_subprocess.return_value = Popen()
+            mock_stream_process.return_value = ("", "")
+
+            # Save default config file
+            cfg = self.get_terraform_config(t)
+            cmd = TerraformBuilder(config=cfg)
+
+            # Build the image
+            output, error, return_code = cmd.install_packer_plugins()
+
+            print(output, error, return_code)
+
+            # Assert that the image built
+            expected_return_code = 0
+            self.assertEqual(expected_return_code, return_code)
+
+    @patch("subprocess.Popen")
+    @patch("observatory.platform.terraform.terraform_builder.stream_process")
     def test_build_image(self, mock_stream_process, mock_subprocess):
         """Test building of the observatory platform"""
 


### PR DESCRIPTION
Forgot to add this with the recent Packer upgrade. The new observatory-image.json.pkr.hcl file relies on external plugins to be installed first before the observatory-image can be built. I did this manually before when I upgraded so I missed it adding it to the platform. 

I've tested it with a fresh Packer installation and I've added a unit test to suit.

Please review and edit as needed. 