### PR TITLE
Fix SlackWebhookHook missing 1 required keyword-only argument: 'slack_webhook_conn_id'

### DIFF
--- a/observatory-platform/observatory/platform/airflow.py
+++ b/observatory-platform/observatory/platform/airflow.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import textwrap
 import traceback
 from datetime import timedelta
 from pydoc import locate
@@ -105,14 +106,16 @@ def send_slack_msg(
     :param slack_conn_id: the Airflow connection id for the Slack connection.
     """
 
-    message = """
-    :red_circle: Task Alert.
-    *Task*: {task}
-    *Dag*: {dag}
-    *Execution Time*: {exec_date}
-    *Log Url*: {log_url}
-    *Comments*: {comments}
-    """.format(
+    message = textwrap.dedent(
+        """
+        :red_circle: Task Alert.
+        *Task*: {task}
+        *Dag*: {dag}
+        *Execution Time*: {exec_date}
+        *Log Url*: {log_url}
+        *Comments*: {comments}
+        """
+    ).format(
         task=ti.task_id,
         dag=ti.dag_id,
         exec_date=execution_date,

--- a/observatory-platform/observatory/platform/airflow.py
+++ b/observatory-platform/observatory/platform/airflow.py
@@ -30,7 +30,7 @@ import validators
 from airflow import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import TaskInstance, DagBag, Variable, XCom, DagRun
-from airflow.providers.slack.operators.slack_webhook import SlackWebhookHook
+from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.db import provide_session
 from airflow.utils.state import State
@@ -119,12 +119,11 @@ def send_slack_msg(
         log_url=ti.log_url,
         comments=comments,
     )
-    slack_conn = BaseHook.get_connection(slack_conn_id)
-    slack_hook = SlackWebhookHook(http_conn_id=slack_conn.conn_id, webhook_token=slack_conn.password, message=message)
+    hook = SlackWebhookHook(slack_webhook_conn_id=slack_conn_id)
 
     # http_hook outputs the secret token, suppressing logging 'info' by setting level to 'warning'
     old_levels = change_task_log_level(logging.WARNING)
-    slack_hook.execute()
+    hook.send_text(message)
     # change back to previous levels
     change_task_log_level(old_levels)
 

--- a/tests/observatory/platform/test_airflow.py
+++ b/tests/observatory/platform/test_airflow.py
@@ -17,6 +17,7 @@
 import datetime
 import os
 import shutil
+import textwrap
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -131,7 +132,10 @@ class TestAirflow(unittest.TestCase):
     @patch("observatory.platform.airflow.SlackWebhookHook")
     @patch("airflow.hooks.base.BaseHook.get_connection")
     def test_send_slack_msg(self, mock_get_connection, m_slack):
-        mock_get_connection.return_value = Connection(uri=f"https://:key@https%3A%2F%2Fhooks.slack.com%2Fservices")
+        slack_webhook_conn_id = "slack_conn"
+        mock_get_connection.return_value = Connection(
+            conn_id=slack_webhook_conn_id, uri=f"https://:key@https%3A%2F%2Fhooks.slack.com%2Fservices"
+        )
 
         class MockTI:
             def __init__(self):
@@ -146,25 +150,25 @@ class TestAirflow(unittest.TestCase):
             ti=ti,
             execution_date=execution_date,
             comments="comment",
+            slack_conn_id=slack_webhook_conn_id,
         )
 
-        expected_message = """
-    :red_circle: Task Alert.
-    *Task*: {task}
-    *Dag*: {dag}
-    *Execution Time*: {exec_date}
-    *Log Url*: {log_url}
-    *Comments*: {comments}
-    """.format(
-            task="task_id",
-            dag="dag_id",
-            exec_date=execution_date.isoformat(),
-            log_url="log_url",
-            comments="comment",
-            project_id="project-id",
-        )
+        message = textwrap.dedent(
+            """
+            :red_circle: Task Alert.
+            *Task*: task_id
+            *Dag*: dag_id
+            *Execution Time*: {exec_date}
+            *Log Url*: log_url
+            *Comments*: comment
+            """
+        ).format(exec_date=execution_date.isoformat())
 
-        m_slack.assert_called_once_with(http_conn_id=None, webhook_token="key", message=expected_message)
+        m_slack.assert_called_once_with(slack_webhook_conn_id=slack_webhook_conn_id)
+        m_slack.return_value.send_text.assert_called_once_with(message)
+
+    # ':red_circle: Task Alert.\n            *Task*: task_id\n            *Dag*: dag_id\n            *Execution Time*: 2023-10-17T16:21:40.257787+13:00\n            *Log Url*: log_url\n            *Comments*: comment'
+    # ':red_circle: Task Alert.\n        *Task*: task_id\n        *Dag*: dag_id\n        *Execution Time*: 2023-10-17T16:21:40.257787+13:00\n        *Log Url*: log_url\n        *Comments*: comment'
 
     def test_get_airflow_connection_url_invalid(self):
         with patch("observatory.platform.airflow.BaseHook") as m_basehook:

--- a/tests/observatory/platform/test_airflow.py
+++ b/tests/observatory/platform/test_airflow.py
@@ -167,9 +167,6 @@ class TestAirflow(unittest.TestCase):
         m_slack.assert_called_once_with(slack_webhook_conn_id=slack_webhook_conn_id)
         m_slack.return_value.send_text.assert_called_once_with(message)
 
-    # ':red_circle: Task Alert.\n            *Task*: task_id\n            *Dag*: dag_id\n            *Execution Time*: 2023-10-17T16:21:40.257787+13:00\n            *Log Url*: log_url\n            *Comments*: comment'
-    # ':red_circle: Task Alert.\n        *Task*: task_id\n        *Dag*: dag_id\n        *Execution Time*: 2023-10-17T16:21:40.257787+13:00\n        *Log Url*: log_url\n        *Comments*: comment'
-
     def test_get_airflow_connection_url_invalid(self):
         with patch("observatory.platform.airflow.BaseHook") as m_basehook:
             m_basehook.get_connection = MagicMock(return_value=MockConnection(""))


### PR DESCRIPTION
Fix the following error:

```python
ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 181, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 198, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/observatory-platform/observatory/platform/workflows/workflow.py", line 565, in task_callable
    result = func(release, **kwargs)
  File "/opt/observatory-platform/observatory/platform/workflows/vm_workflow.py", line 285, in check_run_status
    self.vm_api.check_terraform_run_status(ti=ti, execution_date=execution_date, run_id=run_id)
  File "/opt/observatory-platform/observatory/platform/workflows/vm_workflow.py", line 157, in check_terraform_run_status
    send_slack_msg(ti=ti, execution_date=execution_date, comments=comments, slack_conn_id=self.slack_conn_id)
  File "/opt/observatory-platform/observatory/platform/airflow.py", line 123, in send_slack_msg
    slack_hook = SlackWebhookHook(http_conn_id=slack_conn.conn_id, webhook_token=slack_conn.password, message=message)
TypeError: __init__() missing 1 required keyword-only argument: 'slack_webhook_conn_id'
```