### PR TITLE
Temporary fix for incorrect MYSQL GPG Key

### DIFF
--- a/observatory-platform/observatory/platform/docker/Dockerfile.observatory.jinja2
+++ b/observatory-platform/observatory/platform/docker/Dockerfile.observatory.jinja2
@@ -22,6 +22,7 @@ ARG INSTALL_USER=airflow
 
 # Install git which is required when installing dependencies with pip
 USER root
+RUN rm /etc/apt/sources.list.d/mysql.list # Temporary fix due to incorrect MYSQL GPG Key: https://github.com/apache/airflow/issues/36231
 RUN apt-get update -yqq
 RUN apt-get install git -yqq
 


### PR DESCRIPTION
Temporary fix for incorrect MySQL GPG Key: https://github.com/apache/airflow/issues/36231

Since we do not use MySQL we can just remove it from sources.