### PR TITLE
Set Celery version

### DIFF
--- a/observatory-platform/requirements.txt
+++ b/observatory-platform/requirements.txt
@@ -2,7 +2,8 @@
 observatory-api
 
 # Airflow
-apache-airflow[redis,celery,slack,http]==2.7.3
+apache-airflow[redis,slack,http]==2.7.3
+apache-airflow-providers-celery==3.5.0
 astronomer-starship
 
 # Google Cloud


### PR DESCRIPTION
Set the Celery Airflow providers package version as the newer version doesn't work with Airflow 2.7.3.