### PR TITLE
Added function to normalise date strings

### DIFF
--- a/observatory_platform/date_utils.py
+++ b/observatory_platform/date_utils.py
@@ -14,19 +14,22 @@
 
 # Author: Keegan Smith
 
+from datetime import datetime
+from typing import Union
 from zoneinfo import ZoneInfo
 
 from dateutil import parser
 
 
-def normalise_datetime(dt_string: str) -> str:
+def datetime_normalise(dt: Union[str, datetime]) -> str:
     """
-    Converts a date or datetime string to an isoformatted datetime string at +0000UTC
+    Converts a datetime object or string to an isoformatted datetime string at +0000UTC
 
     :param dt_string:  The string to convert
     :return: The ISO formatted datetime string
     """
-    dt = parser.parse(dt_string)  # Parse string to datetime object
+    if isinstance(dt, str):
+        dt = parser.parse(dt)  # Parse string to datetime object
     if not dt.utcoffset():  # If no timezone present, assume +0000UTC
         dt = dt.replace(tzinfo=ZoneInfo("UTC"))
     dt = dt.astimezone(ZoneInfo("UTC"))

--- a/observatory_platform/date_utils.py
+++ b/observatory_platform/date_utils.py
@@ -1,0 +1,34 @@
+# Copyright 2024 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+from zoneinfo import ZoneInfo
+
+from dateutil import parser
+
+
+def normalise_datetime(dt_string: str) -> str:
+    """
+    Converts a date or datetime string to an isoformatted datetime string at +0000UTC
+
+    :param dt_string:  The string to convert
+    :return: The ISO formatted datetime string
+    """
+    dt = parser.parse(dt_string)  # Parse string to datetime object
+    if not dt.utcoffset():  # If no timezone present, assume +0000UTC
+        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+    dt = dt.astimezone(ZoneInfo("UTC"))
+
+    return dt.isoformat()

--- a/observatory_platform/tests/test_date_utils.py
+++ b/observatory_platform/tests/test_date_utils.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Keegan Smith
+
+import unittest
+
+from observatory_platform.date_utils import normalise_datetime
+
+
+class test_normalise_datetime(unittest.TestCase):
+    """Tests for normalise_datetime"""
+
+    def test_good_inputs(self):
+        inputs = [
+            "2024-01-01 12:00:00+0000",
+            "2024-01-01 00:00:00+0800",
+            "2024-01-01 12:00:00-0800",
+            "2024-01-01 12:00:00Z",
+            "2024-01-01 12:00:00UTC+1",
+        ]
+        expected_outputs = [
+            "2024-01-01T12:00:00+00:00",
+            "2023-12-31T16:00:00+00:00",
+            "2024-01-01T20:00:00+00:00",
+            "2024-01-01T12:00:00+00:00",
+            "2024-01-01T13:00:00+00:00",
+        ]
+        for input, expected_output in zip(inputs, expected_outputs):
+            actual_output = normalise_datetime(input)
+            self.assertEqual(expected_output, actual_output)
+
+    def test_missing_tz(self):
+        inputs = ["2024-01-01 00:00:00", "2024-01-01T12:00:00"]
+        expected_outputs = ["2024-01-01T00:00:00+00:00", "2024-01-01T12:00:00+00:00"]
+        for input, expected_output in zip(inputs, expected_outputs):
+            actual_output = normalise_datetime(input)
+            self.assertEqual(expected_output, actual_output)

--- a/observatory_platform/tests/test_date_utils.py
+++ b/observatory_platform/tests/test_date_utils.py
@@ -14,15 +14,17 @@
 
 # Author: Keegan Smith
 
+from datetime import datetime
 import unittest
+from zoneinfo import ZoneInfo
 
-from observatory_platform.date_utils import normalise_datetime
+from observatory_platform.date_utils import datetime_normalise
 
 
 class test_normalise_datetime(unittest.TestCase):
     """Tests for normalise_datetime"""
 
-    def test_good_inputs(self):
+    def test_str_inputs(self):
         inputs = [
             "2024-01-01 12:00:00+0000",
             "2024-01-01 00:00:00+0800",
@@ -38,12 +40,29 @@ class test_normalise_datetime(unittest.TestCase):
             "2024-01-01T13:00:00+00:00",
         ]
         for input, expected_output in zip(inputs, expected_outputs):
-            actual_output = normalise_datetime(input)
+            actual_output = datetime_normalise(input)
+            self.assertEqual(expected_output, actual_output)
+
+    def test_dt_inputs(self):
+        inputs = [
+            datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("UTC")),
+            datetime(2024, 1, 1, 12, 0, 0, tzinfo=ZoneInfo("Etc/GMT+1")),
+            datetime(2024, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("Etc/GMT-1")),
+            datetime(2023, 12, 31, 23, 0, 0, tzinfo=ZoneInfo("Etc/GMT+1")),
+        ]
+        expected_outputs = [
+            "2024-01-01T12:00:00+00:00",
+            "2024-01-01T13:00:00+00:00",
+            "2023-12-31T23:00:00+00:00",
+            "2024-01-01T00:00:00+00:00",
+        ]
+        for input, expected_output in zip(inputs, expected_outputs):
+            actual_output = datetime_normalise(input)
             self.assertEqual(expected_output, actual_output)
 
     def test_missing_tz(self):
-        inputs = ["2024-01-01 00:00:00", "2024-01-01T12:00:00"]
-        expected_outputs = ["2024-01-01T00:00:00+00:00", "2024-01-01T12:00:00+00:00"]
+        inputs = ["2024-01-01 00:00:00", "2024-01-01T12:00:00", datetime(2024, 1, 1, 12, 0, 0)]
+        expected_outputs = ["2024-01-01T00:00:00+00:00", "2024-01-01T12:00:00+00:00", "2024-01-01T12:00:00+00:00"]
         for input, expected_output in zip(inputs, expected_outputs):
-            actual_output = normalise_datetime(input)
+            actual_output = datetime_normalise(input)
             self.assertEqual(expected_output, actual_output)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,8 @@ optional_dependencies = ["tests"] # to load extras from [project.optional-depend
 # MIT license: https://pypi.org/project/ordereddict/1.1/
 ordereddict = "1.1"
 
-# MIT License: https://pypi.org/project/pendulum/3.0.0/
-pendulum = ">=3.0.0"
+# MIT license: https://pypi.org/project/pendulum/1.4.4/
+pendulum = ">=1.4.4"
 
 # Python Imaging Library (PIL) License: https://github.com/python-pillow/Pillow/blob/master/LICENSE
 Pillow = ">=7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "validators<=0.20.0",
     "xmltodict",
     "tenacity",
-    "dateutil",
+    "python-dateutil",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "validators<=0.20.0",
     "xmltodict",
     "tenacity",
+    "dateutils",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "validators<=0.20.0",
     "xmltodict",
     "tenacity",
-    "dateutils",
+    "dateutil",
 ]
 
 [project.optional-dependencies]
@@ -144,8 +144,8 @@ optional_dependencies = ["tests"] # to load extras from [project.optional-depend
 # MIT license: https://pypi.org/project/ordereddict/1.1/
 ordereddict = "1.1"
 
-# MIT license: https://pypi.org/project/pendulum/1.4.4/
-pendulum = ">=1.4.4"
+# MIT License: https://pypi.org/project/pendulum/3.0.0/
+pendulum = ">=3.0.0"
 
 # Python Imaging Library (PIL) License: https://github.com/python-pillow/Pillow/blob/master/LICENSE
 Pillow = ">=7.2.0"


### PR DESCRIPTION
Added a function to give a generic datetime string for any valid input datetime string. 

I made this because I was running into issues when running tests locally. When uploading to Bigquery, the string will change format to +0000UTC, regardless of what the timezone of the local string is.

The idea is to put both the local and the uploaded version of the strings through the normalising function and they should always be the same if they represent identical datetimes.