### PR TITLE
Add pendulum datetime handler to date normalisation

### DIFF
--- a/observatory_platform/date_utils.py
+++ b/observatory_platform/date_utils.py
@@ -19,6 +19,7 @@ from typing import Union
 from zoneinfo import ZoneInfo
 
 from dateutil import parser
+import pendulum
 
 
 def datetime_normalise(dt: Union[str, datetime]) -> str:
@@ -28,6 +29,8 @@ def datetime_normalise(dt: Union[str, datetime]) -> str:
     :param dt_string:  The string to convert
     :return: The ISO formatted datetime string
     """
+    if isinstance(dt, pendulum.DateTime):
+        dt = dt.to_iso8601_string()
     if isinstance(dt, str):
         dt = parser.parse(dt)  # Parse string to datetime object
     if not dt.utcoffset():  # If no timezone present, assume +0000UTC

--- a/observatory_platform/tests/test_date_utils.py
+++ b/observatory_platform/tests/test_date_utils.py
@@ -18,6 +18,8 @@ from datetime import datetime
 import unittest
 from zoneinfo import ZoneInfo
 
+import pendulum
+
 from observatory_platform.date_utils import datetime_normalise
 
 
@@ -60,8 +62,25 @@ class test_normalise_datetime(unittest.TestCase):
             actual_output = datetime_normalise(input)
             self.assertEqual(expected_output, actual_output)
 
+    def test_pendulum_inputs(self):
+        inputs = [
+            pendulum.datetime(2024, 1, 1, 12, 0, 0, tz="UTC"),
+            pendulum.datetime(2024, 1, 1, 12, 0, 0, tz="Etc/GMT+1"),
+            pendulum.datetime(2024, 1, 1, 0, 0, 0, tz="Etc/GMT-1"),
+            pendulum.datetime(2023, 12, 31, 23, 0, 0, tz="Etc/GMT+1"),
+        ]
+        expected_outputs = [
+            "2024-01-01T12:00:00+00:00",
+            "2024-01-01T13:00:00+00:00",
+            "2023-12-31T23:00:00+00:00",
+            "2024-01-01T00:00:00+00:00",
+        ]
+        for input, expected_output in zip(inputs, expected_outputs):
+            actual_output = datetime_normalise(input)
+            self.assertEqual(expected_output, actual_output)
+
     def test_missing_tz(self):
-        inputs = ["2024-01-01 00:00:00", "2024-01-01T12:00:00", datetime(2024, 1, 1, 12, 0, 0)]
+        inputs = ["2024-01-01 00:00:00", "2024-01-01T12:00:00", datetime(2024, 1, 1, 12, 0, 0), pendulum.datetime(2024, 1, 1, 12, 0, 0)]
         expected_outputs = ["2024-01-01T00:00:00+00:00", "2024-01-01T12:00:00+00:00", "2024-01-01T12:00:00+00:00"]
         for input, expected_output in zip(inputs, expected_outputs):
             actual_output = datetime_normalise(input)

--- a/observatory_platform/tests/test_date_utils.py
+++ b/observatory_platform/tests/test_date_utils.py
@@ -80,8 +80,18 @@ class test_normalise_datetime(unittest.TestCase):
             self.assertEqual(expected_output, actual_output)
 
     def test_missing_tz(self):
-        inputs = ["2024-01-01 00:00:00", "2024-01-01T12:00:00", datetime(2024, 1, 1, 12, 0, 0), pendulum.datetime(2024, 1, 1, 12, 0, 0)]
-        expected_outputs = ["2024-01-01T00:00:00+00:00", "2024-01-01T12:00:00+00:00", "2024-01-01T12:00:00+00:00", "2024-01-01T12:00:00+00:00"]
+        inputs = [
+            "2024-01-01 00:00:00",
+            "2024-01-01T12:00:00",
+            datetime(2024, 1, 1, 12, 0, 0),
+            pendulum.datetime(2024, 1, 1, 12, 0, 0),
+        ]
+        expected_outputs = [
+            "2024-01-01T00:00:00+00:00",
+            "2024-01-01T12:00:00+00:00",
+            "2024-01-01T12:00:00+00:00",
+            "2024-01-01T12:00:00+00:00",
+        ]
         for input, expected_output in zip(inputs, expected_outputs):
             actual_output = datetime_normalise(input)
             self.assertEqual(expected_output, actual_output)

--- a/observatory_platform/tests/test_date_utils.py
+++ b/observatory_platform/tests/test_date_utils.py
@@ -81,7 +81,7 @@ class test_normalise_datetime(unittest.TestCase):
 
     def test_missing_tz(self):
         inputs = ["2024-01-01 00:00:00", "2024-01-01T12:00:00", datetime(2024, 1, 1, 12, 0, 0), pendulum.datetime(2024, 1, 1, 12, 0, 0)]
-        expected_outputs = ["2024-01-01T00:00:00+00:00", "2024-01-01T12:00:00+00:00", "2024-01-01T12:00:00+00:00"]
+        expected_outputs = ["2024-01-01T00:00:00+00:00", "2024-01-01T12:00:00+00:00", "2024-01-01T12:00:00+00:00", "2024-01-01T12:00:00+00:00"]
         for input, expected_output in zip(inputs, expected_outputs):
             actual_output = datetime_normalise(input)
             self.assertEqual(expected_output, actual_output)


### PR DESCRIPTION
I foolishly expected the pendulum datetimes and python datetimes to behave the same, but they don't - perhaps because of versioning issues. So I made an extra step to convert the pendulum datetime to a string first.