### PR TITLE
Update start date deduction for dag run

### DIFF
--- a/observatory_platform/sandbox/sandbox_environment.py
+++ b/observatory_platform/sandbox/sandbox_environment.py
@@ -1,5 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
@@ -34,27 +32,24 @@
 # limitations under the License.
 
 import contextlib
-import datetime
 import logging
 import os
-from datetime import datetime, timedelta
 from typing import List, Optional, Set, Union
 
-import croniter
-import google
-import pendulum
-import requests
 from airflow import DAG, settings
 from airflow.models.connection import Connection
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.variable import Variable
+from airflow.timetables.base import DataInterval
 from airflow.utils import db
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 from click.testing import CliRunner
-from dateutil.relativedelta import relativedelta
+import google
 from google.cloud import bigquery, storage
+import pendulum
+import requests
 
 from observatory_platform.airflow.workflow import Workflow, CloudWorkspace, workflows_to_json_string
 from observatory_platform.config import AirflowVars
@@ -322,7 +317,8 @@ class SandboxEnvironment:
     def create_dag_run(
         self,
         dag: DAG,
-        execution_date: pendulum.DateTime,
+        execution_date: pendulum.DateTime = None,
+        data_interval: DataInterval = None,
         run_type: DagRunType = DagRunType.SCHEDULED,
     ):
         """Create a DagRun that can be used when running tasks.
@@ -334,8 +330,15 @@ class SandboxEnvironment:
         :return: None.
         """
 
-        # Get start date, which is one schedule interval after execution date
-        start_date = dag.next_dagrun_info(last_automated_dagrun=execution_date).data_interval.start
+        if data_interval:
+            start_date = data_interval.start
+            if not execution_date:
+                execution_date = data_interval.start
+        elif execution_date:
+            data_interval = dag.infer_automated_data_interval(logical_date=execution_date)
+            start_date = data_interval.start
+        else:
+            raise ValueError("Must provide one of `data_inerval` or `execution_date`")
 
         try:
             self.dag_run = dag.create_dagrun(
@@ -343,6 +346,7 @@ class SandboxEnvironment:
                 execution_date=execution_date,
                 start_date=start_date,
                 run_type=run_type,
+                data_interval=data_interval,
             )
             yield self.dag_run
         finally:

--- a/observatory_platform/sandbox/sandbox_environment.py
+++ b/observatory_platform/sandbox/sandbox_environment.py
@@ -335,12 +335,7 @@ class SandboxEnvironment:
         """
 
         # Get start date, which is one schedule interval after execution date
-        if isinstance(dag.normalized_schedule_interval, (timedelta, relativedelta)):
-            start_date = (
-                datetime.fromtimestamp(execution_date.timestamp(), pendulum.tz.UTC) + dag.normalized_schedule_interval
-            )
-        else:
-            start_date = croniter.croniter(dag.normalized_schedule_interval, execution_date).get_next(pendulum.DateTime)
+        start_date = dag.next_dagrun_info(last_automated_dagrun=execution_date).data_interval.start
 
         try:
             self.dag_run = dag.create_dagrun(

--- a/observatory_platform/sandbox/tests/test_sandbox_environment.py
+++ b/observatory_platform/sandbox/tests/test_sandbox_environment.py
@@ -21,14 +21,13 @@ import os
 import unittest
 from datetime import timedelta
 
-import croniter
 import pendulum
-from airflow.decorators import dag, task
-from airflow.decorators import task_group
+from airflow.decorators import dag, task, task_group
 from airflow.exceptions import AirflowSkipException
 from airflow.models.connection import Connection
 from airflow.models.dag import ScheduleArg
 from airflow.models.variable import Variable
+from airflow.timetables.base import DataInterval
 from airflow.utils.state import TaskInstanceState
 from google.cloud.exceptions import NotFound
 
@@ -49,11 +48,7 @@ def create_dag(
     schedule: ScheduleArg = "@weekly",
 ):
     # Define the DAG (workflow)
-    @dag(
-        dag_id=dag_id,
-        schedule=schedule,
-        start_date=start_date,
-    )
+    @dag(dag_id=dag_id, schedule=schedule, start_date=start_date, catchup=catchup)
     def my_dag():
         @task()
         def task2():
@@ -296,17 +291,13 @@ class TestSandboxEnvironment(unittest.TestCase):
         env = SandboxEnvironment(self.project_id, self.data_location)
 
         # Setup Telescope
-        first_execution_date = pendulum.datetime(year=2020, month=11, day=1, tz="UTC")
-        second_execution_date = pendulum.datetime(year=2020, month=12, day=1, tz="UTC")
+        first_execution_date = pendulum.datetime(year=2020, month=11, day=1, tz="UTC")  # Sunday
+        second_execution_date = pendulum.datetime(year=2020, month=12, day=1, tz="UTC")  # Tuesday
+        third_data_interval = DataInterval(
+            pendulum.datetime(year=2021, month=1, day=1, tz="UTC"),
+            pendulum.datetime(year=2021, month=1, day=3, tz="UTC"),
+        )
         my_dag = create_dag()
-
-        # Get start dates outside of
-        first_start_date = croniter.croniter(my_dag.normalized_schedule_interval, first_execution_date).get_next(
-            pendulum.DateTime
-        )
-        second_start_date = croniter.croniter(my_dag.normalized_schedule_interval, second_execution_date).get_next(
-            pendulum.DateTime
-        )
 
         # Use DAG run with freezing time
         with env.create():
@@ -322,37 +313,9 @@ class TestSandboxEnvironment(unittest.TestCase):
             with env.create_dag_run(my_dag, first_execution_date):
                 # Test DAG Run is set and has frozen start date
                 self.assertIsNotNone(env.dag_run)
-                self.assertEqual(first_start_date.date(), env.dag_run.start_date.date())
-
-                ti1 = env.run_task("check_dependencies")
-                self.assertEqual(TaskInstanceState.SUCCESS, ti1.state)
-                self.assertIsNone(ti1.previous_ti)
-
-            with env.create_dag_run(my_dag, second_execution_date):
-                # Test DAG Run is set and has frozen start date
-                self.assertIsNotNone(env.dag_run)
-                self.assertEqual(second_start_date, env.dag_run.start_date)
-
-                ti2 = env.run_task("check_dependencies")
-                self.assertEqual(TaskInstanceState.SUCCESS, ti2.state)
-                # Test previous ti is set
-                self.assertEqual(ti1.job_id, ti2.previous_ti.job_id)
-
-        # Use DAG run without freezing time
-        env = SandboxEnvironment(self.project_id, self.data_location)
-        with env.create():
-            # Test add_variable
-            env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
-
-            # Test add_connection
-            conn = Connection(conn_id=MY_CONN_ID, uri="mysql://login:password@host:8080/schema?param1=val1&param2=val2")
-            env.add_connection(conn)
-
-            # First DAG Run
-            with env.create_dag_run(my_dag, first_execution_date):
-                # Test DAG Run is set and has today as start date
-                self.assertIsNotNone(env.dag_run)
-                self.assertEqual(first_start_date, env.dag_run.start_date)
+                self.assertEqual(first_execution_date.date(), env.dag_run.start_date.date())
+                self.assertEqual(env.dag_run.data_interval_start.date(), first_execution_date.date())
+                self.assertEqual(env.dag_run.data_interval_end.date(), first_execution_date.date() + timedelta(days=7))
 
                 ti1 = env.run_task("check_dependencies")
                 self.assertEqual(TaskInstanceState.SUCCESS, ti1.state)
@@ -360,25 +323,54 @@ class TestSandboxEnvironment(unittest.TestCase):
 
             # Second DAG Run
             with env.create_dag_run(my_dag, second_execution_date):
-                # Test DAG Run is set and has today as start date
+                # Test DAG Run is set and has frozen start date
                 self.assertIsNotNone(env.dag_run)
-                self.assertEqual(second_start_date, env.dag_run.start_date)
+                self.assertEqual(second_execution_date.date(), env.dag_run.start_date.date())
+                self.assertEqual(env.dag_run.data_interval_start.date(), second_execution_date.date())
+                self.assertEqual(env.dag_run.data_interval_end.date(), second_execution_date.date() + timedelta(days=5))
 
                 ti2 = env.run_task("check_dependencies")
                 self.assertEqual(TaskInstanceState.SUCCESS, ti2.state)
                 # Test previous ti is set
                 self.assertEqual(ti1.job_id, ti2.previous_ti.job_id)
 
+            # Third DAG Run
+            with env.create_dag_run(my_dag, data_interval=third_data_interval):
+                # Test DAG Run is set and has frozen start date
+                self.assertIsNotNone(env.dag_run)
+                self.assertEqual(third_data_interval.start, env.dag_run.data_interval_start)
+                self.assertEqual(third_data_interval.end, env.dag_run.data_interval_end)
+
+                ti3 = env.run_task("check_dependencies")
+                self.assertEqual(TaskInstanceState.SUCCESS, ti3.state)
+                # Test previous ti is set
+                self.assertEqual(ti2.job_id, ti3.previous_ti.job_id)
+
     def test_create_dag_run_timedelta(self):
         env = SandboxEnvironment(self.project_id, self.data_location)
 
         my_dag = create_dag(schedule=timedelta(days=1))
         execution_date = pendulum.datetime(2021, 1, 1)
-        expected_dag_date = pendulum.datetime(2021, 1, 2)
         with env.create():
             with env.create_dag_run(my_dag, execution_date):
                 self.assertIsNotNone(env.dag_run)
+                self.assertEqual(execution_date, env.dag_run.start_date)
+                execution_date = env.dag_run.data_interval_end
+
+            expected_dag_date = pendulum.datetime(2021, 1, 2)
+            with env.create_dag_run(my_dag, execution_date):
+                self.assertIsNotNone(env.dag_run)
                 self.assertEqual(expected_dag_date, env.dag_run.start_date)
+
+    def test_create_dag_run_timedelta(self):
+        env = SandboxEnvironment(self.project_id, self.data_location)
+
+        my_dag = create_dag(schedule=timedelta(days=1))
+        execution_date = pendulum.datetime(2021, 1, 1)
+        with env.create():
+            with self.assertRaisesRegex(ValueError, "Must provide one of"):
+                with env.create_dag_run(my_dag, execution_date):
+                    pass
 
     def test_map_index(self):
         env = SandboxEnvironment(self.project_id, self.data_location)

--- a/observatory_platform/sandbox/tests/test_sandbox_environment.py
+++ b/observatory_platform/sandbox/tests/test_sandbox_environment.py
@@ -48,7 +48,7 @@ def create_dag(
     schedule: ScheduleArg = "@weekly",
 ):
     # Define the DAG (workflow)
-    @dag(dag_id=dag_id, schedule=schedule, start_date=start_date, catchup=catchup)
+    @dag(dag_id=dag_id, schedule=schedule, start_date=start_date)
     def my_dag():
         @task()
         def task2():

--- a/observatory_platform/sandbox/tests/test_sandbox_environment.py
+++ b/observatory_platform/sandbox/tests/test_sandbox_environment.py
@@ -362,14 +362,13 @@ class TestSandboxEnvironment(unittest.TestCase):
                 self.assertIsNotNone(env.dag_run)
                 self.assertEqual(expected_dag_date, env.dag_run.start_date)
 
-    def test_create_dag_run_timedelta(self):
+    def test_create_dag_run_raises_error(self):
         env = SandboxEnvironment(self.project_id, self.data_location)
 
         my_dag = create_dag(schedule=timedelta(days=1))
-        execution_date = pendulum.datetime(2021, 1, 1)
         with env.create():
             with self.assertRaisesRegex(ValueError, "Must provide one of"):
-                with env.create_dag_run(my_dag, execution_date):
+                with env.create_dag_run(my_dag):
                     pass
 
     def test_map_index(self):


### PR DESCRIPTION
Use the airflow functions to get the next dagrun interval in the sandbox environment. I did this because custom timetables will not allow you to pass only an execution date to `infer_automated_data_interval`, which is what ends up being called when `create_dagrun` is invoked without a `data_interval`. Passing an execution date will be deprecated in Airflow 3 so we would have had to make this change sooner or later anyway.

Date calculations change because of this so this will probably require a bit of test updating