### PR TITLE
Execution date -> Logical date

### DIFF
--- a/observatory_platform/airflow/airflow.py
+++ b/observatory_platform/airflow/airflow.py
@@ -123,8 +123,8 @@ def on_failure_callback(context):
 
     comments = f"Task failed, exception:\n{formatted_exception}"
     ti = context["ti"]
-    execution_date = context["execution_date"]
-    send_slack_msg(ti=ti, execution_date=execution_date, comments=comments, slack_conn_id=AirflowConns.SLACK)
+    logical_date = context["logical_date"]
+    send_slack_msg(ti=ti, logical_date=logical_date, comments=comments, slack_conn_id=AirflowConns.SLACK)
 
 
 def change_task_log_level(new_levels: Union[List, int]) -> list:
@@ -146,13 +146,13 @@ def change_task_log_level(new_levels: Union[List, int]) -> list:
 
 
 def send_slack_msg(
-    *, ti: TaskInstance, execution_date: pendulum.DateTime, comments: str = "", slack_conn_id: str = AirflowConns.SLACK
+    *, ti: TaskInstance, logical_date: pendulum.DateTime, comments: str = "", slack_conn_id: str = AirflowConns.SLACK
 ):
     """
     Send a Slack message using the token in the slack airflow connection.
 
     :param ti: Task instance.
-    :param execution_date: DagRun execution date.
+    :param logical_date: DagRun logical date.
     :param comments: Additional comments in slack message
     :param slack_conn_id: the Airflow connection id for the Slack connection.
     """
@@ -169,7 +169,7 @@ def send_slack_msg(
     ).format(
         task=ti.task_id,
         dag=ti.dag_id,
-        exec_date=execution_date,
+        exec_date=logical_date,
         log_url=ti.log_url,
         comments=comments,
     )
@@ -229,23 +229,21 @@ def normalized_schedule_interval(schedule_interval: Optional[str]) -> Optional[S
 def delete_old_xcoms(
     session: Session = None,
     dag_id: str = None,
-    execution_date: pendulum.DateTime = None,
     retention_days: int = 31,
 ):
     """Delete XCom messages created by the DAG with the given ID that are as old or older than than
-    execution_date - retention_days.  Defaults to 31 days of retention.
+    `retention_days`.  Defaults to 31 days of retention.
 
     :param session: DB session.
     :param dag_id: DAG ID.
-    :param execution_date: DAG execution date.
     :param retention_days: Days of messages to retain.
     """
 
-    cut_off_date = execution_date.subtract(days=retention_days)
+    cut_off_date = pendulum.now().subtract(days=retention_days)
     results = session.query(XCom).filter(
         and_(
             XCom.dag_id == dag_id,
-            XCom.execution_date <= cut_off_date,
+            XCom.timestamp <= cut_off_date,
         )
     )
     # set synchronize_session="fetch" to prevent the following error: sqlalchemy.exc.InvalidRequestError: Could not evaluate current criteria in Python: "Cannot evaluate SelectStatementGrouping". Specify 'fetch' or False for the synchronize_session execution option.

--- a/observatory_platform/airflow/sensors.py
+++ b/observatory_platform/airflow/sensors.py
@@ -92,10 +92,10 @@ class PreviousDagRunSensor(ExternalTaskSensor):
 class DagCompleteSensor(ExternalTaskSensor):
     """
     A sensor that awaits the completion of an external dag by default. Wait functionality can be customised by
-    providing a different execution_date_fn.
+    providing a different logical_date_fn.
 
     The sensor checks for completion of a dag with "external_dag_id" on the logical date returned by the
-    execution_date_fn.
+    logical_date_fn.
     """
 
     def __init__(
@@ -116,8 +116,8 @@ class DagCompleteSensor(ExternalTaskSensor):
         :param poke_interval: how often to check if the external dag run is complete
         :param timeout: how long to check before the sensor fails
         :param check_existence: whether to check that the provided dag_id exists
-        :param execution_date_fn: a function that returns the logical date(s) of the external DAG runs to query for,
-        since you need a logical date and a DAG ID to find a particular DAG run to wait for.
+        :param execution_date_fn: a function that returns the execution/logical date(s) of the external DAG runs to
+        query for, since you need a logical date and a DAG ID to find a particular DAG run to wait for.
         """
 
         if execution_date_fn is None:

--- a/observatory_platform/airflow/tests/test_sensors.py
+++ b/observatory_platform/airflow/tests/test_sensors.py
@@ -74,7 +74,7 @@ def make_dummy_dag(*, dag_id: str, schedule: str, start_date: pendulum.DateTime,
 
     :param dag_id: the DAG id.
     :param schedule: the schedule interval.
-    :param start_date: the DAGs execution date.
+    :param start_date: the DAGs logical date.
     :param fail: Whether to intentionally fail the task
     :return: the DAG.
     """
@@ -141,7 +141,7 @@ class TestDagCompleteSensor(SandboxTestCase):
             dag = create_dag(start_date=logical_date, ext_dag_ids=["crossref_metadata"], schedule="@weekly")
             destination = pendulum.datetime(2024, 2, 11)
             with time_machine.travel(destination, tick=True):
-                with env.create_dag_run(dag=dag, execution_date=logical_date):
+                with env.create_dag_run(dag=dag, logical_date=logical_date):
                     ti = env.run_task(f"crossref_metadata_sensor")
                     self.assertEqual(State.SUCCESS, ti.state)
 
@@ -154,7 +154,7 @@ class TestDagCompleteSensor(SandboxTestCase):
             dag = create_dag(start_date=logical_date, ext_dag_ids=["crossref_metadata"], schedule="@weekly")
             destination = pendulum.datetime(2024, 2, 18)
             with time_machine.travel(destination, tick=True):
-                with env.create_dag_run(dag=dag, execution_date=logical_date):
+                with env.create_dag_run(dag=dag, logical_date=logical_date):
                     ti = env.run_task(f"crossref_metadata_sensor")
                     self.assertEqual(State.SUCCESS, ti.state)
 
@@ -187,7 +187,7 @@ class TestDagCompleteSensor(SandboxTestCase):
             dag = create_dag(start_date=logical_date, ext_dag_ids=["crossref_metadata"], schedule="@weekly")
             destination = pendulum.datetime(2024, 2, 11)
             with time_machine.travel(destination, tick=True):
-                with env.create_dag_run(dag=dag, execution_date=logical_date):
+                with env.create_dag_run(dag=dag, logical_date=logical_date):
                     ti = env.run_task(f"crossref_metadata_sensor")
                     self.assertEqual(State.UP_FOR_RESCHEDULE, ti.state)
 
@@ -220,7 +220,7 @@ class TestDagCompleteSensor(SandboxTestCase):
             dag = create_dag(start_date=logical_date, ext_dag_ids=["unpaywall"], schedule="@weekly")
             destination = pendulum.datetime(2024, 2, 11, 1)
             with time_machine.travel(destination, tick=True):
-                with env.create_dag_run(dag=dag, execution_date=logical_date):
+                with env.create_dag_run(dag=dag, logical_date=logical_date):
                     ti = env.run_task(f"unpaywall_sensor")
                     self.assertEqual(State.SUCCESS, ti.state)
 

--- a/observatory_platform/airflow/workflow.py
+++ b/observatory_platform/airflow/workflow.py
@@ -138,11 +138,10 @@ def fetch_dag_bag(path: str, include_examples: bool = False) -> DagBag:
     return dag_bag
 
 
-def cleanup(dag_id: str, execution_date: str, workflow_folder: str = None, retention_days=31) -> None:
+def cleanup(dag_id: str, workflow_folder: str = None, retention_days=31) -> None:
     """Delete all files, folders and XComs associated from a release.
 
     :param dag_id: The ID of the DAG to remove XComs
-    :param execution_date: The execution date of the DAG run
     :param workflow_folder: The top-level workflow folder to clean up
     :param retention_days: How many days of Xcom messages to retain
     """
@@ -152,7 +151,7 @@ def cleanup(dag_id: str, execution_date: str, workflow_folder: str = None, reten
         except FileNotFoundError as e:
             logging.warning(f"No such file or directory {workflow_folder}: {e}")
 
-    delete_old_xcoms(dag_id=dag_id, execution_date=execution_date, retention_days=retention_days)
+    delete_old_xcoms(dag_id=dag_id, retention_days=retention_days)
 
 
 class CloudWorkspace:

--- a/observatory_platform/sandbox/sandbox_environment.py
+++ b/observatory_platform/sandbox/sandbox_environment.py
@@ -317,7 +317,7 @@ class SandboxEnvironment:
     def create_dag_run(
         self,
         dag: DAG,
-        execution_date: pendulum.DateTime = None,
+        logical_date: pendulum.DateTime = None,
         data_interval: DataInterval = None,
         run_type: DagRunType = DagRunType.SCHEDULED,
     ):
@@ -325,25 +325,25 @@ class SandboxEnvironment:
         During cleanup the DAG run state is updated.
 
         :param dag: the Airflow DAG instance.
-        :param execution_date: the execution date of the DAG.
+        :param logical_date: the logical date of the DAG.
         :param run_type: what run_type to use when running the DAG run.
         :return: None.
         """
 
         if data_interval:
             start_date = data_interval.start
-            if not execution_date:
-                execution_date = data_interval.start
-        elif execution_date:
-            data_interval = dag.infer_automated_data_interval(logical_date=execution_date)
+            if not logical_date:
+                logical_date = data_interval.start
+        elif logical_date:
+            data_interval = dag.infer_automated_data_interval(logical_date=logical_date)
             start_date = data_interval.start
         else:
-            raise ValueError("Must provide one of `data_inerval` or `execution_date`")
+            raise ValueError("Must provide one of `data_inerval` or `logical_date`")
 
         try:
             self.dag_run = dag.create_dagrun(
                 state=State.RUNNING,
-                execution_date=execution_date,
+                execution_date=logical_date,
                 start_date=start_date,
                 run_type=run_type,
                 data_interval=data_interval,
@@ -398,6 +398,8 @@ class SandboxEnvironment:
                     logging.getLogger().setLevel(20)
                     # Propagate logging so it is displayed
                     logging.getLogger("airflow.task").propagate = True
+                else:
+                    logging.getLogger("airflow.task").propagate = False
 
                 # Create buckets and datasets
                 if self.create_gcp_env:

--- a/observatory_platform/sandbox/test_utils.py
+++ b/observatory_platform/sandbox/test_utils.py
@@ -555,18 +555,18 @@ def log_diff(diff_type, changes):
             )
 
 
-def make_dummy_dag(dag_id: str, execution_date: pendulum.DateTime) -> DAG:
+def make_dummy_dag(dag_id: str, logical_date: pendulum.DateTime) -> DAG:
     """A Dummy DAG for testing purposes.
 
     :param dag_id: the DAG id.
-    :param execution_date: the DAGs execution date.
+    :param logical_date: the DAGs logical date.
     :return: the DAG.
     """
 
     with DAG(
         dag_id=dag_id,
         schedule="@weekly",
-        default_args={"owner": "airflow", "start_date": execution_date},
+        default_args={"owner": "airflow", "start_date": logical_date},
         catchup=False,
     ) as dag:
         task1 = EmptyOperator(task_id="dummy_task")

--- a/observatory_platform/sandbox/tests/test_sandbox_environment.py
+++ b/observatory_platform/sandbox/tests/test_sandbox_environment.py
@@ -210,14 +210,14 @@ class TestSandboxEnvironment(unittest.TestCase):
         """Tests create, add_variable, add_connection and run_task"""
 
         # Setup Telescope
-        execution_date = pendulum.datetime(year=2020, month=11, day=1)
+        logical_date = pendulum.datetime(year=2020, month=11, day=1)
         my_dag = create_dag()
 
         # Test that previous tasks have to be finished to run next task
         env = SandboxEnvironment(self.project_id, self.data_location)
 
         with env.create(task_logging=True):
-            with env.create_dag_run(my_dag, execution_date):
+            with env.create_dag_run(my_dag, logical_date):
                 # Add_variable
                 env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
 
@@ -247,12 +247,12 @@ class TestSandboxEnvironment(unittest.TestCase):
         env = SandboxEnvironment(self.project_id, self.data_location)
 
         # Setup Telescope
-        execution_date = pendulum.datetime(year=2020, month=11, day=1)
+        logical_date = pendulum.datetime(year=2020, month=11, day=1)
         my_dag = create_dag()
 
         # Test environment without logging enabled
         with env.create():
-            with env.create_dag_run(my_dag, execution_date):
+            with env.create_dag_run(my_dag, logical_date):
                 # Test add_variable
                 env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
 
@@ -270,7 +270,7 @@ class TestSandboxEnvironment(unittest.TestCase):
         # Test environment with logging enabled
         env = SandboxEnvironment(self.project_id, self.data_location)
         with env.create(task_logging=True):
-            with env.create_dag_run(my_dag, execution_date):
+            with env.create_dag_run(my_dag, logical_date):
                 # Test add_variable
                 env.add_variable(Variable(key=MY_VAR_ID, val="hello"))
 
@@ -291,8 +291,8 @@ class TestSandboxEnvironment(unittest.TestCase):
         env = SandboxEnvironment(self.project_id, self.data_location)
 
         # Setup Telescope
-        first_execution_date = pendulum.datetime(year=2020, month=11, day=1, tz="UTC")  # Sunday
-        second_execution_date = pendulum.datetime(year=2020, month=12, day=1, tz="UTC")  # Tuesday
+        first_logical_date = pendulum.datetime(year=2020, month=11, day=1, tz="UTC")  # Sunday
+        second_logical_date = pendulum.datetime(year=2020, month=12, day=1, tz="UTC")  # Tuesday
         third_data_interval = DataInterval(
             pendulum.datetime(year=2021, month=1, day=1, tz="UTC"),
             pendulum.datetime(year=2021, month=1, day=3, tz="UTC"),
@@ -310,24 +310,24 @@ class TestSandboxEnvironment(unittest.TestCase):
 
             self.assertIsNone(env.dag_run)
             # First DAG Run
-            with env.create_dag_run(my_dag, first_execution_date):
+            with env.create_dag_run(my_dag, logical_date=first_logical_date):
                 # Test DAG Run is set and has frozen start date
                 self.assertIsNotNone(env.dag_run)
-                self.assertEqual(first_execution_date.date(), env.dag_run.start_date.date())
-                self.assertEqual(env.dag_run.data_interval_start.date(), first_execution_date.date())
-                self.assertEqual(env.dag_run.data_interval_end.date(), first_execution_date.date() + timedelta(days=7))
+                self.assertEqual(first_logical_date.date(), env.dag_run.start_date.date())
+                self.assertEqual(env.dag_run.data_interval_start.date(), first_logical_date.date())
+                self.assertEqual(env.dag_run.data_interval_end.date(), first_logical_date.date() + timedelta(days=7))
 
                 ti1 = env.run_task("check_dependencies")
                 self.assertEqual(TaskInstanceState.SUCCESS, ti1.state)
                 self.assertIsNone(ti1.previous_ti)
 
             # Second DAG Run
-            with env.create_dag_run(my_dag, second_execution_date):
+            with env.create_dag_run(my_dag, logical_date=second_logical_date):
                 # Test DAG Run is set and has frozen start date
                 self.assertIsNotNone(env.dag_run)
-                self.assertEqual(second_execution_date.date(), env.dag_run.start_date.date())
-                self.assertEqual(env.dag_run.data_interval_start.date(), second_execution_date.date())
-                self.assertEqual(env.dag_run.data_interval_end.date(), second_execution_date.date() + timedelta(days=5))
+                self.assertEqual(second_logical_date.date(), env.dag_run.start_date.date())
+                self.assertEqual(env.dag_run.data_interval_start.date(), second_logical_date.date())
+                self.assertEqual(env.dag_run.data_interval_end.date(), second_logical_date.date() + timedelta(days=5))
 
                 ti2 = env.run_task("check_dependencies")
                 self.assertEqual(TaskInstanceState.SUCCESS, ti2.state)
@@ -350,15 +350,15 @@ class TestSandboxEnvironment(unittest.TestCase):
         env = SandboxEnvironment(self.project_id, self.data_location)
 
         my_dag = create_dag(schedule=timedelta(days=1))
-        execution_date = pendulum.datetime(2021, 1, 1)
+        logical_date = pendulum.datetime(2021, 1, 1)
         with env.create():
-            with env.create_dag_run(my_dag, execution_date):
+            with env.create_dag_run(my_dag, logical_date):
                 self.assertIsNotNone(env.dag_run)
-                self.assertEqual(execution_date, env.dag_run.start_date)
-                execution_date = env.dag_run.data_interval_end
+                self.assertEqual(logical_date, env.dag_run.start_date)
+                logical_date = env.dag_run.data_interval_end
 
             expected_dag_date = pendulum.datetime(2021, 1, 2)
-            with env.create_dag_run(my_dag, execution_date):
+            with env.create_dag_run(my_dag, logical_date):
                 self.assertIsNotNone(env.dag_run)
                 self.assertEqual(expected_dag_date, env.dag_run.start_date)
 


### PR DESCRIPTION
Updated references to execution_date to logical_date as it's being deprecated. This will definitely break code and tests in oaebu and ao workflows.

Also altered some of the xcom query code to use the timestamp over the execution_date.