### PR TITLE
k8s provider version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     # Airflow
     "apache-airflow[slack]==2.10.5",
-    "apache-airflow-providers-cncf-kubernetes>=7.4.0",
+    "apache-airflow-providers-cncf-kubernetes==7.4.0",
     # Google Cloud
     "google-crc32c>=1.1.0,<2",
     "google-cloud-bigquery>=3.2,<4",


### PR DESCRIPTION
Unit tests were grabbing a newer version of apache-airflow-providers-cncf-kubernetes, which was breaking tests in a really annoying way. So I pinned the version.